### PR TITLE
feat: add agent e2e eval

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,4 +28,6 @@ jobs:
       - name: Install devel dependencies
         run: pdm install --dev
       - name: Run tests
-        run: pdm run python -m pytest tests --cov=src --cov=runner --cov-report term-missing
+        run: pdm run python -m pytest tests --cov=src --cov-report term-missing
+      - name: Run agent tests
+        run: cd lsc_agent_eval && pdm install --dev && pdm run python -m pytest tests --cov=src --cov-report term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,7 @@ cython_debug/
 llm_cache/
 
 # Evaluation output folder
-eval_output/
+eval_output*/
+
+# Keeping experimental changes here
+wip*/

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,16 @@ update-deps: ## Check pyproject.toml for changes, update the lock file if needed
 	pdm install --dev
 
 check-types: ## Checks type hints in sources
-	pdm run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs src/
+	pdm run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs src/ lsc_agent_eval/src/
 
 format: install-deps-test ## Format the code into unified format
 	pdm run black .
-	pdm run ruff check . --fix --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
+	pdm run ruff check . --fix --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101 --per-file-ignores=lsc_agent_eval/tests/*:S101
 
 verify:	install-deps-test ## Verify the code using various linters
 	pdm run black . --check
-	pdm run ruff check . --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
-	pdm run pylint src tests
+	pdm run ruff check . --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101 --per-file-ignores=lsc_agent_eval/tests/*:S101
+	pdm run pylint src tests lsc_agent_eval/src lsc_agent_eval/tests
 
 requirements.txt:	pyproject.toml pdm.lock ## Generate requirements.txt file containing hashes for all non-devel packages
 	pdm export --prod --format requirements --output requirements.txt
@@ -61,7 +61,7 @@ distribution-archives: ## Generate distribution archives to be uploaded into Pyt
 	pdm run python -m build
 
 test: install-deps-test ## Execute tests with Pytest
-	pdm run pytest tests
+	pdm run pytest tests lsc_agent_eval/tests
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
@@ -73,13 +73,13 @@ help: ## Show this help screen
 	@echo ''
 
 pylint:
-	pdm run pylint src
+	pdm run pylint src lsc_agent_eval/src
 
 pyright:
-	pdm run pyright src
+	pdm run pyright src lsc_agent_eval/src
 
 docstyle:
 	pdm run pydocstyle -v .
 
 ruff:
-	pdm run ruff check . --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
+	pdm run ruff check . --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101 --per-file-ignores=lsc_agent_eval/tests/*:S101

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ Evaluation scripts creates below files.
 
 [Evaluation Result](eval_data/result/README.md)
 
+## Agent Evaluation
+For a detailed walkthrough of the new agent-evaluation framework, refer
+[lsc_agent_eval/README.md](lsc_agent_eval/README.md)
 
-# RAG retrieval script
+## RAG retrieval script
 ```
 python -m scripts.evaluation.query_rag
 ```

--- a/lsc_agent_eval/README.md
+++ b/lsc_agent_eval/README.md
@@ -1,0 +1,198 @@
+# Lightspeed Agent Evaluation
+
+A standalone package for evaluating agent-based systems, specifically designed for evaluating agent goal achievement.
+
+## Features
+
+- **Agent Goal Evaluation**: Evaluate whether an agent successfully achieves specified goals
+- **Multi-type Evaluation**: Support for different evaluation types:
+  - `judge-llm`: LLM-based evaluation using a judge model
+  - `script`: Script-based evaluation using verification scripts (similar to [k8s-bench](https://github.com/GoogleCloudPlatform/kubectl-ai/tree/main/k8s-bench))
+  - `sub-string`: Simple substring matching evaluation
+- **Setup/Cleanup Scripts**: Support for running setup and cleanup scripts before/after evaluation
+- **Result Tracking**: Result tracking and CSV output
+- **Standalone Package**: Can be installed and used independently of the main lightspeed-core-evaluation package
+- **LiteLLM Integration**: Unified interface for Judge LLM
+
+## Installation
+
+### Prerequisites
+
+- Python 3.11 or higher
+- Package manager: `pdm` or `pip`
+
+### Install from Git
+
+```bash
+# Install directly from git repository
+pip install git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
+
+# Or install with pdm
+pdm add git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
+```
+
+### Install from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/lightspeed-core/lightspeed-evaluation.git
+cd lightspeed-evaluation/lsc_agent_eval
+
+# Install with pip
+pip install -e .
+
+# Or install with pdm
+pdm install
+```
+
+## Usage
+
+### Command Line Interface
+
+```bash
+# Run agent evaluation with basic configuration
+lsc-agent-eval \
+    --eval_data_yaml agent_goal_eval.yaml \
+    --agent_endpoint http://localhost:8080 \
+    --agent_provider watsonx \
+    --agent_model ibm/granite-3-2-8b-instruct \
+    --judge_provider openai \
+    --judge_model gpt-4o-mini \
+    --result_dir ./eval_output
+```
+
+### Python API
+
+```python
+from lsc_agent_eval import AgentGoalEval
+
+# Create evaluation configuration
+class EvalArgs:
+    def __init__(self):
+        self.eval_data_yaml = 'data/example_eval.yaml'
+        self.agent_endpoint = 'http://localhost:8080'
+        self.agent_provider = 'watsonx'
+        self.agent_model = 'ibm/granite-3-2-8b-instruct'
+        self.judge_provider = 'openai'
+        self.judge_model = 'gpt-4o-mini'
+        self.agent_auth_token_file = None  # Or set `AGENT_API_TOKEN` env var
+        self.result_dir = None
+
+# Run evaluation
+args = EvalArgs()
+evaluator = AgentGoalEval(args)
+evaluator.get_eval_result()
+```
+
+## Configuration
+
+The evaluation is configured using a YAML file that defines test cases. Each test case can include:
+
+- `eval_id`: Unique identifier for the evaluation
+- `eval_query`: The query/task to send to the agent
+- `eval_type`: Type of evaluation (judge-llm, script, sub-string)
+- `expected_response`: Expected response (for judge-llm evaluation)
+- `expected_key_words`: Keywords to look for (for sub-string evaluation)
+- `eval_verify_script`: Verification script (for script evaluation)
+- `eval_setup_script`: Optional setup script to run before evaluation
+- `eval_cleanup_script`: Optional cleanup script to run after evaluation
+
+### Example YAML Configuration
+
+```yaml
+# data/example_eval.yaml
+- eval_id: eval1
+  eval_query: "is there a openshift-monitoring namespace?"
+  eval_type: sub-string
+  expected_key_words:
+    - 'yes'
+    - openshift-monitoring
+
+- eval_id: eval2
+  eval_query: "is there a openshift-monitoring namespace?"
+  eval_type: judge-llm
+  expected_response: "there is a openshift-monitoring namespace."
+
+- eval_id: eval3
+  eval_query: "create a namespace called openshift-lightspeed"
+  eval_setup_script: script/eval3/setup.sh
+  eval_type: script
+  eval_verify_script: script/eval3/verify.sh
+  eval_cleanup_script: script/eval3/cleanup.sh
+```
+
+## Command Line Arguments
+
+- `--eval_data_yaml`: Path to the YAML file containing evaluation data
+- `--agent_endpoint`: Endpoint URL for the agent API (default: <http://localhost:8080>)
+- `--agent_auth_token_file`: Path to .txt file containing API token (if required). Or set `AGENT_API_TOKEN` env var without using a .txt file
+- `--agent_provider`: Provider for the agent API
+- `--agent_model`: Model for the agent API
+- `--judge_provider`: Provider for the judge LLM (optional, required only for judge-llm evaluation)
+- `--judge_model`: Model for the judge LLM (optional, required only for judge-llm evaluation)
+- `--result_dir`: Directory to save evaluation results (default: eval_output/)
+- `--kubeconfig`: Path to kubeconfig file (if needed for scripts)
+
+## Output
+
+The evaluation results are saved to a CSV file containing:
+- `eval_id`: Evaluation identifier
+- `query`: The query sent to the agent
+- `response`: The agent's response
+- `eval_type`: Type of evaluation performed
+- `result`: Result (pass/fail)
+
+## Dependencies
+
+This package depends on:
+- `pandas`: Data manipulation and analysis
+- `httpx`: HTTP client for API calls
+- `tqdm`: Progress bars
+- `pyyaml`: YAML file processing
+- `litellm`: Unified interface to 100+ LLM providers
+
+## LiteLLM Integration (Judge LLM)
+
+For judge-llm evaluations, you can use any of the 100+ supported providers:
+
+- **OpenAI**: Set `OPENAI_API_KEY` environment variable
+- **Azure OpenAI**: Set `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`
+- **IBM Watsonx**: Set `WATSONX_API_KEY`, `WATSONX_API_BASE`, `WATSONX_PROJECT_ID`
+- **Ollama**: Set `OLLAMA_API_BASE` (for local models)
+- **And many more**: See [LiteLLM documentation](https://docs.litellm.ai/docs/providers)
+
+## Development
+
+### Setting up Development Environment
+
+```bash
+# Clone the repository
+git clone https://github.com/lightspeed-core/lightspeed-evaluation.git
+cd lightspeed-evaluation/lsc_agent_eval
+
+# Install development dependencies
+pdm install --dev
+
+# Run tests
+pdm run pytest
+
+# Run linting
+pdm run ruff check
+```
+
+### Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Run the test suite
+6. Submit a pull request
+
+## License
+
+This project is licensed under the Apache License 2.0. See the LICENSE file for details.
+
+## Support
+
+For issues and questions, please use the [GitHub Issues](https://github.com/lightspeed-core/lightspeed-evaluation/issues) tracker. 

--- a/lsc_agent_eval/pyproject.toml
+++ b/lsc_agent_eval/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "lsc-agent-eval"
+version = "0.1.0"
+description = "Agent evaluation package for lightspeed-core systems"
+authors = []
+requires-python = ">=3.11,<=3.13"
+readme = "README.md"
+license = {text = "Apache"}
+
+dependencies = [
+    "pandas>=2.1.4",
+    "httpx>=0.27.2",
+    "tqdm>=4.67.1",
+    "pyyaml>=6.0",
+    "litellm>=1.0.0",
+]
+
+[tool.pdm.dev-dependencies]
+dev = [
+    "black>=25.1.0",
+    "mypy>=1.15.0",
+    "ruff>=0.8.0",
+    "pyright>=1.1.401",
+    "pydocstyle>=6.3.0",
+    "pylint>=3.3.2",
+    "pytest>=8.3.2",
+    "pytest-cov>=5.0.0",
+]
+
+[project.scripts]
+lsc-agent-eval = "lsc_agent_eval.agent_eval:main"
+
+[project.urls]
+"Homepage" = "https://github.com/lightspeed-core/lightspeed-evaluation"
+"Bug Tracker" = "https://github.com/lightspeed-core/lightspeed-evaluation/issues"
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[tool.pdm]
+distribution = true
+
+[tool.ruff]
+# always generate Python 3.11-compatible code.
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint.pydocstyle]
+convention = "google" 

--- a/lsc_agent_eval/sample_data/agent_goal_eval_example.yaml
+++ b/lsc_agent_eval/sample_data/agent_goal_eval_example.yaml
@@ -1,0 +1,26 @@
+- eval_id: eval1
+  eval_query: is there a openshift-monitoring namespace ?
+  eval_type: sub-string
+  expected_key_words:
+  - 'yes'
+  - openshift-monitoring
+
+- eval_id: eval2
+  eval_query: is there a openshift-monitoring namespace ?
+  eval_type: judge-llm
+  expected_response: there is a openshift-monitoring namespace.
+
+- eval_id: eval3
+  eval_query: is there a openshift-lightspeed namespace ?
+  eval_setup_script: sample_data/script/eval3/setup.sh
+  eval_type: sub-string
+  expected_key_words:
+  - 'yes'
+  eval_cleanup_script: sample_data/script/eval3/cleanup.sh
+
+- eval_id: eval4
+  eval_query: create a namespace called openshift-lightspeed
+  eval_setup_script: sample_data/script/eval4/setup.sh
+  eval_type: script
+  eval_verify_script: sample_data/script/eval4/verify.sh
+  eval_cleanup_script: sample_data/script/eval4/cleanup.sh

--- a/lsc_agent_eval/sample_data/script/eval3/cleanup.sh
+++ b/lsc_agent_eval/sample_data/script/eval3/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allow overriding the namespace; fallback to default.
+NAMESPACE="${1:-openshift-lightspeed}"
+ 
+echo "teardown: deleting namespace ${NAMESPACE}"
+oc delete ns "${NAMESPACE}" --ignore-not-found

--- a/lsc_agent_eval/sample_data/script/eval3/setup.sh
+++ b/lsc_agent_eval/sample_data/script/eval3/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-openshift-lightspeed}"
+
+echo "setup: ensuring namespace exists"
+# `oc create ns` returns exit code 1 if the ns is present; ignore that specific case
+oc get ns "${NAMESPACE}" >/dev/null 2>&1 || oc create ns "${NAMESPACE}"

--- a/lsc_agent_eval/sample_data/script/eval4/cleanup.sh
+++ b/lsc_agent_eval/sample_data/script/eval4/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-openshift-lightspeed}"
+
+echo "teardown: deleting namespace ${NAMESPACE}"
+oc delete ns "${NAMESPACE}" --ignore-not-found

--- a/lsc_agent_eval/sample_data/script/eval4/setup.sh
+++ b/lsc_agent_eval/sample_data/script/eval4/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-openshift-lightspeed}"
+
+echo "setup: ensuring clean slate for ${NAMESPACE}"
+oc delete ns "${NAMESPACE}" --ignore-not-found

--- a/lsc_agent_eval/sample_data/script/eval4/verify.sh
+++ b/lsc_agent_eval/sample_data/script/eval4/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-openshift-lightspeed}"
+
+echo "verify: checking namespace ${NAMESPACE}"
+oc get ns "${NAMESPACE}" -o jsonpath='{.status.phase}{"\n"}'

--- a/lsc_agent_eval/src/lsc_agent_eval/__init__.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/__init__.py
@@ -1,0 +1,38 @@
+"""Agent evaluation modules."""
+
+from .core.agent_goal_eval.agent_goal_eval import AgentGoalEval
+from .core.agent_goal_eval.eval_data import AgentGoalEvalDataManager
+from .core.agent_goal_eval.evaluator import EvaluationRunner
+from .core.agent_goal_eval.models import EvaluationDataConfig, EvaluationResult
+from .core.agent_goal_eval.results import ResultsManager
+from .core.agent_goal_eval.script_runner import ScriptRunner
+from .core.utils.api_client import AgentHttpClient
+from .core.utils.exceptions import (
+    AgentAPIError,
+    AgentEvaluationError,
+    ConfigurationError,
+    JudgeModelError,
+    ScriptExecutionError,
+)
+from .core.utils.judge import JudgeModelManager
+
+__all__ = [
+    # Exceptions
+    "AgentEvaluationError",
+    "ConfigurationError",
+    "AgentAPIError",
+    "ScriptExecutionError",
+    "JudgeModelError",
+    # Models
+    "EvaluationResult",
+    "EvaluationDataConfig",
+    # Components
+    "AgentGoalEvalDataManager",
+    "AgentHttpClient",
+    "ScriptRunner",
+    "JudgeModelManager",
+    "EvaluationRunner",
+    "ResultsManager",
+    # Main class
+    "AgentGoalEval",
+]

--- a/lsc_agent_eval/src/lsc_agent_eval/agent_eval.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/agent_eval.py
@@ -1,0 +1,91 @@
+"""Command line interface for agent evaluation."""
+
+import argparse
+import logging
+import sys
+
+from .core.agent_goal_eval.agent_goal_eval import AgentGoalEval
+from .core.utils.constants import DEFAULT_RESULT_DIR
+from .core.utils.utils import add_common_arguments
+
+logger = logging.getLogger(__name__)
+
+
+def _args_parser(args: list[str]) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate agent goal responses using various evaluation types"
+    )
+
+    # Add common arguments
+    add_common_arguments(parser)
+
+    # Agent evaluation specific arguments
+    parser.add_argument(
+        "--eval_data_yaml",
+        type=str,
+        required=True,
+        help="Path to YAML eval data file with evaluation scenarios",
+    )
+
+    parser.add_argument(
+        "--agent_endpoint",
+        type=str,
+        default="http://localhost:8080",
+        help="Agent API endpoint URL",
+    )
+
+    parser.add_argument(
+        "--agent_provider", type=str, required=True, help="Agent provider name"
+    )
+
+    parser.add_argument(
+        "--agent_model", type=str, required=True, help="Agent model name"
+    )
+
+    parser.add_argument(
+        "--agent_auth_token_file",
+        type=str,
+        help="Path to .txt file containing agent authentication token",
+    )
+
+    parser.add_argument(
+        "--judge_provider",
+        type=str,
+        help="Judge model provider (e.g., openai, azure, watsonx)",
+    )
+
+    parser.add_argument(
+        "--judge_model", type=str, help="Judge model name for LLM-based evaluations"
+    )
+
+    parser.add_argument("--kubeconfig", type=str, help="Path to the kubeconfig file")
+
+    parser.add_argument(
+        "--result_dir",
+        type=str,
+        default=DEFAULT_RESULT_DIR,
+        help="Directory to save evaluation results",
+    )
+
+    return parser.parse_args(args)
+
+
+def main() -> None:
+    """Entry point for agent evaluation."""
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Parse arguments
+    args = _args_parser(sys.argv[1:])
+
+    # Create and run evaluation
+    evaluator = AgentGoalEval(args)
+    evaluator.get_eval_result()
+
+
+if __name__ == "__main__":
+    main()

--- a/lsc_agent_eval/src/lsc_agent_eval/core/__init__.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/__init__.py
@@ -1,0 +1,1 @@
+"""Agent evaluation modules."""

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/__init__.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Agent goal evaluation modules."""

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
@@ -1,0 +1,112 @@
+"""Core orchestrator for agent goal evaluation."""
+
+import argparse
+import logging
+
+from tqdm import tqdm
+
+from ..utils.api_client import AgentHttpClient
+from ..utils.judge import JudgeModelManager
+from .eval_data import AgentGoalEvalDataManager
+from .evaluator import EvaluationRunner
+from .models import EvaluationResult
+from .results import ResultsManager
+
+logger = logging.getLogger(__name__)
+
+
+class AgentGoalEval:
+    """Orchestrator for agent goal evaluation."""
+
+    def __init__(self, eval_args: argparse.Namespace) -> None:
+        """Initialize agent goal evaluation."""
+        self.eval_args = eval_args
+        self._setup_components()
+
+    def _setup_components(self) -> None:
+        """Initialize all evaluation components."""
+        # Eval data manager
+        self.data_manager = AgentGoalEvalDataManager(self.eval_args.eval_data_yaml)
+
+        # Agent HTTP client
+        self.agent_client = AgentHttpClient(
+            self.eval_args.agent_endpoint, self.eval_args.agent_auth_token_file
+        )
+
+        # Judge model manager (optional)
+        self.judge_manager = None
+        if self.eval_args.judge_provider and self.eval_args.judge_model:
+            self.judge_manager = JudgeModelManager(
+                self.eval_args.judge_provider, self.eval_args.judge_model
+            )
+
+        # Evaluation runner
+        self.evaluation_runner = EvaluationRunner(
+            self.agent_client,
+            self.judge_manager,
+            kubeconfig=getattr(self.eval_args, "kubeconfig", None),
+        )
+
+        # Results manager
+        self.results_manager = ResultsManager(self.eval_args.result_dir)
+
+    def get_eval_result(self) -> None:
+        """Run all evaluations and save results."""
+        try:
+            eval_data = self.data_manager.get_eval_data()
+            logger.info("Running %d evaluations", len(eval_data))
+
+            results = []
+            for config in tqdm(eval_data, desc="Running evaluations"):
+                result = self.evaluation_runner.run_evaluation(
+                    config, self.eval_args.agent_provider, self.eval_args.agent_model
+                )
+                results.append(result)
+
+                # Log individual result
+                logger.info("Evaluation %s: %s", config.eval_id, result.result)
+                if result.error:
+                    logger.error("Error in %s: %s", config.eval_id, result.error)
+
+            # Save results
+            self.results_manager.save_results(results)
+
+            # Print summary
+            self._print_summary(results)
+
+        except Exception as e:
+            logger.error("Evaluation failed: %s", e)
+            raise
+        finally:
+            # Clean up resources
+            self._cleanup()
+
+    def _print_summary(self, results: list[EvaluationResult]) -> None:
+        """Print evaluation summary."""
+        total = len(results)
+        passed = sum(1 for r in results if r.result == "PASS")
+        failed = sum(1 for r in results if r.result == "FAIL")
+        errored = sum(1 for r in results if r.result == "ERROR")
+        success_rate = (passed / total * 100) if total > 0 else 0
+
+        print(f"\n{'='*25}")
+        print("EVALUATION SUMMARY")
+        print(f"{'='*25}")
+        print(f"Total Evaluations: {total}")
+        print(f"Passed: {passed}")
+        print(f"Failed: {failed}")
+        print(f"Errored: {errored}")
+        print(f"Success Rate: {success_rate:.1f}%")
+        print(f"{'='*25}\n")
+
+    def _cleanup(self) -> None:
+        """Clean up resources."""
+        try:
+            if hasattr(self, "agent_client"):
+                self.agent_client.close()
+        except (AttributeError, OSError) as e:
+            logger.warning("Error during cleanup: %s", e)
+
+    def get_data_manager(self) -> AgentGoalEvalDataManager:
+        """Get the evaluation data manager."""
+        return self.data_manager

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/eval_data.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/eval_data.py
@@ -1,0 +1,88 @@
+"""Agent Goal Eval data management."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..utils.exceptions import ConfigurationError
+from .models import EvaluationDataConfig
+
+
+class AgentGoalEvalDataManager:
+    """Processes agent eval data and validation."""
+
+    def __init__(self, eval_data_file: str):
+        """Initialize configuration manager."""
+        self.eval_data_file = Path(eval_data_file)
+        self.eval_data: list[EvaluationDataConfig] = []
+        self._validate_eval_data_file()
+        self._load_eval_data()
+
+    def _validate_eval_data_file(self) -> None:
+        """Validate eval data file exists and is readable."""
+        if not self.eval_data_file.exists():
+            raise ConfigurationError(f"Eval data file not found: {self.eval_data_file}")
+
+        if not self.eval_data_file.is_file():
+            raise ConfigurationError(
+                f"Eval data file path is not a file: {self.eval_data_file}"
+            )
+
+    def _load_eval_data(self) -> None:
+        """Load evaluation data from YAML file."""
+        try:
+            with open(self.eval_data_file, "r", encoding="utf-8") as file:
+                eval_data = yaml.safe_load(file)
+
+            if not isinstance(eval_data, list):
+                raise ConfigurationError(
+                    "Eval data file must contain a list of evaluations"
+                )
+
+            self.eval_data = []
+            for data in eval_data:
+                self._validate_eval_data(data)
+                self.eval_data.append(EvaluationDataConfig(**data))
+
+        except yaml.YAMLError as e:
+            raise ConfigurationError(f"Invalid YAML in eval data file: {e}") from e
+        except Exception as e:
+            raise ConfigurationError(f"Error loading eval data file: {e}") from e
+
+    def _validate_eval_data(self, eval_data: dict[str, Any]) -> None:
+        """Validate a single evaluation data point."""
+        required_fields = ["eval_id", "eval_query"]
+        for field in required_fields:
+            if field not in eval_data:
+                raise ConfigurationError(
+                    f"Missing required field '{field}' in evaluation data"
+                )
+
+        eval_type = eval_data.get("eval_type", "judge-llm")
+        if eval_type not in ["judge-llm", "script", "sub-string"]:
+            raise ConfigurationError(f"Invalid eval_type: {eval_type}")
+
+        # Validate type-specific requirements
+        if eval_type == "judge-llm" and "expected_response" not in eval_data:
+            raise ConfigurationError(
+                "eval_type 'judge-llm' requires 'expected_response' field"
+            )
+
+        if eval_type == "sub-string" and "expected_key_words" not in eval_data:
+            raise ConfigurationError(
+                "eval_type 'sub-string' requires 'expected_key_words' field"
+            )
+
+        if eval_type == "script" and "eval_verify_script" not in eval_data:
+            raise ConfigurationError(
+                "eval_type 'script' requires 'eval_verify_script' field"
+            )
+
+    def get_eval_data(self) -> list[EvaluationDataConfig]:
+        """Get all evaluation configurations."""
+        return self.eval_data
+
+    def get_eval_count(self) -> int:
+        """Get the number of evaluation configurations."""
+        return len(self.eval_data)

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
@@ -1,0 +1,188 @@
+"""Evaluation runner that orchestrates different evaluation types."""
+
+import logging
+from typing import Optional
+
+from ..utils.api_client import AgentHttpClient
+from ..utils.exceptions import AgentAPIError, JudgeModelError, ScriptExecutionError
+from ..utils.judge import JudgeModelManager
+from ..utils.prompt import ANSWER_CORRECTNESS_PROMPT
+from .models import EvaluationDataConfig, EvaluationResult
+from .script_runner import ScriptRunner
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluationRunner:
+    """Orchestrates different types of evaluations."""
+
+    def __init__(
+        self,
+        agent_client: AgentHttpClient,
+        judge_manager: Optional[JudgeModelManager] = None,
+        kubeconfig: Optional[str] = None,
+    ):
+        """Initialize evaluation runner."""
+        self.agent_client = agent_client
+        self.judge_manager = judge_manager
+        self.kubeconfig = kubeconfig
+
+    def run_evaluation(
+        self, data_config: EvaluationDataConfig, agent_provider: str, agent_model: str
+    ) -> EvaluationResult:
+        """Run a single evaluation based on configuration."""
+        try:
+            # Execute setup script if provided
+            if data_config.eval_setup_script:
+                try:
+                    script_runner = ScriptRunner(kubeconfig=self.kubeconfig)
+                    success = script_runner.run_script(data_config.eval_setup_script)
+                    if not success:
+                        raise ScriptExecutionError(
+                            "Setup script returned non-zero exit code"
+                        )
+                    logger.info(
+                        "Setup script executed successfully for %s", data_config.eval_id
+                    )
+                except ScriptExecutionError as e:
+                    logger.error(
+                        "Setup script failed for %s: %s", data_config.eval_id, e
+                    )
+                    return EvaluationResult(
+                        eval_id=data_config.eval_id,
+                        query=data_config.eval_query,
+                        response="",
+                        eval_type=data_config.eval_type,
+                        result="ERROR",
+                        error=f"Setup script failed: {e}",
+                    )
+
+            response = self.agent_client.query_agent(
+                data_config.eval_query, agent_provider, agent_model
+            )
+
+            # Evaluate response based on type
+            success = self._evaluate_response(data_config, response)
+
+            # Execute cleanup script if provided
+            if data_config.eval_cleanup_script:
+                try:
+                    cleanup_runner = ScriptRunner(kubeconfig=self.kubeconfig)
+                    cleanup_success = cleanup_runner.run_script(
+                        data_config.eval_cleanup_script
+                    )
+                    if cleanup_success:
+                        logger.info(
+                            "Cleanup script executed successfully for %s",
+                            data_config.eval_id,
+                        )
+                    else:
+                        logger.warning(
+                            "Cleanup script failed for %s", data_config.eval_id
+                        )
+                except ScriptExecutionError as e:
+                    logger.warning(
+                        "Cleanup script failed for %s: %s", data_config.eval_id, e
+                    )
+
+            return EvaluationResult(
+                eval_id=data_config.eval_id,
+                query=data_config.eval_query,
+                response=response,
+                eval_type=data_config.eval_type,
+                result="PASS" if success else "FAIL",
+            )
+
+        except (AgentAPIError, ScriptExecutionError, JudgeModelError) as e:
+            logger.error("Evaluation failed for %s: %s", data_config.eval_id, e)
+            return EvaluationResult(
+                eval_id=data_config.eval_id,
+                query=data_config.eval_query,
+                response="",
+                eval_type=data_config.eval_type,
+                result="ERROR",
+                error=str(e),
+            )
+
+    def _evaluate_response(
+        self, data_config: EvaluationDataConfig, response: str
+    ) -> bool:
+        """Evaluate response based on configuration type."""
+        match data_config.eval_type:
+            case "script":
+                return self._evaluate_script(data_config)
+            case "sub-string":
+                return self._evaluate_substring(data_config, response)
+            case "judge-llm":
+                return self._evaluate_judge_llm(data_config, response)
+            case _:
+                logger.error("Unknown evaluation type: %s", data_config.eval_type)
+                return False
+
+    def _evaluate_script(self, data_config: EvaluationDataConfig) -> bool:
+        """Evaluate using script execution."""
+        if not data_config.eval_verify_script:
+            logger.error("No verify script provided for script evaluation")
+            return False
+
+        try:
+            script_runner = ScriptRunner(kubeconfig=self.kubeconfig)
+            return script_runner.run_script(data_config.eval_verify_script)
+        except ScriptExecutionError as e:
+            logger.error("Script evaluation failed: %s", e)
+            return False
+
+    def _evaluate_substring(
+        self, data_config: EvaluationDataConfig, response: str
+    ) -> bool:
+        """Evaluate using substring matching."""
+        if not data_config.expected_key_words:
+            return False
+
+        response_lower = response.lower()
+        return any(
+            keyword.lower() in response_lower
+            for keyword in data_config.expected_key_words
+        )
+
+    def _extract_numeric_result(self, response: Optional[str]) -> int:
+        """Extract numeric result from judge response."""
+        # Look for 1 or 0 in the response
+        if response:
+            response = response.strip()
+
+        if response not in ["0", "1"]:
+            raise JudgeModelError(
+                "Invalid response from the judge model. "
+                f"Expected value either 0/1. Actual value: {response}"
+            )
+
+        return int(response)
+
+    def _evaluate_judge_llm(
+        self, data_config: EvaluationDataConfig, response: str
+    ) -> bool:
+        """Evaluate using judge LLM."""
+        if not self.judge_manager:
+            logger.error("Judge model manager not available for judge-llm evaluation")
+            return False
+
+        if not data_config.expected_response:
+            logger.error("Expected response not provided for judge-llm evaluation")
+            return False
+
+        # Format prompt with parameters
+        prompt = ANSWER_CORRECTNESS_PROMPT.format(
+            question=data_config.eval_query,
+            answer=data_config.expected_response,
+            response=response,
+        )
+        judge_resp = self.judge_manager.evaluate_response(prompt)
+
+        # Extract numeric result (looking for 1 or 0)
+        result = self._extract_numeric_result(judge_resp)
+        return result == 1
+
+    def get_judge_manager(self) -> Optional[JudgeModelManager]:
+        """Get the judge model manager."""
+        return self.judge_manager

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/models.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/models.py
@@ -1,0 +1,30 @@
+"""Data models for agent evaluation."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class EvaluationResult:
+    """Evaluation result data structure."""
+
+    eval_id: str
+    query: str
+    response: str
+    eval_type: str
+    result: str
+    error: Optional[str] = None
+
+
+@dataclass
+class EvaluationDataConfig:  # pylint: disable=too-many-instance-attributes
+    """Single evaluation data configuration."""
+
+    eval_id: str
+    eval_query: str
+    eval_type: str = "judge-llm"
+    expected_response: Optional[str] = None
+    expected_key_words: Optional[list[str]] = None
+    eval_setup_script: Optional[str] = None
+    eval_verify_script: Optional[str] = None
+    eval_cleanup_script: Optional[str] = None

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/results.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/results.py
@@ -1,0 +1,62 @@
+"""Results management for agent evaluation."""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from .models import EvaluationResult
+
+logger = logging.getLogger(__name__)
+
+
+class ResultsManager:
+    """Manages evaluation results and output."""
+
+    def __init__(self, result_dir: str):
+        """Initialize results manager."""
+        self.result_dir = result_dir
+        self.result_path = Path(result_dir)
+
+    def save_results(
+        self,
+        results: list[EvaluationResult],
+        filename: Optional[str] = None,
+    ) -> None:
+        """Save evaluation results to CSV file."""
+        # Create directory if it doesn't exist
+        self.result_path.mkdir(parents=True, exist_ok=True)
+
+        # Generate filename with timestamp if not provided
+        if filename is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"agent_goal_eval_results_{timestamp}.csv"
+
+        # Create full file path
+        file_path = self.result_path / filename
+
+        # Convert results to DataFrame
+        data = []
+        for result in results:
+            data.append(
+                {
+                    "eval_id": result.eval_id,
+                    "query": result.query,
+                    "response": result.response,
+                    "eval_type": result.eval_type,
+                    "result": result.result,
+                    "error": result.error or "",
+                }
+            )
+
+        df = pd.DataFrame(data)
+
+        # Save to CSV using pandas
+        df.to_csv(file_path, index=False, encoding="utf-8")
+        logger.info("Results saved to %s", file_path)
+
+    def get_output_dir(self) -> str:
+        """Get the output directory path."""
+        return str(self.result_path)

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
@@ -1,0 +1,82 @@
+"""Script execution for evaluation."""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from ..utils.exceptions import ScriptExecutionError
+
+logger = logging.getLogger(__name__)
+
+
+class ScriptRunner:
+    """Executes scripts for evaluation purposes."""
+
+    def __init__(self, kubeconfig: Optional[str] = None):
+        """Initialize script runner."""
+        self.kubeconfig = kubeconfig
+
+    def get_environment(self) -> dict:
+        """Get environment variables for script execution."""
+        env = os.environ.copy()
+        if self.kubeconfig:
+            env["KUBECONFIG"] = self.kubeconfig
+        return env
+
+    def run_script(self, script_path: str, input_text: Optional[str] = None) -> bool:
+        """
+        Execute a script and return success status.
+
+        Path normalization: Relative paths are converted to absolute path.
+        """
+        script_file = Path(script_path).resolve()
+
+        if not script_file.exists():
+            raise ScriptExecutionError(f"Script not found: {script_path}")
+
+        if not script_file.is_file():
+            raise ScriptExecutionError(f"Script path is not a file: {script_path}")
+
+        try:
+            # Setup environment
+            env = self.get_environment()
+
+            # Make script executable
+            script_file.chmod(0o755)
+
+            # Prepare command
+            cmd = ["bash", str(script_file)]
+
+            # Run script
+            logger.info("Running script: %s", script_path)
+
+            result = subprocess.run(
+                cmd,
+                input=input_text,
+                text=True,
+                capture_output=True,
+                env=env,
+                timeout=300,  # 5 minute timeout
+                check=False,
+            )
+
+            # Log output
+            if result.stdout:
+                logger.debug("Script stdout: %s", result.stdout)
+            if result.stderr:
+                logger.debug("Script stderr: %s", result.stderr)
+
+            return result.returncode == 0
+
+        except subprocess.TimeoutExpired as e:
+            raise ScriptExecutionError(f"Script timeout: {script_path}") from e
+        except subprocess.SubprocessError as e:
+            raise ScriptExecutionError(
+                f"Error running script {script_path}: {e}"
+            ) from e
+        except Exception as e:
+            raise ScriptExecutionError(
+                f"Unexpected error running script {script_path}: {e}"
+            ) from e

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/__init__.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Agent evaluation modules."""

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/api_client.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/api_client.py
@@ -1,0 +1,88 @@
+"""HTTP client for agent API communication."""
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from .exceptions import AgentAPIError
+
+logger = logging.getLogger(__name__)
+
+
+class AgentHttpClient:
+    """HTTP client for agent API communication."""
+
+    def __init__(self, endpoint: str, token_file: Optional[str] = None):
+        """Initialize HTTP client."""
+        self.endpoint = endpoint
+        self.client: Optional[httpx.Client] = None
+        self._setup_client(token_file)
+
+    def _setup_client(self, token_file: Optional[str]) -> None:
+        """Initialize HTTP client with authentication."""
+        try:
+            # enable verify, currently for eval it is set to False
+            self.client = httpx.Client(base_url=self.endpoint, verify=False)
+
+            token = None
+            if token_file:
+                token = self._read_token_file(token_file)
+            token = token or os.getenv("AGENT_API_TOKEN")
+            if token and self.client:
+                self.client.headers.update({"Authorization": f"Bearer {token}"})
+
+        except Exception as e:
+            raise AgentAPIError(f"Failed to setup HTTP client: {e}") from e
+
+    def _read_token_file(self, token_file: str) -> str:
+        """Read authentication token from file."""
+        try:
+            with open(token_file, "r", encoding="utf-8") as f:
+                return f.read().strip()
+        except FileNotFoundError as e:
+            raise AgentAPIError(f"Token file not found: {token_file}") from e
+        except Exception as e:
+            raise AgentAPIError(f"Error reading token file: {e}") from e
+
+    def query_agent(
+        self, query: str, provider: str, model: str, timeout: int = 300
+    ) -> str:
+        """Query the agent and return response."""
+        if not self.client:
+            raise AgentAPIError("HTTP client not initialized")
+
+        try:
+            api_input = {
+                "query": query,
+                "provider": provider,
+                "model": model,
+            }
+            response = self.client.post(
+                "/v1/query",
+                json=api_input,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+
+            response_data = response.json()
+            if "response" not in response_data:
+                raise AgentAPIError("Agent response missing 'response' field")
+
+            logger.info("Agent response >\n%s", response_data["response"].strip())
+            return response_data["response"].strip()
+
+        except httpx.TimeoutException as e:
+            raise AgentAPIError(f"Agent query timeout after {timeout} seconds") from e
+        except httpx.HTTPStatusError as e:
+            raise AgentAPIError(
+                f"Agent API error: {e.response.status_code} - {e.response.text}"
+            ) from e
+        except Exception as e:
+            raise AgentAPIError(f"Unexpected error querying agent: {e}") from e
+
+    def close(self) -> None:
+        """Close HTTP client."""
+        if self.client:
+            self.client.close()

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/constants.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/constants.py
@@ -1,0 +1,8 @@
+"""Constants for agent evaluation."""
+
+# Default directory for evaluation results
+DEFAULT_RESULT_DIR = "results/"
+
+# Retry configuration
+MAX_RETRY_ATTEMPTS = 3
+TIME_TO_BREATH = 2  # seconds between retries

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/exceptions.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/exceptions.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for agent evaluation."""
+
+
+class AgentEvaluationError(Exception):
+    """Base exception for agent evaluation errors."""
+
+
+class ConfigurationError(AgentEvaluationError):
+    """Configuration-related errors."""
+
+
+class AgentAPIError(AgentEvaluationError):
+    """Agent API communication errors."""
+
+
+class ScriptExecutionError(AgentEvaluationError):
+    """Script execution errors."""
+
+
+class JudgeModelError(AgentEvaluationError):
+    """Judge model errors."""

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
@@ -1,0 +1,130 @@
+"""Judge model management using LiteLLM."""
+
+import logging
+import os
+from time import sleep
+from typing import Optional
+
+import litellm  # pylint: disable=import-error  # type: ignore[import-untyped]
+
+from .constants import MAX_RETRY_ATTEMPTS, TIME_TO_BREATH
+from .exceptions import JudgeModelError
+
+logger = logging.getLogger(__name__)
+
+
+# TODO(future): Move to llama-stack
+class JudgeModelManager:
+    """Manages judge model loading and evaluation using llm."""
+
+    def __init__(self, judge_provider: str, judge_model: str):
+        """Initialize judge model manager."""
+        self.judge_provider = judge_provider
+        self.judge_model = judge_model
+        try:
+            self._setup_litellm()
+        except Exception as e:
+            raise JudgeModelError(f"Failed to setup JudgeLLM using LiteLLM: {e}") from e
+
+    def _setup_litellm(self) -> None:
+        """Initialize LiteLLM with provider-specific configuration."""
+        logger.info(
+            "Setting up LiteLLM for %s/%s", self.judge_provider, self.judge_model
+        )
+
+        provider = self.judge_provider.lower()
+
+        if provider == "openai":
+            api_key = os.environ.get("OPENAI_API_KEY")
+            if not api_key:
+                raise JudgeModelError(
+                    "OPENAI_API_KEY environment variable is required "
+                    "for OpenAI provider"
+                )
+            self.model_name = self.judge_model
+
+        elif provider == "azure":
+            # Azure OpenAI - LiteLLM format: azure/{deployment_name}
+            # Keep the deployment_name same as model name for consistency
+            api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+            api_base = os.environ.get("AZURE_OPENAI_ENDPOINT")
+            deployment_name = os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME")
+
+            if not all([api_key, api_base]):
+                raise JudgeModelError(
+                    "AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT "
+                    "environment variables are required for Azure provider"
+                )
+
+            # Use deployment name if provided, otherwise use model name
+            deployment = deployment_name or self.judge_model
+            self.model_name = f"azure/{deployment}"
+
+        elif provider == "watsonx":
+            # Watsonx - LiteLLM format: watsonx/{model}
+            api_key = os.environ.get("WATSONX_API_KEY")
+            api_base = os.environ.get("WATSONX_API_BASE")
+            project_id = os.environ.get("WATSONX_PROJECT_ID")
+
+            if not all([api_key, api_base, project_id]):
+                raise JudgeModelError(
+                    "WATSONX_API_KEY, WATSONX_API_BASE, and "
+                    "WATSONX_PROJECT_ID environment variables are "
+                    "required for Watsonx provider"
+                )
+
+            self.model_name = f"watsonx/{self.judge_model}"
+
+        else:
+            # Generic provider - try as-is
+            logger.warning("Using generic provider format for %s", provider)
+            self.model_name = f"{provider}/{self.judge_model}"
+
+        # LiteLLM configuration - verbose logging is disabled by default
+
+    def evaluate_response(self, prompt: str) -> Optional[str]:
+        """Evaluate response using judge model via LiteLLM."""
+        for retry_counter in range(MAX_RETRY_ATTEMPTS):
+            try:
+                # Use LiteLLM completion
+                response = litellm.completion(
+                    model=self.model_name,
+                    # use system prompt
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0.0,
+                    timeout=300,
+                )
+                content = None
+                # Try to access response content through different possible structures
+                choices = getattr(response, "choices", None)
+                if choices and len(choices) > 0:
+                    message = getattr(
+                        choices[0], "message", None
+                    )  # pylint: disable=unsubscriptable-object
+                    if message:
+                        content = getattr(message, "content", None)
+
+                if content:
+                    return content.strip()
+
+                raise JudgeModelError(
+                    f"No valid response from Judge Model. Check full response\n{str(response)}"
+                )
+
+            except TimeoutError as e:
+                if retry_counter == MAX_RETRY_ATTEMPTS - 1:
+                    raise JudgeModelError(
+                        f"Judge model evaluation failed after "
+                        f"{MAX_RETRY_ATTEMPTS} attempts: {e}"
+                    ) from e
+
+                logger.warning(
+                    "Judge model attempt %d failed: %s", retry_counter + 1, e
+                )
+                sleep(TIME_TO_BREATH)
+
+        return None
+
+    def get_model_name(self) -> str:
+        """Get the configured model name."""
+        return self.model_name

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/prompt.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/prompt.py
@@ -1,0 +1,19 @@
+"""Prompt for Judge LLM."""
+
+# Basic Prompt to check correctness (returns 1 or 0)
+ANSWER_CORRECTNESS_PROMPT = """You are an expert evaluator. \
+Your task is to evaluate whether a response correctly answers \
+a question based on the expected answer.
+
+Question: {question}
+Expected Answer: {answer}
+Actual Response: {response}
+
+Please evaluate if the actual response is correct based on the expected answer.
+Consider:
+1. Does the response answer the question correctly?
+2. Does it contain the key information from the expected answer?
+3. Is the response factually accurate?
+
+Return only 1 if the response is correct, or 0 if it is incorrect.
+Do not add any other text apart from 0 or 1 in your response."""

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/utils.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/utils.py
@@ -1,0 +1,11 @@
+"""Utility functions for agent evaluation."""
+
+import argparse
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments to argument parser."""
+    # Add common evaluation arguments
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")

--- a/lsc_agent_eval/tests/__init__.py
+++ b/lsc_agent_eval/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for agent eval."""

--- a/lsc_agent_eval/tests/core/__init__.py
+++ b/lsc_agent_eval/tests/core/__init__.py
@@ -1,0 +1,1 @@
+"""Test core package."""

--- a/lsc_agent_eval/tests/core/agent_goal_eval/__init__.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Test agent goal eval package."""

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_agent_goal_eval.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_agent_goal_eval.py
@@ -1,0 +1,490 @@
+"""Tests for agent goal evaluation orchestrator."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.core.agent_goal_eval.agent_goal_eval import AgentGoalEval
+from lsc_agent_eval.core.agent_goal_eval.models import (
+    EvaluationDataConfig,
+    EvaluationResult,
+)
+
+
+class TestAgentGoalEval:
+    """Test AgentGoalEval orchestrator."""
+
+    @pytest.fixture
+    def mock_args(self):
+        """Mock evaluation arguments."""
+        args = Mock()
+        args.eval_data_yaml = "test_data.yaml"
+        args.agent_endpoint = "http://localhost:8080"
+        args.agent_auth_token_file = None
+        args.agent_provider = "openai"
+        args.agent_model = "gpt-4"
+        args.judge_provider = "openai"
+        args.judge_model = "gpt-4"
+        args.kubeconfig = None
+        args.result_dir = "results/"
+        return args
+
+    @pytest.fixture
+    def sample_configs(self):
+        """Sample evaluation configurations."""
+        return [
+            EvaluationDataConfig(
+                eval_id="test_001",
+                eval_query="What is Kubernetes?",
+                eval_type="judge-llm",
+                expected_response="Kubernetes is a container orchestration platform",
+            ),
+            EvaluationDataConfig(
+                eval_id="test_002",
+                eval_query="Deploy nginx",
+                eval_type="script",
+                eval_verify_script="./verify.sh",
+            ),
+        ]
+
+    @pytest.fixture
+    def sample_results(self):
+        """Sample evaluation results."""
+        return [
+            EvaluationResult(
+                eval_id="test_001",
+                query="What is Kubernetes?",
+                response="Kubernetes is a container orchestration platform",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+            EvaluationResult(
+                eval_id="test_002",
+                query="Deploy nginx",
+                response="kubectl create deployment nginx --image=nginx",
+                eval_type="script",
+                result="PASS",
+            ),
+        ]
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    def test_init_with_judge_manager(
+        self,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+    ):
+        """Test initialization with judge manager."""
+        AgentGoalEval(mock_args)
+
+        # Verify all components were initialized
+        mock_config_manager.assert_called_once_with("test_data.yaml")
+        mock_agent_client.assert_called_once_with("http://localhost:8080", None)
+        mock_judge_manager.assert_called_once_with("openai", "gpt-4")
+        mock_evaluation_runner.assert_called_once_with(
+            mock_agent_client.return_value,
+            mock_judge_manager.return_value,
+            kubeconfig=None,
+        )
+        mock_results_manager.assert_called_once_with("results/")
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    def test_init_without_judge_manager(
+        self,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+    ):
+        """Test initialization without judge manager."""
+        mock_args.judge_provider = None
+        mock_args.judge_model = None
+
+        evaluator = AgentGoalEval(mock_args)
+
+        # Verify judge manager was not created
+        assert evaluator.judge_manager is None
+        mock_evaluation_runner.assert_called_once_with(
+            mock_agent_client.return_value,
+            None,
+            kubeconfig=None,
+        )
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    def test_init_with_kubeconfig(
+        self,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+    ):
+        """Test initialization with kubeconfig."""
+        mock_args.kubeconfig = "~/kubeconfig"
+
+        AgentGoalEval(mock_args)
+
+        mock_evaluation_runner.assert_called_once_with(
+            mock_agent_client.return_value,
+            mock_judge_manager.return_value,
+            kubeconfig="~/kubeconfig",
+        )
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.tqdm")
+    def test_get_eval_result_success(
+        self,
+        mock_tqdm,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+        sample_configs,
+        sample_results,
+    ):
+        """Test successful evaluation execution."""
+        # Setup mocks
+        mock_config_manager.return_value.get_eval_data.return_value = sample_configs
+        mock_evaluation_runner.return_value.run_evaluation.side_effect = sample_results
+        mock_tqdm.return_value = sample_configs
+
+        evaluator = AgentGoalEval(mock_args)
+
+        # Capture print output
+        with patch("builtins.print") as mock_print:
+            evaluator.get_eval_result()
+
+        # Verify evaluations were run
+        assert mock_evaluation_runner.return_value.run_evaluation.call_count == 2
+
+        # Verify results were saved
+        mock_results_manager.return_value.save_results.assert_called_once_with(
+            sample_results
+        )
+
+        # Verify summary was printed
+        mock_print.assert_called()
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.tqdm")
+    def test_get_eval_result_with_errors(
+        self,
+        mock_tqdm,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+        sample_configs,
+    ):
+        """Test evaluation execution with errors."""
+        # Setup results with errors
+        results_with_errors = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="What is Kubernetes?",
+                response="Kubernetes is a container orchestration platform",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+            EvaluationResult(
+                eval_id="test_002",
+                query="Deploy nginx",
+                response="",
+                eval_type="script",
+                result="ERROR",
+                error="Script execution failed",
+            ),
+        ]
+
+        mock_config_manager.return_value.get_eval_data.return_value = sample_configs
+        mock_evaluation_runner.return_value.run_evaluation.side_effect = (
+            results_with_errors
+        )
+        mock_tqdm.return_value = sample_configs
+
+        evaluator = AgentGoalEval(mock_args)
+
+        with patch(
+            "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.logger"
+        ) as mock_logger:
+            evaluator.get_eval_result()
+
+        # Verify error was logged
+        mock_logger.error.assert_called_with(
+            "Error in %s: %s", "test_002", "Script execution failed"
+        )
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    def test_get_eval_result_exception(
+        self,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+    ):
+        """Test evaluation execution with exception."""
+        mock_config_manager.return_value.get_eval_data.side_effect = Exception(
+            "Config error"
+        )
+
+        evaluator = AgentGoalEval(mock_args)
+
+        with patch(
+            "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.logger"
+        ) as mock_logger:
+            with pytest.raises(Exception, match="Config error"):
+                evaluator.get_eval_result()
+
+        # Verify error was logged
+        mock_logger.error.assert_called()
+        args, kwargs = mock_logger.error.call_args
+        assert args[0] == "Evaluation failed: %s"
+        assert str(args[1]) == "Config error"
+
+    def test_print_summary_all_pass(self, mock_args):
+        """Test print summary with all passing results."""
+        results = [
+            EvaluationResult("test_001", "query1", "response1", "judge-llm", "PASS"),
+            EvaluationResult("test_002", "query2", "response2", "script", "PASS"),
+        ]
+
+        with (
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner"
+            ),
+            patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager"),
+        ):
+
+            evaluator = AgentGoalEval(mock_args)
+
+            with patch("builtins.print") as mock_print:
+                evaluator._print_summary(results)
+
+            # Check that summary was printed
+            print_calls = [call[0][0] for call in mock_print.call_args_list]
+            summary_text = "\n".join(print_calls)
+
+            assert "Total Evaluations: 2" in summary_text
+            assert "Passed: 2" in summary_text
+            assert "Failed: 0" in summary_text
+            assert "Errored: 0" in summary_text
+            assert "Success Rate: 100.0%" in summary_text
+
+    def test_print_summary_mixed_results(self, mock_args):
+        """Test print summary with mixed results."""
+        results = [
+            EvaluationResult("test_001", "query1", "response1", "judge-llm", "PASS"),
+            EvaluationResult("test_002", "query2", "response2", "script", "FAIL"),
+            EvaluationResult("test_003", "query3", "response3", "script", "ERROR"),
+        ]
+
+        with (
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner"
+            ),
+            patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager"),
+        ):
+
+            evaluator = AgentGoalEval(mock_args)
+
+            with patch("builtins.print") as mock_print:
+                evaluator._print_summary(results)
+
+            # Check that summary was printed
+            print_calls = [call[0][0] for call in mock_print.call_args_list]
+            summary_text = "\n".join(print_calls)
+
+            assert "Total Evaluations: 3" in summary_text
+            assert "Passed: 1" in summary_text
+            assert "Failed: 1" in summary_text
+            assert "Errored: 1" in summary_text
+            assert "Success Rate: 33.3%" in summary_text
+
+    def test_cleanup_with_client(self, mock_args):
+        """Test cleanup method with client."""
+        with (
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient"
+            ) as mock_client_class,
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner"
+            ),
+            patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager"),
+        ):
+
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
+
+            evaluator = AgentGoalEval(mock_args)
+            evaluator._cleanup()
+
+            # Verify client was closed
+            mock_client.close.assert_called_once()
+
+    def test_cleanup_exception(self, mock_args):
+        """Test cleanup method with exception."""
+        with (
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient"
+            ) as mock_client_class,
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager"
+            ),
+            patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner"
+            ),
+            patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager"),
+        ):
+
+            mock_client = Mock()
+            mock_client.close.side_effect = OSError("Cleanup error")
+            mock_client_class.return_value = mock_client
+
+            evaluator = AgentGoalEval(mock_args)
+
+            with patch(
+                "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.logger"
+            ) as mock_logger:
+                evaluator._cleanup()
+
+            # Verify warning was logged
+            mock_logger.warning.assert_called()
+            args, kwargs = mock_logger.warning.call_args
+            assert args[0] == "Error during cleanup: %s"
+            assert str(args[1]) == "Cleanup error"
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.tqdm")
+    def test_get_eval_result_cleanup_called(
+        self,
+        mock_tqdm,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+        sample_configs,
+        sample_results,
+    ):
+        """Test that cleanup is called even on success."""
+        mock_config_manager.return_value.get_eval_data.return_value = sample_configs
+        mock_evaluation_runner.return_value.run_evaluation.side_effect = sample_results
+        mock_tqdm.return_value = sample_configs
+
+        evaluator = AgentGoalEval(mock_args)
+
+        with patch.object(evaluator, "_cleanup") as mock_cleanup:
+            evaluator.get_eval_result()
+
+        # Verify cleanup was called
+        mock_cleanup.assert_called_once()
+
+    @patch(
+        "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentGoalEvalDataManager"
+    )
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.AgentHttpClient")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
+    @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
+    def test_get_eval_result_cleanup_called_on_exception(
+        self,
+        mock_results_manager,
+        mock_evaluation_runner,
+        mock_judge_manager,
+        mock_agent_client,
+        mock_config_manager,
+        mock_args,
+    ):
+        """Test that cleanup is called even on exception."""
+        mock_config_manager.return_value.get_eval_data.side_effect = Exception(
+            "Config error"
+        )
+
+        evaluator = AgentGoalEval(mock_args)
+
+        with patch.object(evaluator, "_cleanup") as mock_cleanup:
+            with pytest.raises(Exception):
+                evaluator.get_eval_result()
+
+        # Verify cleanup was called
+        mock_cleanup.assert_called_once()

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_eval_data.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_eval_data.py
@@ -1,0 +1,486 @@
+"""Tests for evaluation data manager."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+import yaml
+
+from lsc_agent_eval.core.agent_goal_eval.eval_data import AgentGoalEvalDataManager
+from lsc_agent_eval.core.agent_goal_eval.models import EvaluationDataConfig
+from lsc_agent_eval.core.utils.exceptions import ConfigurationError
+
+
+class TestAgentGoalEvalDataManager:
+    """Test AgentGoalEvalDataManager."""
+
+    @pytest.fixture
+    def valid_eval_data(self):
+        """Valid evaluation data for testing."""
+        return [
+            {
+                "eval_id": "test_001",
+                "eval_query": "What is Kubernetes?",
+                "eval_type": "judge-llm",
+                "expected_response": "Kubernetes is a container orchestration platform",
+            },
+            {
+                "eval_id": "test_002",
+                "eval_query": "Deploy nginx",
+                "eval_type": "script",
+                "eval_verify_script": "./scripts/verify_nginx.sh",
+            },
+            {
+                "eval_id": "test_003",
+                "eval_query": "Show pods",
+                "eval_type": "sub-string",
+                "expected_key_words": ["pod", "running"],
+            },
+        ]
+
+    @pytest.fixture
+    def valid_yaml_content(self, valid_eval_data):
+        """Valid YAML content as string."""
+        return yaml.dump(valid_eval_data)
+
+    def test_init_success(self, valid_yaml_content):
+        """Test successful initialization."""
+        with (
+            patch("builtins.open", mock_open(read_data=valid_yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+
+            assert len(manager.eval_data) == 3
+            assert manager.eval_data_file == Path("test.yaml")
+            assert isinstance(manager.eval_data[0], EvaluationDataConfig)
+
+    def test_init_file_not_found(self):
+        """Test initialization with non-existent file."""
+        with patch("pathlib.Path.exists", return_value=False):
+            with pytest.raises(ConfigurationError, match="Eval data file not found"):
+                AgentGoalEvalDataManager("nonexistent.yaml")
+
+    def test_init_path_not_file(self):
+        """Test initialization when path is not a file."""
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=False),
+        ):
+
+            with pytest.raises(ConfigurationError, match="path is not a file"):
+                AgentGoalEvalDataManager("directory/")
+
+    def test_validate_eval_data_file_exists(self):
+        """Test file validation when file exists."""
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+            patch("builtins.open", mock_open(read_data="[]")),
+        ):
+
+            # Should not raise exception
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert manager.eval_data_file == Path("test.yaml")
+
+    def test_load_eval_data_invalid_yaml(self):
+        """Test loading invalid YAML content."""
+        invalid_yaml = "invalid: yaml: content: ["
+
+        with (
+            patch("builtins.open", mock_open(read_data=invalid_yaml)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(ConfigurationError, match="Invalid YAML"):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_load_eval_data_not_list(self):
+        """Test loading YAML that is not a list."""
+        yaml_dict = yaml.dump({"key": "value"})
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_dict)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(ConfigurationError, match="must contain a list"):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_load_eval_data_empty_list(self):
+        """Test loading empty evaluation list."""
+        empty_yaml = yaml.dump([])
+
+        with (
+            patch("builtins.open", mock_open(read_data=empty_yaml)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 0
+
+    def test_load_eval_data_file_read_error(self):
+        """Test loading when file read fails."""
+        with (
+            patch("builtins.open", side_effect=IOError("Read error")),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="Error loading eval data file"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_missing_eval_id(self):
+        """Test validation with missing eval_id."""
+        invalid_data = [{"eval_query": "test query"}]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="Missing required field 'eval_id'"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_missing_eval_query(self):
+        """Test validation with missing eval_query."""
+        invalid_data = [{"eval_id": "test_001"}]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="Missing required field 'eval_query'"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_invalid_eval_type(self):
+        """Test validation with invalid eval_type."""
+        invalid_data = [
+            {
+                "eval_id": "test_001",
+                "eval_query": "test query",
+                "eval_type": "invalid_type",
+            }
+        ]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="Invalid eval_type: invalid_type"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_judge_llm_missing_expected_response(self):
+        """Test validation for judge-llm type missing expected_response."""
+        invalid_data = [
+            {
+                "eval_id": "test_001",
+                "eval_query": "test query",
+                "eval_type": "judge-llm",
+            }
+        ]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="requires 'expected_response' field"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_sub_string_missing_keywords(self):
+        """Test validation for sub-string type missing expected_key_words."""
+        invalid_data = [
+            {
+                "eval_id": "test_001",
+                "eval_query": "test query",
+                "eval_type": "sub-string",
+            }
+        ]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="requires 'expected_key_words' field"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_script_missing_verify_script(self):
+        """Test validation for script type missing eval_verify_script."""
+        invalid_data = [
+            {"eval_id": "test_001", "eval_query": "test query", "eval_type": "script"}
+        ]
+        yaml_content = yaml.dump(invalid_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            with pytest.raises(
+                ConfigurationError, match="requires 'eval_verify_script' field"
+            ):
+                AgentGoalEvalDataManager("test.yaml")
+
+    def test_validate_eval_data_default_eval_type(self):
+        """Test validation with default eval_type (judge-llm)."""
+        data_with_default_type = [
+            {
+                "eval_id": "test_001",
+                "eval_query": "test query",
+                "expected_response": "test response",
+                # eval_type not specified, should default to judge-llm
+            }
+        ]
+        yaml_content = yaml.dump(data_with_default_type)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 1
+            assert manager.eval_data[0].eval_type == "judge-llm"
+
+    def test_get_eval_data(self, valid_yaml_content):
+        """Test get_eval_data method."""
+        with (
+            patch("builtins.open", mock_open(read_data=valid_yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            eval_data = manager.get_eval_data()
+
+            assert isinstance(eval_data, list)
+            assert len(eval_data) == 3
+            assert all(isinstance(item, EvaluationDataConfig) for item in eval_data)
+            assert eval_data[0].eval_id == "test_001"
+            assert eval_data[1].eval_id == "test_002"
+            assert eval_data[2].eval_id == "test_003"
+
+    def test_get_eval_count(self, valid_yaml_content):
+        """Test get_eval_count method."""
+        with (
+            patch("builtins.open", mock_open(read_data=valid_yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            count = manager.get_eval_count()
+
+            assert count == 3
+            assert count == len(manager.eval_data)
+
+    def test_get_eval_count_empty(self):
+        """Test get_eval_count with empty data."""
+        empty_yaml = yaml.dump([])
+
+        with (
+            patch("builtins.open", mock_open(read_data=empty_yaml)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            count = manager.get_eval_count()
+
+            assert count == 0
+
+    def test_judge_llm_validation_success(self):
+        """Test successful validation for judge-llm type."""
+        judge_llm_data = [
+            {
+                "eval_id": "test_judge",
+                "eval_query": "What is Docker?",
+                "eval_type": "judge-llm",
+                "expected_response": "Docker is a containerization platform",
+            }
+        ]
+        yaml_content = yaml.dump(judge_llm_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 1
+            assert manager.eval_data[0].eval_type == "judge-llm"
+            assert (
+                manager.eval_data[0].expected_response
+                == "Docker is a containerization platform"
+            )
+
+    def test_script_validation_success(self):
+        """Test successful validation for script type."""
+        script_data = [
+            {
+                "eval_id": "test_script",
+                "eval_query": "Deploy application",
+                "eval_type": "script",
+                "eval_verify_script": "./verify_deployment.sh",
+            }
+        ]
+        yaml_content = yaml.dump(script_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 1
+            assert manager.eval_data[0].eval_type == "script"
+            assert manager.eval_data[0].eval_verify_script == "./verify_deployment.sh"
+
+    def test_sub_string_validation_success(self):
+        """Test successful validation for sub-string type."""
+        sub_string_data = [
+            {
+                "eval_id": "test_substring",
+                "eval_query": "List services",
+                "eval_type": "sub-string",
+                "expected_key_words": ["service", "active", "running"],
+            }
+        ]
+        yaml_content = yaml.dump(sub_string_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 1
+            assert manager.eval_data[0].eval_type == "sub-string"
+            assert manager.eval_data[0].expected_key_words == [
+                "service",
+                "active",
+                "running",
+            ]
+
+    def test_mixed_eval_types(self):
+        """Test loading data with mixed evaluation types."""
+        mixed_data = [
+            {
+                "eval_id": "judge_test",
+                "eval_query": "What is Kubernetes?",
+                "eval_type": "judge-llm",
+                "expected_response": "Container orchestration",
+            },
+            {
+                "eval_id": "script_test",
+                "eval_query": "Deploy nginx",
+                "eval_type": "script",
+                "eval_verify_script": "./verify.sh",
+            },
+            {
+                "eval_id": "substring_test",
+                "eval_query": "List pods",
+                "eval_type": "sub-string",
+                "expected_key_words": ["pod", "running"],
+            },
+        ]
+        yaml_content = yaml.dump(mixed_data)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 3
+
+            types = [item.eval_type for item in manager.eval_data]
+            assert "judge-llm" in types
+            assert "script" in types
+            assert "sub-string" in types
+
+    def test_eval_data_with_optional_fields(self):
+        """Test evaluation data with optional fields."""
+        data_with_optional = [
+            {
+                "eval_id": "test_with_optional",
+                "eval_query": "Deploy app",
+                "eval_type": "script",
+                "eval_verify_script": "./verify.sh",
+                "eval_setup_script": "./setup.sh",
+                "eval_cleanup_script": "./cleanup.sh",
+            }
+        ]
+        yaml_content = yaml.dump(data_with_optional)
+
+        with (
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
+        ):
+
+            manager = AgentGoalEvalDataManager("test.yaml")
+            assert len(manager.eval_data) == 1
+            eval_item = manager.eval_data[0]
+            assert eval_item.eval_setup_script == "./setup.sh"
+            assert eval_item.eval_cleanup_script == "./cleanup.sh"
+
+    def test_load_real_yaml_file_integration(self):
+        """Integration test with a real temporary YAML file."""
+        eval_data = [
+            {
+                "eval_id": "integration_test",
+                "eval_query": "Test query",
+                "eval_type": "judge-llm",
+                "expected_response": "Test response",
+            }
+        ]
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(eval_data, f)
+            temp_file_path = f.name
+
+        try:
+            manager = AgentGoalEvalDataManager(temp_file_path)
+            assert len(manager.eval_data) == 1
+            assert manager.eval_data[0].eval_id == "integration_test"
+        finally:
+            Path(temp_file_path).unlink()  # Clean up temporary file

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
@@ -1,0 +1,420 @@
+"""Tests for evaluation runner."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.core.agent_goal_eval.evaluator import EvaluationRunner
+from lsc_agent_eval.core.agent_goal_eval.models import (
+    EvaluationDataConfig,
+    EvaluationResult,
+)
+from lsc_agent_eval.core.utils.api_client import AgentHttpClient
+from lsc_agent_eval.core.utils.exceptions import AgentAPIError, ScriptExecutionError
+from lsc_agent_eval.core.utils.judge import JudgeModelManager
+
+
+class TestEvaluationRunner:
+    """Test EvaluationRunner."""
+
+    @pytest.fixture
+    def mock_agent_client(self):
+        """Mock agent client."""
+        mock_client = Mock(spec=AgentHttpClient)
+        mock_client.query_agent.return_value = "Test agent response"
+        return mock_client
+
+    @pytest.fixture
+    def mock_judge_manager(self):
+        """Mock judge manager."""
+        mock_judge = Mock(spec=JudgeModelManager)
+        mock_judge.evaluate_response.return_value = "1"
+        return mock_judge
+
+    @pytest.fixture
+    def sample_config_judge_llm(self):
+        """Sample judge-llm evaluation configuration."""
+        return EvaluationDataConfig(
+            eval_id="test_001",
+            eval_query="What is Kubernetes?",
+            eval_type="judge-llm",
+            expected_response="Kubernetes is a container orchestration platform",
+        )
+
+    @pytest.fixture
+    def sample_config_script(self):
+        """Sample script evaluation configuration."""
+        return EvaluationDataConfig(
+            eval_id="test_002",
+            eval_query="Deploy nginx",
+            eval_type="script",
+            eval_verify_script="./verify.sh",
+        )
+
+    @pytest.fixture
+    def sample_config_substring(self):
+        """Sample substring evaluation configuration."""
+        return EvaluationDataConfig(
+            eval_id="test_003",
+            eval_query="What is Docker?",
+            eval_type="sub-string",
+            expected_key_words=["container", "docker"],
+        )
+
+    def test_init(self, mock_agent_client, mock_judge_manager):
+        """Test EvaluationRunner initialization."""
+        runner = EvaluationRunner(
+            mock_agent_client, mock_judge_manager, kubeconfig="~/kubeconfig"
+        )
+
+        assert runner.agent_client == mock_agent_client
+        assert runner.judge_manager == mock_judge_manager
+        assert runner.kubeconfig == "~/kubeconfig"
+
+    def test_init_without_judge_manager(self, mock_agent_client):
+        """Test EvaluationRunner initialization without judge manager."""
+        runner = EvaluationRunner(mock_agent_client)
+
+        assert runner.agent_client == mock_agent_client
+        assert runner.judge_manager is None
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_judge_llm_success(
+        self,
+        mock_script_runner,
+        mock_agent_client,
+        mock_judge_manager,
+        sample_config_judge_llm,
+    ):
+        """Test successful judge-llm evaluation."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = (
+            "Kubernetes is a container orchestration platform"
+        )
+
+        # Mock judge response
+        mock_judge_manager.evaluate_response.return_value = "1"
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(sample_config_judge_llm, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_001"
+        assert result.result == "PASS"
+        assert result.eval_type == "judge-llm"
+        assert result.error is None
+
+        # Verify agent was queried
+        mock_agent_client.query_agent.assert_called_once_with(
+            "What is Kubernetes?", "openai", "gpt-4"
+        )
+
+        # Verify judge was called
+        mock_judge_manager.evaluate_response.assert_called_once()
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_script_success(
+        self, mock_script_runner_class, mock_agent_client, sample_config_script
+    ):
+        """Test successful script evaluation."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = (
+            "kubectl create deployment nginx --image=nginx"
+        )
+
+        # Mock script runner instance
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = True
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(sample_config_script, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_002"
+        assert result.result == "PASS"
+        assert result.eval_type == "script"
+        assert result.error is None
+
+        # Verify ScriptRunner was created with the right kubeconfig
+        mock_script_runner_class.assert_called_with(kubeconfig=None)
+        # Verify script was executed
+        mock_script_runner_instance.run_script.assert_called_once_with("./verify.sh")
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_script_failure(
+        self, mock_script_runner_class, mock_agent_client, sample_config_script
+    ):
+        """Test script evaluation failure."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = (
+            "kubectl create deployment nginx --image=nginx"
+        )
+
+        # Mock script runner instance returning failure
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = False
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(sample_config_script, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_002"
+        assert result.result == "FAIL"
+        assert result.eval_type == "script"
+        assert result.error is None
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_script_with_kubeconfig(
+        self, mock_script_runner_class, mock_agent_client, sample_config_script
+    ):
+        """Test script evaluation with kubeconfig."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = (
+            "kubectl create deployment nginx --image=nginx"
+        )
+
+        # Mock script runner instance
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = True
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        runner = EvaluationRunner(mock_agent_client, kubeconfig="~/kubeconfig")
+        result = runner.run_evaluation(sample_config_script, "openai", "gpt-4")
+
+        assert result.result == "PASS"
+
+        # Verify ScriptRunner was created with kubeconfig
+        mock_script_runner_class.assert_called_with(kubeconfig="~/kubeconfig")
+        # Verify script was executed
+        mock_script_runner_instance.run_script.assert_called_once_with("./verify.sh")
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_script_execution_error(
+        self, mock_script_runner_class, mock_agent_client, sample_config_script
+    ):
+        """Test script evaluation with execution error."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = (
+            "kubectl create deployment nginx --image=nginx"
+        )
+
+        # Mock script runner instance raising error
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.side_effect = ScriptExecutionError(
+            "Script failed"
+        )
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(sample_config_script, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_002"
+        assert result.result == "FAIL"
+        assert result.error is None
+
+    def test_run_evaluation_substring_success(
+        self, mock_agent_client, sample_config_substring
+    ):
+        """Test successful substring evaluation."""
+        # Mock agent response containing expected keywords
+        mock_agent_client.query_agent.return_value = "Docker is a container platform"
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(sample_config_substring, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_003"
+        assert result.result == "PASS"
+        assert result.eval_type == "sub-string"
+
+    def test_run_evaluation_substring_failure(
+        self, mock_agent_client, sample_config_substring
+    ):
+        """Test substring evaluation failure."""
+        # Mock agent response not containing expected keywords
+        mock_agent_client.query_agent.return_value = "This is about virtual machines"
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(sample_config_substring, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_003"
+        assert result.result == "FAIL"
+        assert result.eval_type == "sub-string"
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_with_setup_script(
+        self, mock_script_runner_class, mock_agent_client, mock_judge_manager
+    ):
+        """Test evaluation with setup script."""
+        config = EvaluationDataConfig(
+            eval_id="test_setup",
+            eval_query="Test query",
+            eval_type="judge-llm",
+            expected_response="Test response",
+            eval_setup_script="./setup.sh",
+        )
+
+        # Mock script runner instance for setup
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = True
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        # Mock agent and judge responses
+        mock_agent_client.query_agent.return_value = "Test response"
+        mock_judge_manager.evaluate_response.return_value = "1"
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(config, "openai", "gpt-4")
+
+        assert result.result == "PASS"
+        # Verify setup script was called
+        mock_script_runner_instance.run_script.assert_called_with("./setup.sh")
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_setup_script_failure(
+        self, mock_script_runner_class, mock_agent_client, mock_judge_manager
+    ):
+        """Test evaluation with setup script failure."""
+        config = EvaluationDataConfig(
+            eval_id="test_setup_fail",
+            eval_query="Test query",
+            eval_type="judge-llm",
+            expected_response="Test response",
+            eval_setup_script="./setup.sh",
+        )
+
+        # Mock failing setup script execution
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = False
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(config, "openai", "gpt-4")
+
+        assert result.result == "ERROR"
+        assert "Setup script failed" in result.error
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_with_cleanup_script(
+        self, mock_script_runner_class, mock_agent_client, mock_judge_manager
+    ):
+        """Test evaluation with cleanup script."""
+        config = EvaluationDataConfig(
+            eval_id="test_cleanup",
+            eval_query="Test query",
+            eval_type="judge-llm",
+            expected_response="Test response",
+            eval_cleanup_script="./cleanup.sh",
+        )
+
+        # Mock successful cleanup script execution
+        mock_script_runner_instance = Mock()
+        mock_script_runner_instance.run_script.return_value = True
+        mock_script_runner_class.return_value = mock_script_runner_instance
+
+        # Mock agent and judge responses
+        mock_agent_client.query_agent.return_value = "Test response"
+        mock_judge_manager.evaluate_response.return_value = "1"
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(config, "openai", "gpt-4")
+
+        assert result.result == "PASS"
+        # Verify cleanup script was called
+        mock_script_runner_instance.run_script.assert_called_with("./cleanup.sh")
+
+    def test_run_evaluation_agent_api_error(
+        self, mock_agent_client, mock_judge_manager, sample_config_judge_llm
+    ):
+        """Test evaluation with agent API error."""
+        # Mock agent API error
+        mock_agent_client.query_agent.side_effect = AgentAPIError(
+            "API connection failed"
+        )
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(sample_config_judge_llm, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.result == "ERROR"
+        assert "API connection failed" in result.error
+
+    def test_run_evaluation_unknown_type(self, mock_agent_client):
+        """Test evaluation with unknown evaluation type."""
+        config = EvaluationDataConfig(
+            eval_id="test_unknown",
+            eval_query="Test query",
+            eval_type="unknown-type",
+        )
+
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = "Test response"
+
+        runner = EvaluationRunner(mock_agent_client)
+        result = runner.run_evaluation(config, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.result == "FAIL"
+
+    def test_get_judge_manager(self, mock_agent_client, mock_judge_manager):
+        """Test get_judge_manager method."""
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        assert runner.get_judge_manager() == mock_judge_manager
+
+        runner_no_judge = EvaluationRunner(mock_agent_client)
+        assert runner_no_judge.get_judge_manager() is None
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_judge_llm_failure(
+        self,
+        mock_script_runner,
+        mock_agent_client,
+        mock_judge_manager,
+        sample_config_judge_llm,
+    ):
+        """Test judge-llm evaluation failure."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = "Some incorrect response"
+
+        # Mock judge response indicating failure
+        mock_judge_manager.evaluate_response.return_value = "0"
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(sample_config_judge_llm, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_001"
+        assert result.result == "FAIL"
+        assert result.eval_type == "judge-llm"
+        assert result.error is None
+
+    @patch("lsc_agent_eval.core.agent_goal_eval.evaluator.ScriptRunner")
+    def test_run_evaluation_judge_llm_error(
+        self,
+        mock_script_runner,
+        mock_agent_client,
+        mock_judge_manager,
+        sample_config_judge_llm,
+    ):
+        """Test judge-llm evaluation error."""
+        # Mock agent response
+        mock_agent_client.query_agent.return_value = "Some incorrect response"
+
+        # Mock judge response indicating failure
+        mock_judge_manager.evaluate_response.return_value = "00"
+
+        runner = EvaluationRunner(mock_agent_client, mock_judge_manager)
+        result = runner.run_evaluation(sample_config_judge_llm, "openai", "gpt-4")
+
+        assert isinstance(result, EvaluationResult)
+        assert result.eval_id == "test_001"
+        assert result.result == "ERROR"
+        assert result.eval_type == "judge-llm"
+        assert result.error == (
+            "Invalid response from the judge model. "
+            "Expected value either 0/1. Actual value: 00"
+        )

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_models.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_models.py
@@ -1,0 +1,156 @@
+"""Tests for agent evaluation models."""
+
+from lsc_agent_eval.core.agent_goal_eval.models import (
+    EvaluationDataConfig,
+    EvaluationResult,
+)
+
+
+class TestEvaluationResult:
+    """Test EvaluationResult data class."""
+
+    def test_evaluation_result_creation(self):
+        """Test creating EvaluationResult instance."""
+        result = EvaluationResult(
+            eval_id="test_001",
+            query="What is Kubernetes?",
+            response="Kubernetes is a container orchestration platform",
+            eval_type="judge-llm",
+            result="PASS",
+            error=None,
+        )
+
+        assert result.eval_id == "test_001"
+        assert result.query == "What is Kubernetes?"
+        assert result.response == "Kubernetes is a container orchestration platform"
+        assert result.eval_type == "judge-llm"
+        assert result.result == "PASS"
+        assert result.error is None
+
+    def test_evaluation_result_with_error(self):
+        """Test EvaluationResult with error."""
+        result = EvaluationResult(
+            eval_id="test_002",
+            query="Deploy nginx",
+            response="",
+            eval_type="script",
+            result="ERROR",
+            error="Script execution failed",
+        )
+
+        assert result.eval_id == "test_002"
+        assert result.query == "Deploy nginx"
+        assert result.response == ""
+        assert result.eval_type == "script"
+        assert result.result == "ERROR"
+        assert result.error == "Script execution failed"
+
+    def test_evaluation_result_defaults(self):
+        """Test EvaluationResult with default values."""
+        result = EvaluationResult(
+            eval_id="test_003",
+            query="Test query",
+            response="Test response",
+            eval_type="sub-string",
+            result="PASS",
+        )
+
+        assert result.error is None
+
+
+class TestEvaluationDataConfig:
+    """Test EvaluationDataConfig data class."""
+
+    def test_evaluation_data_config_minimal(self):
+        """Test creating minimal EvaluationDataConfig."""
+        config = EvaluationDataConfig(
+            eval_id="test_001",
+            eval_query="What is Kubernetes?",
+        )
+
+        assert config.eval_id == "test_001"
+        assert config.eval_query == "What is Kubernetes?"
+        assert config.eval_type == "judge-llm"  # default
+        assert config.expected_response is None
+        assert config.expected_key_words is None
+        assert config.eval_setup_script is None
+        assert config.eval_verify_script is None
+        assert config.eval_cleanup_script is None
+
+    def test_evaluation_data_config_judge_llm(self):
+        """Test EvaluationDataConfig for judge-llm evaluation."""
+        config = EvaluationDataConfig(
+            eval_id="judge_test",
+            eval_query="Explain containers",
+            eval_type="judge-llm",
+            expected_response="Containers are lightweight virtualization",
+        )
+
+        assert config.eval_id == "judge_test"
+        assert config.eval_query == "Explain containers"
+        assert config.eval_type == "judge-llm"
+        assert config.expected_response == "Containers are lightweight virtualization"
+        assert config.expected_key_words is None
+        assert config.eval_setup_script is None
+        assert config.eval_verify_script is None
+        assert config.eval_cleanup_script is None
+
+    def test_evaluation_data_config_script(self):
+        """Test EvaluationDataConfig for script evaluation."""
+        config = EvaluationDataConfig(
+            eval_id="script_test",
+            eval_query="Deploy nginx pod",
+            eval_type="script",
+            eval_setup_script="./setup.sh",
+            eval_verify_script="./verify.sh",
+            eval_cleanup_script="./cleanup.sh",
+        )
+
+        assert config.eval_id == "script_test"
+        assert config.eval_query == "Deploy nginx pod"
+        assert config.eval_type == "script"
+        assert config.expected_response is None
+        assert config.expected_key_words is None
+        assert config.eval_setup_script == "./setup.sh"
+        assert config.eval_verify_script == "./verify.sh"
+        assert config.eval_cleanup_script == "./cleanup.sh"
+
+    def test_evaluation_data_config_substring(self):
+        """Test EvaluationDataConfig for sub-string evaluation."""
+        config = EvaluationDataConfig(
+            eval_id="substring_test",
+            eval_query="List container benefits",
+            eval_type="sub-string",
+            expected_key_words=["isolation", "portability", "efficiency"],
+        )
+
+        assert config.eval_id == "substring_test"
+        assert config.eval_query == "List container benefits"
+        assert config.eval_type == "sub-string"
+        assert config.expected_response is None
+        assert config.expected_key_words == ["isolation", "portability", "efficiency"]
+        assert config.eval_setup_script is None
+        assert config.eval_verify_script is None
+        assert config.eval_cleanup_script is None
+
+    def test_evaluation_data_config_all_fields(self):
+        """Test EvaluationDataConfig with all fields."""
+        config = EvaluationDataConfig(
+            eval_id="full_test",
+            eval_query="What is OpenShift?",
+            eval_type="judge-llm",
+            expected_response="OpenShift is a Kubernetes platform",
+            expected_key_words=["kubernetes", "platform", "container"],
+            eval_setup_script="./setup.sh",
+            eval_verify_script="./verify.sh",
+            eval_cleanup_script="./cleanup.sh",
+        )
+
+        assert config.eval_id == "full_test"
+        assert config.eval_query == "What is OpenShift?"
+        assert config.eval_type == "judge-llm"
+        assert config.expected_response == "OpenShift is a Kubernetes platform"
+        assert config.expected_key_words == ["kubernetes", "platform", "container"]
+        assert config.eval_setup_script == "./setup.sh"
+        assert config.eval_verify_script == "./verify.sh"
+        assert config.eval_cleanup_script == "./cleanup.sh"

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_results.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_results.py
@@ -1,0 +1,389 @@
+"""Tests for results manager."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.core.agent_goal_eval.models import EvaluationResult
+from lsc_agent_eval.core.agent_goal_eval.results import ResultsManager
+
+
+class TestResultsManager:
+    """Test ResultsManager."""
+
+    def test_init(self):
+        """Test ResultsManager initialization."""
+        manager = ResultsManager("test_results/")
+
+        assert manager.result_dir == "test_results/"
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_success(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test successful results saving."""
+        # Setup test data
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="What is Kubernetes?",
+                response="Kubernetes is a container orchestration platform",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+            EvaluationResult(
+                eval_id="test_002",
+                query="Deploy nginx",
+                response="kubectl create deployment nginx --image=nginx",
+                eval_type="script",
+                result="PASS",
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify directory creation
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+        # Verify DataFrame was created with correct data
+        mock_dataframe.assert_called_once()
+        call_args = mock_dataframe.call_args[0][0]
+        assert len(call_args) == 2
+        assert call_args[0]["eval_id"] == "test_001"
+        assert call_args[1]["eval_id"] == "test_002"
+
+        # Verify to_csv was called
+        mock_df_instance.to_csv.assert_called_once()
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_with_error(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test results saving with error field."""
+        # Setup test data with error
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="",
+                eval_type="script",
+                result="ERROR",
+                error="Script execution failed",
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify DataFrame was created with error field
+        mock_dataframe.assert_called_once()
+        call_args = mock_dataframe.call_args[0][0]
+        assert len(call_args) == 1
+        assert call_args[0]["error"] == "Script execution failed"
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_empty_list(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test saving empty results list."""
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results([])
+
+        # Verify DataFrame was created with empty list
+        mock_dataframe.assert_called_once_with([])
+        mock_df_instance.to_csv.assert_called_once()
+
+    @patch("pathlib.Path.mkdir", side_effect=OSError("Permission denied"))
+    def test_save_results_mkdir_error(self, mock_mkdir):
+        """Test results saving with directory creation error."""
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        manager = ResultsManager("test_results/")
+
+        with pytest.raises(OSError, match="Permission denied"):
+            manager.save_results(results)
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv", side_effect=IOError("File write error"))
+    @patch("pandas.DataFrame")
+    def test_save_results_file_error(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test results saving with file write error."""
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+        mock_df_instance.to_csv.side_effect = IOError("File write error")
+
+        manager = ResultsManager("test_results/")
+
+        with pytest.raises(IOError, match="File write error"):
+            manager.save_results(results)
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    @patch("lsc_agent_eval.core.agent_goal_eval.results.datetime")
+    def test_save_results_filename_generation(
+        self, mock_datetime, mock_dataframe, mock_to_csv, mock_mkdir
+    ):
+        """Test CSV filename generation with timestamp."""
+        # Setup mock datetime
+        mock_datetime.now.return_value.strftime.return_value = "20240108_103000"
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify to_csv was called with correct path
+        mock_df_instance.to_csv.assert_called_once()
+        call_args = mock_df_instance.to_csv.call_args
+        file_path = call_args[0][0]
+        assert "agent_goal_eval_results_20240108_103000.csv" in str(file_path)
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_csv_parameters(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test CSV parameters are correct."""
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify to_csv was called with correct parameters
+        mock_df_instance.to_csv.assert_called_once()
+        call_args = mock_df_instance.to_csv.call_args
+        assert not call_args[1]["index"]
+        assert call_args[1]["encoding"] == "utf-8"
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_data_conversion(
+        self, mock_dataframe, mock_to_csv, mock_mkdir
+    ):
+        """Test EvaluationResult to dict conversion."""
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+                error=None,
+            ),
+        ]
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify DataFrame was created with correct data
+        mock_dataframe.assert_called_once()
+        call_args = mock_dataframe.call_args[0][0]
+        expected_row = {
+            "eval_id": "test_001",
+            "query": "Test query",
+            "response": "Test response",
+            "eval_type": "judge-llm",
+            "result": "PASS",
+            "error": "",
+        }
+        assert call_args[0] == expected_row
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_multiple_results(
+        self, mock_dataframe, mock_to_csv, mock_mkdir
+    ):
+        """Test saving multiple results."""
+        # Setup test data
+        results = [
+            EvaluationResult("test_001", "query1", "response1", "judge-llm", "PASS"),
+            EvaluationResult("test_002", "query2", "response2", "script", "FAIL"),
+            EvaluationResult("test_003", "query3", "response3", "sub-string", "PASS"),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify DataFrame was created with all results
+        mock_dataframe.assert_called_once()
+        call_args = mock_dataframe.call_args[0][0]
+        assert len(call_args) == 3
+
+        # Verify each result was converted correctly
+        assert call_args[0]["eval_id"] == "test_001"
+        assert call_args[1]["eval_id"] == "test_002"
+        assert call_args[2]["eval_id"] == "test_003"
+
+    def test_result_dir_with_trailing_slash(self):
+        """Test result directory with trailing slash."""
+        manager = ResultsManager("test_results/")
+        assert manager.result_dir == "test_results/"
+
+    def test_result_dir_without_trailing_slash(self):
+        """Test result directory without trailing slash."""
+        manager = ResultsManager("test_results")
+        assert manager.result_dir == "test_results"
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_encoding(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test CSV file is saved with UTF-8 encoding."""
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="What is Kubernetes?",
+                response="Kubernetes is a container orchestration platform",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify to_csv was called with UTF-8 encoding
+        call_args = mock_df_instance.to_csv.call_args
+        assert call_args[1]["encoding"] == "utf-8"
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_no_index(self, mock_dataframe, mock_to_csv, mock_mkdir):
+        """Test CSV file index handling."""
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify to_csv was called with index=False
+        call_args = mock_df_instance.to_csv.call_args
+        assert not call_args[1]["index"]
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pandas.DataFrame.to_csv")
+    @patch("pandas.DataFrame")
+    def test_save_results_none_error_handling(
+        self, mock_dataframe, mock_to_csv, mock_mkdir
+    ):
+        """Test handling of None error values."""
+        results = [
+            EvaluationResult(
+                eval_id="test_001",
+                query="Test query",
+                response="Test response",
+                eval_type="judge-llm",
+                result="PASS",
+                error=None,
+            ),
+        ]
+
+        # Setup mocks
+        mock_df_instance = Mock()
+        mock_dataframe.return_value = mock_df_instance
+
+        # Run test
+        manager = ResultsManager("test_results/")
+        manager.save_results(results)
+
+        # Verify None error is converted to empty string
+        mock_dataframe.assert_called_once()
+        call_args = mock_dataframe.call_args[0][0]
+        assert call_args[0]["error"] == ""
+
+    def test_get_output_dir(self):
+        """Test get_output_dir method."""
+        manager = ResultsManager("test_results/")
+        output_dir = manager.get_output_dir()
+        assert output_dir == str(manager.result_path)

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_script_runner.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_script_runner.py
@@ -1,0 +1,393 @@
+"""Tests for script runner."""
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.core.agent_goal_eval.script_runner import ScriptRunner
+from lsc_agent_eval.core.utils.exceptions import ScriptExecutionError
+
+
+class TestScriptRunner:
+    """Test ScriptRunner."""
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_success(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test successful script execution."""
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Success"
+        mock_result.stderr = ""
+        mock_subprocess_run.return_value = mock_result
+
+        # Run test using instance method
+        runner = ScriptRunner()
+        result = runner.run_script("test_script.sh")
+
+        # Assertions
+        assert result  # Instance method returns boolean
+        mock_exists.assert_called_once()
+        mock_chmod.assert_called_once_with(0o755)
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", str(Path("test_script.sh").resolve())],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=300,
+            check=False,
+        )
+
+    @patch("pathlib.Path.exists")
+    def test_run_script_file_not_found(self, mock_exists):
+        """Test script execution with non-existent file."""
+        mock_exists.return_value = False
+
+        runner = ScriptRunner()
+        with pytest.raises(ScriptExecutionError, match="Script not found"):
+            runner.run_script("missing_script.sh")
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_with_kubeconfig(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with kubeconfig."""
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        # Test with kubeconfig set during initialization
+        runner = ScriptRunner(kubeconfig="./kubeconfig")
+        result = runner.run_script("test_script.sh")
+
+        assert result
+        # Verify environment includes KUBECONFIG
+        expected_env = os.environ.copy()
+        expected_env["KUBECONFIG"] = "./kubeconfig"
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", str(Path("test_script.sh").resolve())],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=expected_env,
+            timeout=300,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_failure(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution failure."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Script failed"
+        mock_subprocess_run.return_value = mock_result
+
+        runner = ScriptRunner()
+        result = runner.run_script("test_script.sh")
+
+        # Instance method returns False for non-zero return codes
+        assert not result
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_subprocess_error(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with subprocess error."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_subprocess_run.side_effect = subprocess.SubprocessError(
+            "Subprocess failed"
+        )
+
+        runner = ScriptRunner()
+        with pytest.raises(ScriptExecutionError, match="Error running script"):
+            runner.run_script("test_script.sh")
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_unexpected_error(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with unexpected error."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_subprocess_run.side_effect = Exception("Unexpected error")
+
+        runner = ScriptRunner()
+        with pytest.raises(
+            ScriptExecutionError, match="Unexpected error running script"
+        ):
+            runner.run_script("test_script.sh")
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_chmod_error(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with chmod error."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_chmod.side_effect = OSError("Permission denied")
+
+        runner = ScriptRunner()
+        with pytest.raises(
+            ScriptExecutionError, match="Unexpected error running script"
+        ):
+            runner.run_script("test_script.sh")
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_absolute_path(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with absolute path."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        absolute_path = "/test/test_script.sh"
+        runner = ScriptRunner()
+        result = runner.run_script(absolute_path)
+
+        assert result
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", absolute_path],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=300,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_relative_path(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with relative path."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        relative_path = "./scripts/test.sh"
+        runner = ScriptRunner()
+        result = runner.run_script(relative_path)
+
+        assert result
+
+        expected_path = str(Path("scripts/test.sh").resolve())
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", expected_path],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=300,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_environment_preservation(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test that original environment is preserved."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        # Set test environment variable
+        with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
+            runner = ScriptRunner()
+            runner.run_script("test_script.sh")
+
+            # Verify environment includes test variable
+            expected_env = os.environ.copy()
+            mock_subprocess_run.assert_called_once_with(
+                ["bash", str(Path("test_script.sh").resolve())],
+                input=None,
+                text=True,
+                capture_output=True,
+                env=expected_env,
+                timeout=300,
+                check=False,
+            )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_kubeconfig_absolute_path(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test kubeconfig with absolute path."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        kubeconfig_path = "/home/user/.kube/config"
+        runner = ScriptRunner(kubeconfig=kubeconfig_path)
+        runner.run_script("test_script.sh")
+
+        expected_env = os.environ.copy()
+        expected_env["KUBECONFIG"] = kubeconfig_path
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", str(Path("test_script.sh").resolve())],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=expected_env,
+            timeout=300,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_no_kubeconfig(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution without kubeconfig."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        runner = ScriptRunner()  # No kubeconfig
+        result = runner.run_script("test_script.sh")
+
+        assert result
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", str(Path("test_script.sh").resolve())],
+            input=None,
+            text=True,
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=300,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_capture_output(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test that script execution captures output."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Script output"
+        mock_result.stderr = "Script error"
+        mock_subprocess_run.return_value = mock_result
+
+        runner = ScriptRunner()
+        result = runner.run_script("test_script.sh")
+
+        assert result
+        # Note: Instance method returns boolean, not the result object
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.chmod")
+    def test_run_script_with_input_text(
+        self, mock_chmod, mock_exists, mock_is_file, mock_subprocess_run
+    ):
+        """Test script execution with input text."""
+        mock_exists.return_value = True
+        mock_is_file.return_value = True
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        input_text = "test input"
+        runner = ScriptRunner()
+        result = runner.run_script("test_script.sh", input_text=input_text)
+
+        assert result
+        mock_subprocess_run.assert_called_once_with(
+            ["bash", str(Path("test_script.sh").resolve())],
+            input=input_text,
+            text=True,
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=300,
+            check=False,
+        )
+
+    def test_script_runner_init(self):
+        """Test ScriptRunner initialization."""
+        runner = ScriptRunner()
+        assert runner.kubeconfig is None
+
+        runner_with_config = ScriptRunner(kubeconfig="~/kubeconfig")
+        assert runner_with_config.kubeconfig == "~/kubeconfig"
+
+    def test_get_environment_without_kubeconfig(self):
+        """Test get_environment without kubeconfig."""
+        runner = ScriptRunner()
+        env = runner.get_environment()
+
+        # Should return copy of os.environ
+        assert env == os.environ.copy()
+        assert env is not os.environ  # Should be a copy
+
+    def test_get_environment_with_kubeconfig(self):
+        """Test get_environment with kubeconfig."""
+        runner = ScriptRunner(kubeconfig="~/kubeconfig")
+        env = runner.get_environment()
+
+        expected_env = os.environ.copy()
+        expected_env["KUBECONFIG"] = "~/kubeconfig"
+        assert env == expected_env

--- a/lsc_agent_eval/tests/core/utils/__init__.py
+++ b/lsc_agent_eval/tests/core/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Test utils package."""

--- a/lsc_agent_eval/tests/core/utils/test_api_client.py
+++ b/lsc_agent_eval/tests/core/utils/test_api_client.py
@@ -1,0 +1,165 @@
+"""Tests for agent API client."""
+
+from unittest.mock import Mock, mock_open, patch
+
+import httpx
+import pytest
+
+from lsc_agent_eval.core.utils.api_client import AgentHttpClient
+from lsc_agent_eval.core.utils.exceptions import AgentAPIError
+
+
+class TestAgentHttpClient:
+    """Test AgentHttpClient."""
+
+    def test_init_without_token(self):
+        """Test initializing client without token."""
+        with patch("httpx.Client") as mock_client:
+            client = AgentHttpClient("http://localhost:8080")
+
+            assert client.endpoint == "http://localhost:8080"
+            mock_client.assert_called_once_with(
+                base_url="http://localhost:8080", verify=False
+            )
+
+    def test_init_with_token_file(self):
+        """Test initializing client with token file."""
+        token_content = "test-token-123"
+
+        with (
+            patch("httpx.Client") as mock_client,
+            patch("builtins.open", mock_open(read_data=token_content)),
+        ):
+
+            client = AgentHttpClient("http://localhost:8080", "token.txt")
+
+            assert client.endpoint == "http://localhost:8080"
+            mock_client.assert_called_once_with(
+                base_url="http://localhost:8080", verify=False
+            )
+            mock_client.return_value.headers.update.assert_called_once_with(
+                {"Authorization": "Bearer test-token-123"}
+            )
+
+    def test_init_with_missing_token_file(self):
+        """Test initializing client with missing token file."""
+        with (
+            patch("httpx.Client"),
+            patch("builtins.open", side_effect=FileNotFoundError),
+        ):
+
+            with pytest.raises(AgentAPIError, match="Token file not found"):
+                AgentHttpClient("http://localhost:8080", "missing.txt")
+
+    def test_init_with_env_token(self):
+        """Test initializing client with environment token."""
+        with (
+            patch("httpx.Client") as mock_client,
+            patch("os.getenv", return_value="env-token-456"),
+        ):
+            AgentHttpClient("http://localhost:8080")
+
+            mock_client.return_value.headers.update.assert_called_once_with(
+                {"Authorization": "Bearer env-token-456"}
+            )
+
+    def test_query_agent_success(self):
+        """Test successful agent query."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"response": "Test agent response"}
+        mock_response.raise_for_status.return_value = None
+
+        # Mock HTTP client
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = AgentHttpClient("http://localhost:8080")
+
+            result = client.query_agent("What is Kubernetes?", "openai", "gpt-4")
+
+            assert result == "Test agent response"
+            mock_client.post.assert_called_once_with(
+                "/v1/query",
+                json={
+                    "query": "What is Kubernetes?",
+                    "provider": "openai",
+                    "model": "gpt-4",
+                },
+                timeout=300,
+            )
+
+    def test_query_agent_http_error(self):
+        """Test agent query with HTTP error."""
+        # Mock HTTP error response
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        # Mock HTTP client
+        mock_client = Mock()
+        mock_client.post.side_effect = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=Mock(), response=mock_response
+        )
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = AgentHttpClient("http://localhost:8080")
+
+            with pytest.raises(AgentAPIError, match="Agent API error: 500"):
+                client.query_agent("Test query", "openai", "gpt-4")
+
+    def test_query_agent_timeout(self):
+        """Test agent query with timeout."""
+        # Mock HTTP client
+        mock_client = Mock()
+        mock_client.post.side_effect = httpx.TimeoutException("Request timeout")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = AgentHttpClient("http://localhost:8080")
+
+            with pytest.raises(AgentAPIError, match="Agent query timeout"):
+                client.query_agent("Test query", "openai", "gpt-4")
+
+    def test_query_agent_missing_response_field(self):
+        """Test agent query with missing response field."""
+        # Mock HTTP response without 'response' field
+        mock_response = Mock()
+        mock_response.json.return_value = {"error": "Invalid request"}
+        mock_response.raise_for_status.return_value = None
+
+        # Mock HTTP client
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = AgentHttpClient("http://localhost:8080")
+
+            with pytest.raises(
+                AgentAPIError, match="Agent response missing 'response' field"
+            ):
+                client.query_agent("Test query", "openai", "gpt-4")
+
+    def test_query_agent_client_not_initialized(self):
+        """Test agent query when client is not initialized."""
+        with patch("httpx.Client", side_effect=Exception("Setup failed")):
+            with pytest.raises(AgentAPIError, match="Failed to setup HTTP client"):
+                AgentHttpClient("http://localhost:8080")
+
+    def test_close_client_success(self):
+        """Test closing client successfully."""
+        mock_client = Mock()
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = AgentHttpClient("http://localhost:8080")
+            client.close()
+
+            mock_client.close.assert_called_once()
+
+    def test_client_setup_exception(self):
+        """Test client setup exception."""
+        with patch("httpx.Client", side_effect=Exception("Setup failed")):
+            with pytest.raises(
+                AgentAPIError, match="Failed to setup HTTP client: Setup failed"
+            ):
+                AgentHttpClient("http://localhost:8080")

--- a/lsc_agent_eval/tests/core/utils/test_exceptions.py
+++ b/lsc_agent_eval/tests/core/utils/test_exceptions.py
@@ -1,0 +1,124 @@
+"""Tests for custom exceptions."""
+
+from lsc_agent_eval.core.utils.exceptions import (
+    AgentAPIError,
+    AgentEvaluationError,
+    ConfigurationError,
+    JudgeModelError,
+    ScriptExecutionError,
+)
+
+
+class TestAgentEvaluationError:
+    """Test base AgentEvaluationError."""
+
+    def test_agent_evaluation_error_creation(self):
+        """Test creating AgentEvaluationError."""
+        error = AgentEvaluationError("Test error message")
+        assert str(error) == "Test error message"
+        assert isinstance(error, Exception)
+
+    def test_agent_evaluation_error_inheritance(self):
+        """Test AgentEvaluationError inheritance."""
+        error = AgentEvaluationError("Test error")
+        assert isinstance(error, AgentEvaluationError)
+        assert isinstance(error, Exception)
+
+
+class TestConfigurationError:
+    """Test ConfigurationError."""
+
+    def test_configuration_error_creation(self):
+        """Test creating ConfigurationError."""
+        error = ConfigurationError("Invalid configuration")
+        assert str(error) == "Invalid configuration"
+        assert isinstance(error, ConfigurationError)
+        assert isinstance(error, AgentEvaluationError)
+
+    def test_configuration_error_inheritance(self):
+        """Test ConfigurationError inheritance."""
+        error = ConfigurationError("Config error")
+        assert isinstance(error, ConfigurationError)
+        assert isinstance(error, AgentEvaluationError)
+        assert isinstance(error, Exception)
+
+
+class TestAgentAPIError:
+    """Test AgentAPIError."""
+
+    def test_agent_api_error_creation(self):
+        """Test creating AgentAPIError."""
+        error = AgentAPIError("API connection failed")
+        assert str(error) == "API connection failed"
+        assert isinstance(error, AgentAPIError)
+        assert isinstance(error, AgentEvaluationError)
+
+    def test_agent_api_error_inheritance(self):
+        """Test AgentAPIError inheritance."""
+        error = AgentAPIError("API error")
+        assert isinstance(error, AgentAPIError)
+        assert isinstance(error, AgentEvaluationError)
+        assert isinstance(error, Exception)
+
+
+class TestScriptExecutionError:
+    """Test ScriptExecutionError."""
+
+    def test_script_execution_error_creation(self):
+        """Test creating ScriptExecutionError."""
+        error = ScriptExecutionError("Script failed with exit code 1")
+        assert str(error) == "Script failed with exit code 1"
+        assert isinstance(error, ScriptExecutionError)
+        assert isinstance(error, AgentEvaluationError)
+
+    def test_script_execution_error_inheritance(self):
+        """Test ScriptExecutionError inheritance."""
+        error = ScriptExecutionError("Script error")
+        assert isinstance(error, ScriptExecutionError)
+        assert isinstance(error, AgentEvaluationError)
+        assert isinstance(error, Exception)
+
+
+class TestJudgeModelError:
+    """Test JudgeModelError."""
+
+    def test_judge_model_error_creation(self):
+        """Test creating JudgeModelError."""
+        error = JudgeModelError("Judge model initialization failed")
+        assert str(error) == "Judge model initialization failed"
+        assert isinstance(error, JudgeModelError)
+        assert isinstance(error, AgentEvaluationError)
+
+    def test_judge_model_error_inheritance(self):
+        """Test JudgeModelError inheritance."""
+        error = JudgeModelError("Judge error")
+        assert isinstance(error, JudgeModelError)
+        assert isinstance(error, AgentEvaluationError)
+        assert isinstance(error, Exception)
+
+
+class TestExceptionHierarchy:
+    """Test exception hierarchy."""
+
+    def test_all_exceptions_inherit_from_base(self):
+        """Test that all custom exceptions inherit from AgentEvaluationError."""
+        exceptions = [
+            ConfigurationError("config error"),
+            AgentAPIError("api error"),
+            ScriptExecutionError("script error"),
+            JudgeModelError("judge error"),
+        ]
+
+        for exc in exceptions:
+            assert isinstance(exc, AgentEvaluationError)
+            assert isinstance(exc, Exception)
+
+    def test_exception_with_none_message(self):
+        """Test exceptions with None message."""
+        error = AgentEvaluationError(None)
+        assert str(error) == "None"
+
+    def test_exception_with_empty_message(self):
+        """Test exceptions with empty message."""
+        error = AgentEvaluationError("")
+        assert str(error) == ""

--- a/lsc_agent_eval/tests/core/utils/test_judge.py
+++ b/lsc_agent_eval/tests/core/utils/test_judge.py
@@ -1,0 +1,220 @@
+"""Tests for judge model manager."""
+
+import os
+import re
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.core.utils.exceptions import JudgeModelError
+from lsc_agent_eval.core.utils.judge import JudgeModelManager
+
+
+class TestJudgeModelManager:
+    """Test JudgeModelManager."""
+
+    def test_init_openai_success(self):
+        """Test initializing OpenAI judge model."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+
+            assert judge.judge_provider == "openai"
+            assert judge.judge_model == "gpt-4"
+            assert judge.model_name == "gpt-4"
+
+    def test_init_openai_missing_key(self):
+        """Test initializing OpenAI judge model without API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(
+                JudgeModelError, match="OPENAI_API_KEY environment variable is required"
+            ):
+                JudgeModelManager("openai", "gpt-4")
+
+    def test_init_azure_success(self):
+        """Test initializing Azure judge model."""
+        with patch.dict(
+            os.environ,
+            {
+                "AZURE_OPENAI_API_KEY": "test-key",
+                "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
+                "AZURE_OPENAI_DEPLOYMENT_NAME": "gpt-4-deployment",
+            },
+        ):
+            judge = JudgeModelManager("azure", "gpt-4")
+
+            assert judge.judge_provider == "azure"
+            assert judge.judge_model == "gpt-4"
+            assert judge.model_name == "azure/gpt-4-deployment"
+
+    def test_init_watsonx_success(self):
+        """Test initializing Watsonx judge model."""
+        with patch.dict(
+            os.environ,
+            {
+                "WATSONX_API_KEY": "test-key",
+                "WATSONX_API_BASE": "https://test.watsonx.ibm.com",
+                "WATSONX_PROJECT_ID": "test-project",
+            },
+        ):
+            judge = JudgeModelManager("watsonx", "granite-3-8b-instruct")
+
+            assert judge.judge_provider == "watsonx"
+            assert judge.judge_model == "granite-3-8b-instruct"
+            assert judge.model_name == "watsonx/granite-3-8b-instruct"
+
+    def test_init_generic_provider(self):
+        """Test initializing generic provider."""
+        with patch("lsc_agent_eval.core.utils.judge.logger") as mock_logger:
+            judge = JudgeModelManager("xyz", "abcd")
+
+            assert judge.judge_provider == "xyz"
+            assert judge.judge_model == "abcd"
+            assert judge.model_name == "xyz/abcd"
+            mock_logger.warning.assert_called_once_with(
+                "Using generic provider format for %s", "xyz"
+            )
+
+    def test_init_setup_failure(self):
+        """Test judge model setup failure."""
+        with (
+            patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}),
+            patch(
+                "lsc_agent_eval.core.utils.judge.JudgeModelManager._setup_litellm",
+                side_effect=Exception("Setup error"),
+            ),
+        ):
+
+            with pytest.raises(
+                JudgeModelError, match="Failed to setup JudgeLLM using LiteLLM"
+            ):
+                JudgeModelManager("openai", "gpt-4")
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    def test_evaluate_response_success(self, mock_litellm):
+        """Test successful response evaluation."""
+        # Mock LiteLLM completion response
+        mock_response = Mock()
+        mock_message = Mock()
+        mock_message.content = "1"
+        mock_choice = Mock()
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_litellm.completion.return_value = mock_response
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+            result = judge.evaluate_response("Test prompt")
+
+            assert result == "1"
+            mock_litellm.completion.assert_called_once_with(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "Test prompt"}],
+                temperature=0.0,
+                timeout=300,
+            )
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    def test_evaluate_response_invalid_structure(self, mock_litellm):
+        """Test response evaluation with invalid response structure."""
+        # Mock LiteLLM completion response with invalid structure
+        mock_response = Mock()
+        mock_response.choices = None
+        mock_litellm.completion.return_value = mock_response
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+            with pytest.raises(
+                JudgeModelError,
+                match="No valid response from Judge Model. Check full response\n",
+            ):
+                judge.evaluate_response("Test prompt")
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    @patch("lsc_agent_eval.core.utils.judge.sleep")
+    def test_evaluate_response_timeout_retry(self, mock_sleep, mock_litellm):
+        """Test response evaluation with timeout and retry."""
+        # Mock timeout on first call, success on second
+        mock_response = Mock()
+        mock_message = Mock()
+        mock_message.content = "1"
+        mock_choice = Mock()
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        mock_litellm.completion.side_effect = [
+            TimeoutError("Request timeout"),
+            mock_response,
+        ]
+
+        with (
+            patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}),
+            patch("lsc_agent_eval.core.utils.judge.logger") as mock_logger,
+        ):
+            judge = JudgeModelManager("openai", "gpt-4")
+            result = judge.evaluate_response("Test prompt")
+
+            assert result == "1"
+            assert mock_litellm.completion.call_count == 2
+            mock_logger.warning.assert_called_once()
+            mock_sleep.assert_called_once()
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    def test_evaluate_response_max_retries_exceeded(self, mock_litellm):
+        """Test response evaluation with max retries exceeded."""
+        mock_litellm.completion.side_effect = TimeoutError("Request timeout")
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+
+            with pytest.raises(
+                JudgeModelError, match="Judge model evaluation failed after 3 attempts"
+            ):
+                judge.evaluate_response("Test prompt")
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    def test_evaluate_response_with_whitespace(self, mock_litellm):
+        """Test response evaluation with whitespace in content."""
+        # Mock LiteLLM completion response with whitespace
+        mock_response = Mock()
+        mock_message = Mock()
+        mock_message.content = "  1  \n"
+        mock_choice = Mock()
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_litellm.completion.return_value = mock_response
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+            result = judge.evaluate_response("Test prompt")
+
+            assert result == "1"
+
+    @patch("lsc_agent_eval.core.utils.judge.litellm")
+    def test_evaluate_response_empty_content(self, mock_litellm):
+        """Test response evaluation with empty content."""
+        # Mock LiteLLM completion response with empty content
+        mock_response = Mock()
+        mock_message = Mock()
+        mock_message.content = ""
+        mock_choice = Mock()
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        # Set all fallback attributes to empty
+        mock_litellm.completion.return_value = mock_response
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+            with pytest.raises(
+                JudgeModelError,
+                match=re.escape(
+                    "No valid response from Judge Model. "
+                    f"Check full response\n{mock_response}"
+                ),
+            ):
+                judge.evaluate_response("Test prompt")
+
+    def test_get_model_name(self):
+        """Test get_model_name method."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            judge = JudgeModelManager("openai", "gpt-4")
+            assert judge.get_model_name() == "gpt-4"

--- a/lsc_agent_eval/tests/test_agent_eval.py
+++ b/lsc_agent_eval/tests/test_agent_eval.py
@@ -1,0 +1,233 @@
+"""Tests for agent evaluation CLI."""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lsc_agent_eval.agent_eval import _args_parser, main
+
+
+class TestArgsParser:
+    """Test argument parser."""
+
+    def test_args_parser_minimal(self):
+        """Test argument parser with minimal required arguments."""
+        args = [
+            "--eval_data_yaml",
+            "test.yaml",
+            "--agent_provider",
+            "openai",
+            "--agent_model",
+            "gpt-4",
+        ]
+
+        parsed = _args_parser(args)
+
+        assert parsed.eval_data_yaml == "test.yaml"
+        assert parsed.agent_provider == "openai"
+        assert parsed.agent_model == "gpt-4"
+        assert parsed.agent_endpoint == "http://localhost:8080"  # default
+        assert parsed.result_dir == "results/"  # default
+
+    def test_args_parser_all_arguments(self):
+        """Test argument parser with all arguments."""
+        args = [
+            "--eval_data_yaml",
+            "test.yaml",
+            "--agent_endpoint",
+            "http://custom:9090",
+            "--agent_provider",
+            "watsonx",
+            "--agent_model",
+            "granite-3-8b-instruct",
+            "--agent_auth_token_file",
+            "token.txt",
+            "--judge_provider",
+            "openai",
+            "--judge_model",
+            "gpt-4",
+            "--kubeconfig",
+            "~/kubeconfig",
+            "--result_dir",
+            "custom_results/",
+        ]
+
+        parsed = _args_parser(args)
+
+        assert parsed.eval_data_yaml == "test.yaml"
+        assert parsed.agent_endpoint == "http://custom:9090"
+        assert parsed.agent_provider == "watsonx"
+        assert parsed.agent_model == "granite-3-8b-instruct"
+        assert parsed.agent_auth_token_file == "token.txt"
+        assert parsed.judge_provider == "openai"
+        assert parsed.judge_model == "gpt-4"
+        assert parsed.kubeconfig == "~/kubeconfig"
+        assert parsed.result_dir == "custom_results/"
+
+    def test_args_parser_missing_required(self):
+        """Test argument parser with missing required arguments."""
+        args = [
+            "--eval_data_yaml",
+            "test.yaml",
+            "--agent_provider",
+            "openai",
+            # Missing agent_model
+        ]
+
+        with pytest.raises(SystemExit):
+            _args_parser(args)
+
+    def test_args_parser_help(self):
+        """Test argument parser help."""
+        args = ["--help"]
+
+        with pytest.raises(SystemExit):
+            _args_parser(args)
+
+    def test_args_parser_optional_judge_args(self):
+        """Test argument parser with optional judge arguments."""
+        args = [
+            "--eval_data_yaml",
+            "test.yaml",
+            "--agent_provider",
+            "openai",
+            "--agent_model",
+            "gpt-4",
+            "--judge_provider",
+            "watsonx",
+            # Missing judge_model - should be allowed
+        ]
+
+        parsed = _args_parser(args)
+
+        assert parsed.judge_provider == "watsonx"
+        assert parsed.judge_model is None
+
+
+class TestMain:
+    """Test main function."""
+
+    @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
+    @patch("lsc_agent_eval.agent_eval._args_parser")
+    @patch("lsc_agent_eval.agent_eval.logging.basicConfig")
+    def test_main_success(
+        self, mock_logging_config, mock_args_parser, mock_agent_goal_eval
+    ):
+        """Test successful main execution."""
+        # Setup mocks
+        mock_args = Mock()
+        mock_args_parser.return_value = mock_args
+        mock_evaluator = Mock()
+        mock_agent_goal_eval.return_value = mock_evaluator
+
+        # Run main
+        main()
+
+        # Verify components were called
+        mock_args_parser.assert_called_once_with(sys.argv[1:])
+        mock_agent_goal_eval.assert_called_once_with(mock_args)
+        mock_evaluator.get_eval_result.assert_called_once()
+        mock_logging_config.assert_called_once()
+
+    @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
+    @patch("lsc_agent_eval.agent_eval._args_parser")
+    @patch("lsc_agent_eval.agent_eval.logging.basicConfig")
+    def test_main_logging_configuration(
+        self, mock_logging_config, mock_args_parser, mock_agent_goal_eval
+    ):
+        """Test main logging configuration."""
+        # Setup mocks
+        mock_args = Mock()
+        mock_args_parser.return_value = mock_args
+        mock_evaluator = Mock()
+        mock_agent_goal_eval.return_value = mock_evaluator
+
+        # Run main
+        main()
+
+        # Verify logging was configured correctly
+        import logging
+
+        mock_logging_config.assert_called_once_with(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+
+    @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
+    @patch("lsc_agent_eval.agent_eval._args_parser")
+    @patch("lsc_agent_eval.agent_eval.logging.basicConfig")
+    def test_main_evaluator_initialization(
+        self, mock_logging_config, mock_args_parser, mock_agent_goal_eval
+    ):
+        """Test main evaluator initialization."""
+        # Setup mocks
+        mock_args = Mock()
+        mock_args_parser.return_value = mock_args
+        mock_evaluator = Mock()
+        mock_agent_goal_eval.return_value = mock_evaluator
+
+        # Run main
+        main()
+
+        # Verify evaluator was initialized with parsed args
+        mock_agent_goal_eval.assert_called_once_with(mock_args)
+
+    @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
+    @patch("lsc_agent_eval.agent_eval._args_parser")
+    @patch("lsc_agent_eval.agent_eval.logging.basicConfig")
+    def test_main_evaluator_execution(
+        self, mock_logging_config, mock_args_parser, mock_agent_goal_eval
+    ):
+        """Test main evaluator execution."""
+        # Setup mocks
+        mock_args = Mock()
+        mock_args_parser.return_value = mock_args
+        mock_evaluator = Mock()
+        mock_agent_goal_eval.return_value = mock_evaluator
+
+        # Run main
+        main()
+
+        # Verify evaluator execution was called
+        mock_evaluator.get_eval_result.assert_called_once()
+
+    @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
+    @patch("lsc_agent_eval.agent_eval._args_parser")
+    @patch("lsc_agent_eval.agent_eval.logging.basicConfig")
+    @patch(
+        "sys.argv",
+        [
+            "agent_eval",
+            "--eval_data_yaml",
+            "test.yaml",
+            "--agent_provider",
+            "openai",
+            "--agent_model",
+            "gpt-4",
+        ],
+    )
+    def test_main_with_real_argv(
+        self, mock_logging_config, mock_args_parser, mock_agent_goal_eval
+    ):
+        """Test main with real sys.argv."""
+        # Setup mocks
+        mock_args = Mock()
+        mock_args_parser.return_value = mock_args
+        mock_evaluator = Mock()
+        mock_agent_goal_eval.return_value = mock_evaluator
+
+        # Run main
+        main()
+
+        # Verify args parser was called with correct arguments
+        mock_args_parser.assert_called_once_with(
+            [
+                "--eval_data_yaml",
+                "test.yaml",
+                "--agent_provider",
+                "openai",
+                "--agent_model",
+                "gpt-4",
+            ]
+        )


### PR DESCRIPTION
[LCORE-325](https://issues.redhat.com/browse/LCORE-325)

**Agent Goal Evaluation**: Evaluate whether an agent successfully achieves specified goals
**Multi-type Evaluation**: Support for different evaluation types:
  - `judge-llm`: LLM-based evaluation using a judge model
  - `script`: Script-based evaluation using verification scripts (similar to [k8s-bench](https://github.com/GoogleCloudPlatform/kubectl-ai/tree/main/k8s-bench))
  - `sub-string`: Simple substring matching evaluation
 
**Setup/Cleanup Scripts**: Support for running setup and cleanup scripts before/after evaluation
**Standalone Package**: Can be installed and used independently of the main lightspeed-core-evaluation package
**LiteLLM Integration**: Unified interface for Judge LLM (for now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a standalone agent evaluation framework supporting judge-LLM, script-based, and substring evaluation methods.
  * Added a command-line interface and Python API for running evaluations and exporting results as CSV files.
  * Included sample evaluation data and shell scripts for environment setup, verification, and cleanup.

* **Documentation**
  * Added detailed documentation covering installation, usage, configuration, and contribution guidelines for the evaluation framework.

* **Chores**
  * Updated workflows, Makefile, and `.gitignore` to integrate the new evaluation subproject and enhance development workflows.

* **Tests**
  * Added comprehensive unit tests for all core components, data models, utilities, and CLI features of the agent evaluation framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->