### PR TITLE
Retrieved RAG context from lightspeed-stack API

### DIFF
--- a/src/lightspeed_evaluation/core/api/streaming_parser.py
+++ b/src/lightspeed_evaluation/core/api/streaming_parser.py
@@ -16,7 +16,6 @@ def parse_streaming_response(response: httpx.Response) -> dict[str, Any]:
     conversation_id = ""
     final_response = ""
     tool_calls: list[dict[str, Any]] = []
-    contexts: list[str] = []
 
     for line in response.iter_lines():
         line = line.strip()
@@ -58,7 +57,6 @@ def parse_streaming_response(response: httpx.Response) -> dict[str, Any]:
         "response": final_response,
         "tool_calls": tool_sequences,
         "conversation_id": conversation_id,
-        "contexts": contexts,
     }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Responses now include rag_chunks (content, source, optional score) and contexts are auto-populated from these chunks when needed.

- Refactor
  - Streaming responses no longer return a separate contexts field; payload now focuses on response, tool calls, conversation ID and rag_chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->