### PR TITLE
agent eval: verbose print and fixes

### DIFF
--- a/lsc_agent_eval/README.md
+++ b/lsc_agent_eval/README.md
@@ -66,7 +66,7 @@ lsc-agent-eval \
 ```python
 from lsc_agent_eval import AgentGoalEval
 
-# Create evaluation configuration
+# Create evaluation configuration, Alternatively use namespace
 class EvalArgs:
     def __init__(self):
         self.eval_data_yaml = 'data/example_eval.yaml'
@@ -81,7 +81,7 @@ class EvalArgs:
 # Run evaluation
 args = EvalArgs()
 evaluator = AgentGoalEval(args)
-evaluator.get_eval_result()
+evaluator.run_evaluation()
 ```
 
 ## Configuration
@@ -92,7 +92,7 @@ The evaluation is configured using a YAML file that defines test cases. Each tes
 - `eval_query`: The query/task to send to the agent
 - `eval_type`: Type of evaluation (judge-llm, script, sub-string)
 - `expected_response`: Expected response (for judge-llm evaluation)
-- `expected_key_words`: Keywords to look for (for sub-string evaluation)
+- `expected_keywords`: Keywords to look for (for sub-string evaluation)
 - `eval_verify_script`: Verification script (for script evaluation)
 - `eval_setup_script`: Optional setup script to run before evaluation
 - `eval_cleanup_script`: Optional cleanup script to run after evaluation
@@ -104,7 +104,7 @@ The evaluation is configured using a YAML file that defines test cases. Each tes
 - eval_id: eval1
   eval_query: "is there a openshift-monitoring namespace?"
   eval_type: sub-string
-  expected_key_words:
+  expected_keywords:
     - 'yes'
     - openshift-monitoring
 

--- a/lsc_agent_eval/sample_data/agent_goal_eval_example.yaml
+++ b/lsc_agent_eval/sample_data/agent_goal_eval_example.yaml
@@ -1,7 +1,7 @@
 - eval_id: eval1
   eval_query: is there a openshift-monitoring namespace ?
   eval_type: sub-string
-  expected_key_words:
+  expected_keywords:
   - 'yes'
   - openshift-monitoring
 
@@ -14,7 +14,7 @@
   eval_query: is there a openshift-lightspeed namespace ?
   eval_setup_script: sample_data/script/eval3/setup.sh
   eval_type: sub-string
-  expected_key_words:
+  expected_keywords:
   - 'yes'
   eval_cleanup_script: sample_data/script/eval3/cleanup.sh
 

--- a/lsc_agent_eval/src/lsc_agent_eval/agent_eval.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/agent_eval.py
@@ -84,7 +84,7 @@ def main() -> None:
 
     # Create and run evaluation
     evaluator = AgentGoalEval(args)
-    evaluator.get_eval_result()
+    evaluator.run_evaluation()
 
 
 if __name__ == "__main__":

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
@@ -51,7 +51,7 @@ class AgentGoalEval:
         # Results manager
         self.results_manager = ResultsManager(self.eval_args.result_dir)
 
-    def get_eval_result(self) -> None:
+    def run_evaluation(self) -> None:
         """Run all evaluations and save results."""
         try:
             eval_data = self.data_manager.get_eval_data()
@@ -100,9 +100,9 @@ class AgentGoalEval:
             pbar.write(f"   Query: {result.query}")
             pbar.write(f"   Response: {result.response}")
             pbar.write(f"   Evaluation type: {result.eval_type}")
-            if data_config.expected_key_words:
+            if data_config.expected_keywords:
                 pbar.write(
-                    f"   Expected keywords: {','.join(data_config.expected_key_words)}"
+                    f"   Expected keywords: {','.join(data_config.expected_keywords)}"
                 )
             if data_config.expected_response:
                 pbar.write(f"   Expected response: {data_config.expected_response}")

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/agent_goal_eval.py
@@ -21,6 +21,7 @@ class AgentGoalEval:
     def __init__(self, eval_args: argparse.Namespace) -> None:
         """Initialize agent goal evaluation."""
         self.eval_args = eval_args
+        self.result_summary: dict[str, int] = {}
         self._setup_components()
 
     def _setup_components(self) -> None:
