### PR TITLE
[LCORE-648] Fix processing of `float('NaN')` values when OutputParserException

### DIFF
--- a/src/lightspeed_evaluation/core/metrics/ragas.py
+++ b/src/lightspeed_evaluation/core/metrics/ragas.py
@@ -101,13 +101,13 @@ class RagasMetrics:
                 f"connection issue: {str(e)}",
             )
         except OSError as e:
+            err_msg = f"Ragas {metric_name} evaluation failed: {str(e)}"
             if e.errno == 32:  # Broken pipe
-                return (
-                    None,
+                err_msg = (
                     f"Ragas {metric_name} evaluation failed due to broken pipe "
-                    f"(network/LLM timeout): {str(e)}",
+                    f"(network/LLM timeout): {str(e)}"
                 )
-            return None, f"Ragas {metric_name} evaluation failed: {str(e)}"
+            return None, err_msg
         except (RuntimeError, ValueError, TypeError, ImportError) as e:
             return None, f"Ragas {metric_name} evaluation failed: {str(e)}"
 


### PR DESCRIPTION
The RAGAS framework returns `float('NaN')` when it encounters malformed output from the LLM. The malformed output is accompanied by an OutputParserException in the logs, but this exception is caught internally.

The NaN causes a later failure during the generation of statistics like standard deviation at the end of the evaluation and ultimately causes no results to be obtained from the evaluation when the malformed output is encountered by RAGAS.

This commit fixes this issue by checking whether `float('NaN')` was returned from RAGAS and, if so, ensures that the `evaluate()` function returns None, as in other cases of failure. This ensures that NaN does not reach the computation of the final statistics.

Resolves: #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of network/timeout errors (e.g., broken connections) with clearer, user-friendly messages.
  * Detects and safely handles malformed or NaN model outputs, returning a safe result and explanatory error instead of crashing.
  * Unified post-processing ensures consistent result handling and more informative feedback during evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->