### PR TITLE
[nit] Clean up evaluation_data.yaml

### DIFF
--- a/config/evaluation_data.yaml
+++ b/config/evaluation_data.yaml
@@ -7,13 +7,13 @@
     - "ragas:faithfulness"
     - "ragas:response_relevancy"
     - "ragas:context_precision_without_reference"
-  
-  turn_metrics_metadata: 
-    "ragas:faithfulness": 
+
+  turn_metrics_metadata:
+    "ragas:faithfulness":
       threshold: 0.99
   conversation_metrics: []
   conversation_metrics_metadata: {}
-  
+
   turns:
     - turn_id: "1"
       query: "User query"
@@ -28,13 +28,13 @@
 
   turn_metrics:
     - "ragas:context_recall"
-    - "ragas:context_relevance" 
+    - "ragas:context_relevance"
     - "ragas:context_precision_with_reference"
-  
+
   turn_metrics_metadata: {}
   conversation_metrics: []
   conversation_metrics_metadata: {}
-  
+
   turns:
     - turn_id: "1"
       query: "User Query"
@@ -48,15 +48,15 @@
 
   turn_metrics:
     - "custom:answer_correctness"
-  
+
   turn_metrics_metadata: {}
-  
+
   conversation_metrics:
     - "deepeval:conversation_completeness"
     - "deepeval:conversation_relevancy"
-  
+
   conversation_metrics_metadata: {}
-  
+
   turns:
     - turn_id: "1"
       query: "User Query 1"
@@ -64,7 +64,7 @@
       contexts:
         - "Context"
       expected_response: "Expected Response 1"
-    
+
     - turn_id: "2"
       query: "User Query 2"
       response: "API Response 2"

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -34,28 +34,28 @@ metrics_metadata:
     "ragas:faithfulness":
       threshold: 0.8
       description: "How faithful the response is to the provided context"
-      
+
     "ragas:response_relevancy":
       threshold: 0.8
       description: "How relevant the response is to the question"
-    
+
     # Ragas Context/Retrieval Evaluation metrics
     "ragas:context_recall":
       threshold: 0.8
       description: "Did we fetch every fact the answer needs?"
-      
+
     "ragas:context_relevance":
       threshold: 0.7
       description: "Is what we retrieved actually relevant to user query?"
-      
+
     "ragas:context_precision_with_reference":
       threshold: 0.7
       description: "How precise the retrieved context is (with reference)"
-      
+
     "ragas:context_precision_without_reference":
       threshold: 0.7
       description: "How precise the retrieved context is (without reference)"
-    
+
     # Custom metrics
     "custom:answer_correctness":
       threshold: 0.75
@@ -63,18 +63,18 @@ metrics_metadata:
 
     "custom:tool_eval":
       description: "Tool call evaluation comparing expected vs actual tool calls"
-  
+
   # Conversation-level metrics metadata
   conversation_level:
     # DeepEval metrics
     "deepeval:conversation_completeness":
       threshold: 0.8
       description: "How completely the conversation addresses user intentions"
-      
+
     "deepeval:conversation_relevancy":
       threshold: 0.7
       description: "How relevant the conversation is to the topic/context"
-      
+
     "deepeval:knowledge_retention":
       threshold: 0.7
       description: "How well the model retains information from previous turns"
@@ -87,11 +87,11 @@ output:
     - csv                   # Detailed results CSV
     - json                  # Summary JSON with statistics
     - txt                   # Human-readable summary
-  
+
   # CSV columns to include
   csv_columns:
     - "conversation_group_id"
-    - "turn_id" 
+    - "turn_id"
     - "metric_identifier"
     - "score"
     - "threshold"
@@ -105,7 +105,7 @@ output:
 visualization:
   figsize: [12, 8]            # Graph size (width, height)
   dpi: 300                    # Image resolution
-  
+
   # Graph types to generate
   enabled_graphs:
     - "pass_rates"            # Pass rate bar chart


### PR DESCRIPTION
This update makes sure the evaluation_data.yaml adheres the models
[1][2].

- Standardize turn_id format to strings
- Simplify contexts structure from objects to arrays
- Add missing description field to conversation group 3

Co-Authored-By: Claude <noreply@anthropic.com>

[1] https://github.com/lightspeed-core/lightspeed-evaluation/blob/b629ddc56912cfa6ce42eee06569c9bc7b27cfd9/src/lightspeed_evaluation/core/models/data.py#L31
[2] https://github.com/lightspeed-core/lightspeed-evaluation/blob/b629ddc56912cfa6ce42eee06569c9bc7b27cfd9/src/lightspeed_evaluation/core/models/data.py#L146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new evaluation metrics at turn and conversation levels to broaden quality assessment.
  * Expanded CSV export with additional columns (result, reason, query, response, execution_time) for richer reporting.
  * Introduced new visualization options: score distribution, conversation heatmap, and status breakdown.

* **Changes**
  * Standardized turn IDs to strings across datasets.
  * Simplified context entries from objects to plain strings.
  * Added descriptions to select conversation groups and streamlined group fields.
  * Reorganized per-turn metric thresholds for clearer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->