### PR TITLE
Setting the execution bit only if it's not set

### DIFF
--- a/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
+++ b/lsc_agent_eval/src/lsc_agent_eval/core/agent_goal_eval/script_runner.py
@@ -41,8 +41,9 @@ class ScriptRunner:
             # Setup environment
             env = self.get_environment()
 
-            # Make script executable
-            script_path.chmod(0o755)
+            # Make script executable if it is not executable
+            if not os.access(str(script_path.resolve()), os.X_OK):
+                script_path.chmod(0o755)
 
             # Run script
             logger.debug("Running script: %s", script_path)


### PR DESCRIPTION
If it is run in an OpenShift pod then it fails, because OpenShift starts the pod with a random user. If the user has already execute permission then it is not needed to set it. Not setting the permissions can prevent the error in an OpenShift pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Script execution setup is more conservative: scripts are only marked executable when needed. This reduces unnecessary permission changes, helps avoid permission-related warnings or conflicts in various environments, and improves reliability during runs.
- **Chores**
  - Minor adjustments to execution flow to better respect existing file permissions and minimize side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->