### PR TITLE
allow none llm for LS API

### DIFF
--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -10,8 +10,6 @@ import httpx
 from ..constants import (
     DEFAULT_API_TIMEOUT,
     DEFAULT_ENDPOINT_TYPE,
-    DEFAULT_LLM_MODEL,
-    DEFAULT_LLM_PROVIDER,
     SUPPORTED_ENDPOINT_TYPES,
 )
 from ..models import APIRequest, APIResponse
@@ -36,14 +34,8 @@ class APIClient:
         self.api_base = api_base
         self.endpoint_type = endpoint_type
         self.timeout = timeout
-        # LLM configuration with defaults
-        default_config = {
-            "provider": DEFAULT_LLM_PROVIDER,
-            "model": DEFAULT_LLM_MODEL,
-            "no_tools": None,
-            "system_prompt": None,
-        }
-        self.llm_config = {**default_config, **(config or {})}
+
+        self.llm_config = config or {}
 
         self.client: Optional[httpx.Client] = None
 

--- a/src/lightspeed_evaluation/core/models/api.py
+++ b/src/lightspeed_evaluation/core/models/api.py
@@ -4,8 +4,6 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ..constants import DEFAULT_LLM_MODEL, DEFAULT_LLM_PROVIDER
-
 
 class AttachmentData(BaseModel):
     """Individual attachment structure for API."""
@@ -23,8 +21,8 @@ class APIRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str = Field(..., min_length=1, description="User query")
-    provider: str = Field(default=DEFAULT_LLM_PROVIDER, description="LLM provider")
-    model: str = Field(default=DEFAULT_LLM_MODEL, description="LLM model")
+    provider: Optional[str] = Field(default=None, description="LLM provider")
+    model: Optional[str] = Field(default=None, description="LLM model")
     no_tools: Optional[bool] = Field(default=None, description="Disable tool usage")
     conversation_id: Optional[str] = Field(
         default=None, description="Conversation ID for context"
@@ -44,8 +42,8 @@ class APIRequest(BaseModel):
     ) -> "APIRequest":
         """Create API request with optional attachments."""
         # Extract parameters with defaults
-        provider = kwargs.get("provider", DEFAULT_LLM_PROVIDER)
-        model = kwargs.get("model", DEFAULT_LLM_MODEL)
+        provider = kwargs.get("provider")
+        model = kwargs.get("model")
         no_tools = kwargs.get("no_tools")
         conversation_id = kwargs.get("conversation_id")
         system_prompt = kwargs.get("system_prompt")

--- a/src/lightspeed_evaluation/core/models/system.py
+++ b/src/lightspeed_evaluation/core/models/system.py
@@ -78,10 +78,8 @@ class APIConfig(BaseModel):
     timeout: int = Field(
         default=DEFAULT_API_TIMEOUT, ge=1, description="Request timeout in seconds"
     )
-    provider: str = Field(
-        default=DEFAULT_LLM_PROVIDER, description="LLM provider for API"
-    )
-    model: str = Field(default=DEFAULT_LLM_MODEL, description="LLM model for API")
+    provider: Optional[str] = Field(default=None, description="LLM provider for API")
+    model: Optional[str] = Field(default=None, description="LLM model for API")
     no_tools: Optional[bool] = Field(
         default=None, description="Disable tool usage in API calls"
     )


### PR DESCRIPTION
It is possible to disable model change for LS API.. In that case we can not send provider/model as part of API request.
So allowing None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed default LLM provider/model. Configuration now requires explicitly setting provider and model.
  - Made provider and model optional fields in API configuration and request payloads; values are read directly from user-supplied config.
- Chores
  - Reduced public surface by eliminating unused default constants.

Note: This is a breaking change. Existing setups relying on implicit defaults must update configuration or request parameters to include provider and model to avoid errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->