### PR TITLE
provider vertex support for judge llm

### DIFF
--- a/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/utils/judge.py
@@ -74,6 +74,14 @@ class JudgeModelManager:
 
             self.model_name = f"watsonx/{self.judge_model}"
 
+        elif provider == "vertex":
+            if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+                raise JudgeModelError(
+                    "GOOGLE_APPLICATION_CREDENTIALS environment variable is "
+                    "required for Vertex AI provider"
+                )
+            self.model_name = self.judge_model
+
         else:
             # Generic provider - try as-is
             logger.warning("Using generic provider format for %s", provider)


### PR DESCRIPTION
adding the handling of provider vertex in the judge providers, because the default format 'f"{provider}/{self.judge_model}"' is not working for this provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud Vertex AI as a provider for judge models, allowing selection of Vertex model names alongside OpenAI, Azure, and watsonx.
* **Bug Fixes**
  * Improved setup validation with a clear error when Google credentials are missing to prevent misconfiguration at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->