@@ -128,6 +129,8 @@ class AgentGoalEval:
         print(f"Success Rate: {success_rate:.1f}%")
         print(f"{'='*25}\n")
 
+        self.result_summary = {"PASS": passed, "FAIL": failed, "ERROR": errored}
+
     def _cleanup(self) -> None:
         """Clean up resources."""
         try:
@@ -136,6 +139,6 @@ class AgentGoalEval:
         except (AttributeError, OSError) as e:
             logger.warning("Error during cleanup: %s", e)
 
-    def get_data_manager(self) -> AgentGoalEvalDataManager:
-        """Get the evaluation data manager."""
-        return self.data_manager
+    def get_result_summary(self) -> dict[str, int]:
+        """Get result summary."""
+        return self.result_summary

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/eval_data.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/eval_data.py
@@ -69,9 +69,9 @@ class AgentGoalEvalDataManager:
                 "eval_type 'judge-llm' requires 'expected_response' field"
             )
 
-        if eval_type == "sub-string" and "expected_key_words" not in eval_data:
+        if eval_type == "sub-string" and "expected_keywords" not in eval_data:
             raise ConfigurationError(
-                "eval_type 'sub-string' requires 'expected_key_words' field"
+                "eval_type 'sub-string' requires 'expected_keywords' field"
             )
 
         if eval_type == "script" and "eval_verify_script" not in eval_data:

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
@@ -41,7 +41,7 @@ class EvaluationRunner:
                         raise ScriptExecutionError(
                             "Setup script returned non-zero exit code"
                         )
-                    logger.info(
+                    logger.debug(
                         "Setup script executed successfully for %s", data_config.eval_id
                     )
                 except ScriptExecutionError as e:
@@ -72,7 +72,7 @@ class EvaluationRunner:
                         data_config.eval_cleanup_script
                     )
                     if cleanup_success:
-                        logger.info(
+                        logger.debug(
                             "Cleanup script executed successfully for %s",
                             data_config.eval_id,
                         )

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
@@ -136,13 +136,13 @@ class EvaluationRunner:
         self, data_config: EvaluationDataConfig, response: str
     ) -> bool:
         """Evaluate using substring matching."""
-        if not data_config.expected_key_words:
+        if not data_config.expected_keywords:
             return False
 
         response_lower = response.lower()
         return any(
             keyword.lower() in response_lower
-            for keyword in data_config.expected_key_words
+            for keyword in data_config.expected_keywords
         )
 
     def _extract_numeric_result(self, response: Optional[str]) -> int:

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/evaluator.py
@@ -125,12 +125,8 @@ class EvaluationRunner:
             logger.error("No verify script provided for script evaluation")
             return False
 
