### PR TITLE
keep original input file intact

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ visualization:
 - **Dynamic responses**: `response` and `tool_calls` fields populated by API
 - **Conversation context**: Conversation context is maintained across turns
 - **Authentication**: Use `API_KEY` environment variable
-- **Data persistence**: Writes `response`/`tool_calls` back to the original evaluation data so it can be reused with API disabled
+- **Data persistence**: Saves amended `response`/`tool_calls` data to output directory so it can be used with API disabled
 
 #### With API Disabled (`api.enabled: false`)
 - **Static data mode**: Use pre-filled `response` and `tool_calls` data

--- a/src/lightspeed_evaluation/core/output/data_persistence.py
+++ b/src/lightspeed_evaluation/core/output/data_persistence.py
@@ -1,6 +1,5 @@
 """Simple data persistence utilities for evaluation framework."""
 
-import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -17,9 +16,9 @@ def save_evaluation_data(
     original_data_path: str,
     output_dir: str = DEFAULT_OUTPUT_DIR,
 ) -> Optional[str]:
-    """Save updated evaluation data, backing up original with timestamp."""
+    """Save amended evaluation data to output directory with timestamp."""
     original_path = Path(original_data_path)
-    backup_path = None
+    amended_data_path = None
 
     try:
         output_path = Path(output_dir)
@@ -27,18 +26,15 @@ def save_evaluation_data(
         # Ensure output directory exists
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # Create backup with timestamp in output directory
+        # Create amended data file with timestamp in output directory
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        backup_path = (
-            output_path / f"{original_path.stem}_bkp_{timestamp}{original_path.suffix}"
+        amended_data_path = (
+            output_path
+            / f"{original_path.stem}_amended_{timestamp}{original_path.suffix}"
         )
 
-        # Copy original to backup
-        shutil.copy2(str(original_path), str(backup_path))
-        print(f"📋 Original file backed up: {backup_path}")
-
-        # Save updated data to original filename
-        with open(original_path, "w", encoding="utf-8") as f:
+        # Save amended data to output directory
+        with open(amended_data_path, "w", encoding="utf-8") as f:
             yaml.dump(
                 [conv_data.model_dump() for conv_data in evaluation_data],
                 f,
@@ -48,11 +44,9 @@ def save_evaluation_data(
                 indent=2,
             )
 
-        print(f"💾 Updated evaluation data saved: {original_path}")
-        print(f"📁 Backup created: {backup_path}")
-        return str(original_path)
+        print(f"💾 Amended evaluation data saved to: {amended_data_path}")
+        return str(amended_data_path)
 
     except (OSError, yaml.YAMLError) as e:
-        print(f"❌ Failed to save updated evaluation data: {e}")
-        print(f"💾 Original file remains intact, backup available at: {backup_path}")
+        print(f"❌ Failed to save amended evaluation data: {e}")
         return None

--- a/src/lightspeed_evaluation/pipeline/evaluation/amender.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/amender.py
@@ -40,7 +40,7 @@ class APIDataAmender:
                 )
                 conversation_id = api_response.conversation_id  # Track for next turns
 
-                # UPDATE ORIGINAL YAML DATA: This modifies the loaded TurnData object in-place
+                # AMEND EVALUATION DATA: This modifies the loaded TurnData object in-place
                 # Update response from API
                 turn_data.response = api_response.response
                 turn_data.conversation_id = api_response.conversation_id

--- a/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
@@ -25,7 +25,7 @@ class EvaluationPipeline:
     - Validate data
     - Orchestrate evaluation flow
     - Collect results
-    - Save updated data
+    - Save amended data
     """
 
     def __init__(self, config_loader: ConfigLoader, output_dir: Optional[str] = None):
@@ -137,36 +137,37 @@ class EvaluationPipeline:
             conv_results = self.conversation_processor.process_conversation(conv_data)
             results.extend(conv_results)
 
-        # Step 3: Save updated data if API was used
+        # Step 3: Save amended data if API was used
         config = self.config_loader.system_config
         if config is None:
             raise ValueError("SystemConfig must be loaded")
         if config.api.enabled:
-            logger.info("Saving updated evaluation data")
-            self._save_updated_data(evaluation_data)
+            logger.info("Saving amended evaluation data")
+            self._save_amended_data(evaluation_data)
 
         logger.info("Evaluation complete: %d results generated", len(results))
         return results
 
-    def _save_updated_data(self, evaluation_data: list[EvaluationData]) -> None:
-        """Save updated evaluation data with API amendments."""
+    def _save_amended_data(self, evaluation_data: list[EvaluationData]) -> None:
+        """Save amended evaluation data with API amendments to output directory."""
         if not self.original_data_path:
-            logger.warning("No original data path available, cannot save updated data")
+            logger.warning("No original data path available, cannot save amended data")
             return
 
         try:
-            updated_file = save_evaluation_data(
+            amended_file = save_evaluation_data(
                 evaluation_data, self.original_data_path, self.output_dir
             )
-            if updated_file:
-                logger.info("Updated data saved: %s", updated_file)
+            if amended_file:
+                logger.info("Amended data saved: %s", amended_file)
                 logger.info(
                     "To use amended data without new API calls, "
-                    "disable the API call using system config"
+                    "disable the API call using system config & "
+                    "replace the original evaluation data file with the amended file"
                 )
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Don't fail the evaluation if saving fails
-            logger.warning("Failed to save updated data: %s", e)
+            logger.warning("Failed to save amended data: %s", e)
 
     def close(self) -> None:
         """Clean up resources."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Amended evaluation data is now saved as new files in the output directory with timestamped names, preserving original files. Logs and messages reflect the “amended” terminology.

- Documentation
  - Updated README to clarify that persistence writes amended responses/tool calls to an output directory.

- Refactor
  - Renamed the save step and related user-facing messages from “updated” to “amended” to align with the new persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->