### PR TITLE
feat: Added parallelism for answer generation

### DIFF
--- a/README-generate-answers.md
+++ b/README-generate-answers.md
@@ -55,6 +55,8 @@ Options:
   -f, --force-overwrite       Overwrite the output file if it exists
   -v, --verbose               Increase the logging level to DEBUG
   -h, --help                  Show this message and exit.
+  -p, --max-concurrent INTEGER  Maximum number of questions to process in
+                                parallel simultaneously  [default: 1]
 ```
 
 ## Results


### PR DESCRIPTION
Parallelization to speed up answer generation.

Tested with LCS, works fine!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option --max-concurrent (-p) to control how many answers are generated in parallel; defaults to sequential when set to 1.  
* **Performance**
  * Enabled configurable parallel processing for answer generation, reducing runtime on larger datasets while preserving progress feedback.  
* **Documentation**
  * Updated usage docs to describe the new concurrency flag and its default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->