-        try:
-            script_runner = ScriptRunner(kubeconfig=self.kubeconfig)
-            return script_runner.run_script(data_config.eval_verify_script)
-        except ScriptExecutionError as e:
-            logger.error("Script evaluation failed: %s", e)
-            return False
+        script_runner = ScriptRunner(kubeconfig=self.kubeconfig)
+        return script_runner.run_script(data_config.eval_verify_script)
 
     def _evaluate_substring(
         self, data_config: EvaluationDataConfig, response: str

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/models.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/models.py
@@ -24,7 +24,7 @@ class EvaluationDataConfig:  # pylint: disable=too-many-instance-attributes
     eval_query: str
     eval_type: str = "judge-llm"
     expected_response: Optional[str] = None
-    expected_key_words: Optional[list[str]] = None
+    expected_keywords: Optional[list[str]] = None
     eval_setup_script: Optional[str] = None
     eval_verify_script: Optional[str] = None
     eval_cleanup_script: Optional[str] = None

--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
@@ -50,7 +50,7 @@ class ScriptRunner:
             cmd = ["bash", str(script_file)]
 
             # Run script
-            logger.info("Running script: %s", script_path)
+            logger.debug("Running script: %s", script_file)
 
             result = subprocess.run(
                 cmd,
@@ -66,7 +66,7 @@ class ScriptRunner:
             if result.stdout:
                 logger.debug("Script stdout: %s", result.stdout)
             if result.stderr:
-                logger.debug("Script stderr: %s", result.stderr)
+                logger.warning("Script stderr: %s", result.stderr)
 
             return result.returncode == 0
 

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/api_client.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/api_client.py
@@ -70,7 +70,6 @@ class AgentHttpClient:
             if "response" not in response_data:
                 raise AgentAPIError("Agent response missing 'response' field")
 
-            logger.info("Agent response >\n%s", response_data["response"].strip())
             return response_data["response"].strip()
 
         except httpx.TimeoutException as e:

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/constants.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/constants.py
@@ -1,7 +1,7 @@
 """Constants for agent evaluation."""
 
 # Default directory for evaluation results
-DEFAULT_RESULT_DIR = "results/"
+DEFAULT_RESULT_DIR = "eval_output/"
 
 # Retry configuration
 MAX_RETRY_ATTEMPTS = 3

--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
@@ -28,7 +28,7 @@ class JudgeModelManager:
 
     def _setup_litellm(self) -> None:
         """Initialize LiteLLM with provider-specific configuration."""
-        logger.info(
+        logger.debug(
             "Setting up LiteLLM for %s/%s", self.judge_provider, self.judge_model
         )
 

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_agent_goal_eval.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_agent_goal_eval.py
@@ -159,7 +159,7 @@ class TestAgentGoalEval:
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
-    def test_get_eval_result_success(
+    def test_run_evaluation_success(
         self,
         mock_results_manager,
         mock_evaluation_runner,
@@ -179,7 +179,7 @@ class TestAgentGoalEval:
 
         # Capture print output
         with patch("builtins.print") as mock_print:
-            evaluator.get_eval_result()
+            evaluator.run_evaluation()
 
         # Verify evaluations were run
         assert mock_evaluation_runner.return_value.run_evaluation.call_count == 2
@@ -199,7 +199,7 @@ class TestAgentGoalEval:
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
-    def test_get_eval_result_with_errors(
+    def test_run_evaluation_with_errors(
         self,
         mock_results_manager,
         mock_evaluation_runner,
@@ -237,7 +237,7 @@ class TestAgentGoalEval:
 
         evaluator = AgentGoalEval(mock_args)
 
-        evaluator.get_eval_result()
+        evaluator.run_evaluation()
 
         # Capture stdout/stderr output
         captured = capsys.readouterr()
@@ -265,7 +265,7 @@ class TestAgentGoalEval:
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
-    def test_get_eval_result_exception(
+    def test_run_evaluation_exception(
         self,
         mock_results_manager,
         mock_evaluation_runner,
@@ -285,7 +285,7 @@ class TestAgentGoalEval:
             "lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.logger"
         ) as mock_logger:
             with pytest.raises(Exception, match="Config error"):
-                evaluator.get_eval_result()
+                evaluator.run_evaluation()
 
         # Verify error was logged
         mock_logger.error.assert_called()
@@ -439,7 +439,7 @@ class TestAgentGoalEval:
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
-    def test_get_eval_result_cleanup_called(
+    def test_run_evaluation_cleanup_called(
         self,
         mock_results_manager,
         mock_evaluation_runner,
@@ -457,7 +457,7 @@ class TestAgentGoalEval:
         evaluator = AgentGoalEval(mock_args)
 
         with patch.object(evaluator, "_cleanup") as mock_cleanup:
-            evaluator.get_eval_result()
+            evaluator.run_evaluation()
 
         # Verify cleanup was called
         mock_cleanup.assert_called_once()
@@ -469,7 +469,7 @@ class TestAgentGoalEval:
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.JudgeModelManager")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.EvaluationRunner")
     @patch("lsc_agent_eval.core.agent_goal_eval.agent_goal_eval.ResultsManager")
-    def test_get_eval_result_cleanup_called_on_exception(
+    def test_run_evaluation_cleanup_called_on_exception(
         self,
         mock_results_manager,
         mock_evaluation_runner,
@@ -487,7 +487,7 @@ class TestAgentGoalEval:
 
         with patch.object(evaluator, "_cleanup") as mock_cleanup:
             with pytest.raises(Exception):
-                evaluator.get_eval_result()
+                evaluator.run_evaluation()
 
         # Verify cleanup was called
         mock_cleanup.assert_called_once()

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_eval_data.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_eval_data.py
@@ -35,7 +35,7 @@ class TestAgentGoalEvalDataManager:
                 "eval_id": "test_003",
                 "eval_query": "Show pods",
                 "eval_type": "sub-string",
-                "expected_key_words": ["pod", "running"],
+                "expected_keywords": ["pod", "running"],
             },
         ]
 
@@ -215,7 +215,7 @@ class TestAgentGoalEvalDataManager:
                 AgentGoalEvalDataManager("test.yaml")
 
     def test_validate_eval_data_sub_string_missing_keywords(self):
-        """Test validation for sub-string type missing expected_key_words."""
+        """Test validation for sub-string type missing expected_keywords."""
         invalid_data = [
             {
                 "eval_id": "test_001",
@@ -232,7 +232,7 @@ class TestAgentGoalEvalDataManager:
         ):
 
             with pytest.raises(
-                ConfigurationError, match="requires 'expected_key_words' field"
+                ConfigurationError, match="requires 'expected_keywords' field"
             ):
                 AgentGoalEvalDataManager("test.yaml")
 
@@ -379,7 +379,7 @@ class TestAgentGoalEvalDataManager:
                 "eval_id": "test_substring",
                 "eval_query": "List services",
                 "eval_type": "sub-string",
-                "expected_key_words": ["service", "active", "running"],
+                "expected_keywords": ["service", "active", "running"],
             }
         ]
         yaml_content = yaml.dump(sub_string_data)
@@ -393,7 +393,7 @@ class TestAgentGoalEvalDataManager:
             manager = AgentGoalEvalDataManager("test.yaml")
             assert len(manager.eval_data) == 1
             assert manager.eval_data[0].eval_type == "sub-string"
-            assert manager.eval_data[0].expected_key_words == [
+            assert manager.eval_data[0].expected_keywords == [
                 "service",
                 "active",
                 "running",
@@ -418,7 +418,7 @@ class TestAgentGoalEvalDataManager:
                 "eval_id": "substring_test",
                 "eval_query": "List pods",
                 "eval_type": "sub-string",
-                "expected_key_words": ["pod", "running"],
+                "expected_keywords": ["pod", "running"],
             },
         ]
         yaml_content = yaml.dump(mixed_data)

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
@@ -212,8 +212,8 @@ class TestEvaluationRunner:
 
         assert isinstance(result, EvaluationResult)
         assert result.eval_id == "test_002"
-        assert result.result == "FAIL"
-        assert result.error is None
+        assert result.result == "ERROR"
+        assert result.error == "Script failed"
 
     def test_run_evaluation_substring_success(
         self, mock_agent_client, sample_config_substring

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_evaluator.py
@@ -58,7 +58,7 @@ class TestEvaluationRunner:
             eval_id="test_003",
             eval_query="What is Docker?",
             eval_type="sub-string",
-            expected_key_words=["container", "docker"],
+            expected_keywords=["container", "docker"],
         )
 
     def test_init(self, mock_agent_client, mock_judge_manager):

--- a/lsc_agent_eval/tests/core/agent_goal_eval/test_models.py
+++ b/lsc_agent_eval/tests/core/agent_goal_eval/test_models.py
@@ -72,7 +72,7 @@ class TestEvaluationDataConfig:
         assert config.eval_query == "What is Kubernetes?"
         assert config.eval_type == "judge-llm"  # default
         assert config.expected_response is None
-        assert config.expected_key_words is None
+        assert config.expected_keywords is None
         assert config.eval_setup_script is None
         assert config.eval_verify_script is None
         assert config.eval_cleanup_script is None
@@ -90,7 +90,7 @@ class TestEvaluationDataConfig:
         assert config.eval_query == "Explain containers"
         assert config.eval_type == "judge-llm"
         assert config.expected_response == "Containers are lightweight virtualization"
-        assert config.expected_key_words is None
+        assert config.expected_keywords is None
         assert config.eval_setup_script is None
         assert config.eval_verify_script is None
         assert config.eval_cleanup_script is None
@@ -110,7 +110,7 @@ class TestEvaluationDataConfig:
         assert config.eval_query == "Deploy nginx pod"
         assert config.eval_type == "script"
         assert config.expected_response is None
-        assert config.expected_key_words is None
+        assert config.expected_keywords is None
         assert config.eval_setup_script == "./setup.sh"
         assert config.eval_verify_script == "./verify.sh"
         assert config.eval_cleanup_script == "./cleanup.sh"
@@ -121,14 +121,14 @@ class TestEvaluationDataConfig:
             eval_id="substring_test",
             eval_query="List container benefits",
             eval_type="sub-string",
-            expected_key_words=["isolation", "portability", "efficiency"],
+            expected_keywords=["isolation", "portability", "efficiency"],
         )
 
         assert config.eval_id == "substring_test"
         assert config.eval_query == "List container benefits"
         assert config.eval_type == "sub-string"
         assert config.expected_response is None
-        assert config.expected_key_words == ["isolation", "portability", "efficiency"]
+        assert config.expected_keywords == ["isolation", "portability", "efficiency"]
         assert config.eval_setup_script is None
         assert config.eval_verify_script is None
         assert config.eval_cleanup_script is None
@@ -140,7 +140,7 @@ class TestEvaluationDataConfig:
             eval_query="What is OpenShift?",
             eval_type="judge-llm",
             expected_response="OpenShift is a Kubernetes platform",
-            expected_key_words=["kubernetes", "platform", "container"],
+            expected_keywords=["kubernetes", "platform", "container"],
             eval_setup_script="./setup.sh",
             eval_verify_script="./verify.sh",
             eval_cleanup_script="./cleanup.sh",
@@ -150,7 +150,7 @@ class TestEvaluationDataConfig:
         assert config.eval_query == "What is OpenShift?"
         assert config.eval_type == "judge-llm"
         assert config.expected_response == "OpenShift is a Kubernetes platform"
-        assert config.expected_key_words == ["kubernetes", "platform", "container"]
+        assert config.expected_keywords == ["kubernetes", "platform", "container"]
         assert config.eval_setup_script == "./setup.sh"
         assert config.eval_verify_script == "./verify.sh"
         assert config.eval_cleanup_script == "./cleanup.sh"

--- a/lsc_agent_eval/tests/test_agent_eval.py
+++ b/lsc_agent_eval/tests/test_agent_eval.py
@@ -127,7 +127,7 @@ class TestMain:
         # Verify components were called
         mock_args_parser.assert_called_once_with(sys.argv[1:])
         mock_agent_goal_eval.assert_called_once_with(mock_args)
-        mock_evaluator.get_eval_result.assert_called_once()
+        mock_evaluator.run_evaluation.assert_called_once()
         mock_logging_config.assert_called_once()
 
     @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
@@ -190,7 +190,7 @@ class TestMain:
         main()
 
         # Verify evaluator execution was called
-        mock_evaluator.get_eval_result.assert_called_once()
+        mock_evaluator.run_evaluation.assert_called_once()
 
     @patch("lsc_agent_eval.agent_eval.AgentGoalEval")
     @patch("lsc_agent_eval.agent_eval._args_parser")

--- a/lsc_agent_eval/tests/test_agent_eval.py
+++ b/lsc_agent_eval/tests/test_agent_eval.py
@@ -28,7 +28,7 @@ class TestArgsParser:
         assert parsed.agent_provider == "openai"
         assert parsed.agent_model == "gpt-4"
         assert parsed.agent_endpoint == "http://localhost:8080"  # default
-        assert parsed.result_dir == "results/"  # default
+        assert parsed.result_dir == "eval_output/"  # default
 
     def test_args_parser_all_arguments(self):
         """Test argument parser with all arguments."""


### PR DESCRIPTION
- Add more verbose printing for local run
- Return result summary count
- Set status to ERROR instead of FAIL for verify subprocess failure
- Some refactoring (name change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced evaluation progress display with a dynamic progress bar and detailed result markers for each evaluation, including clearer summaries with emoji indicators.

* **Style**
  * Improved output formatting for individual and summary evaluation results to make statuses and details more visible.

* **Chores**
  * Changed the default output directory name from "results/" to "eval_output/".

* **Tests**
  * Updated tests to reflect the new default output directory.
  * Removed progress bar mocking and replaced logger error assertions with output capture to verify evaluation messages.
  * Updated test data and assertions to use consistent field naming for expected keywords.
  * Adjusted test expectations for script execution errors to align with updated error handling.

* **Refactor**
  * Adjusted logging levels to reduce verbosity by moving several informational messages to debug level.
  * Renamed evaluation method from `get_eval_result()` to `run_evaluation()` throughout code and documentation.
  * Corrected and standardized field naming from `expected_key_words` to `expected_keywords` in evaluation configurations and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->