### PR TITLE
use absolute imports

### DIFF
--- a/src/lightspeed_evaluation/__init__.py
+++ b/src/lightspeed_evaluation/__init__.py
@@ -9,9 +9,9 @@ Main components:
 __version__ = "0.1.0"
 
 # Core components
-from .core.api import APIClient
-from .core.llm import LLMManager
-from .core.models import (
+from lightspeed_evaluation.core.api import APIClient
+from lightspeed_evaluation.core.llm import LLMManager
+from lightspeed_evaluation.core.models import (
     APIConfig,
     EvaluationData,
     EvaluationResult,
@@ -23,12 +23,12 @@ from .core.models import (
 )
 
 # Output handling
-from .core.output import GraphGenerator, OutputHandler
-from .core.script import ScriptExecutionManager
+from lightspeed_evaluation.core.output import GraphGenerator, OutputHandler
+from lightspeed_evaluation.core.script import ScriptExecutionManager
 
 # System config
-from .core.system import ConfigLoader, DataValidator, SystemConfig
-from .core.system.exceptions import (
+from lightspeed_evaluation.core.system import ConfigLoader, DataValidator, SystemConfig
+from lightspeed_evaluation.core.system.exceptions import (
     APIError,
     DataValidationError,
     EvaluationError,
@@ -36,7 +36,7 @@ from .core.system.exceptions import (
 )
 
 # Main pipeline
-from .pipeline.evaluation import EvaluationPipeline
+from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
 __all__ = [
     "EvaluationPipeline",

--- a/src/lightspeed_evaluation/core/__init__.py
+++ b/src/lightspeed_evaluation/core/__init__.py
@@ -1,8 +1,13 @@
 """Core functionality - Components for evaluation."""
 
-from .llm import LLMManager
-from .models import EvaluationData, EvaluationResult, LLMConfig, TurnData
-from .system import ConfigLoader, DataValidator, SystemConfig
+from lightspeed_evaluation.core.llm import LLMManager
+from lightspeed_evaluation.core.models import (
+    EvaluationData,
+    EvaluationResult,
+    LLMConfig,
+    TurnData,
+)
+from lightspeed_evaluation.core.system import ConfigLoader, DataValidator, SystemConfig
 
 __all__ = [
     # Configuration & data

--- a/src/lightspeed_evaluation/core/api/__init__.py
+++ b/src/lightspeed_evaluation/core/api/__init__.py
@@ -1,5 +1,5 @@
 """API client module for actual data generation."""
 
-from .client import APIClient
+from lightspeed_evaluation.core.api.client import APIClient
 
 __all__ = ["APIClient"]

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -7,14 +7,14 @@ from typing import Any, Optional
 
 import httpx
 
-from ..constants import (
+from lightspeed_evaluation.core.api.streaming_parser import parse_streaming_response
+from lightspeed_evaluation.core.constants import (
     DEFAULT_API_TIMEOUT,
     DEFAULT_ENDPOINT_TYPE,
     SUPPORTED_ENDPOINT_TYPES,
 )
-from ..models import APIRequest, APIResponse
-from ..system.exceptions import APIError
-from .streaming_parser import parse_streaming_response
+from lightspeed_evaluation.core.models import APIRequest, APIResponse
+from lightspeed_evaluation.core.system.exceptions import APIError
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/core/embedding/manager.py
+++ b/src/lightspeed_evaluation/core/embedding/manager.py
@@ -1,7 +1,7 @@
 """Embedding Manager - Generic embedding configuration, validation, and parameter provider."""
 
-from ..models import EmbeddingConfig, SystemConfig
-from ..system.env_validator import validate_provider_env
+from lightspeed_evaluation.core.models import EmbeddingConfig, SystemConfig
+from lightspeed_evaluation.core.system.env_validator import validate_provider_env
 
 
 class EmbeddingError(Exception):

--- a/src/lightspeed_evaluation/core/embedding/ragas.py
+++ b/src/lightspeed_evaluation/core/embedding/ragas.py
@@ -4,7 +4,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_openai import OpenAIEmbeddings
 from ragas.embeddings import LangchainEmbeddingsWrapper
 
-from ..embedding.manager import EmbeddingManager
+from lightspeed_evaluation.core.embedding.manager import EmbeddingManager
 
 
 class RagasEmbeddingManager:  # pylint: disable=too-few-public-methods

--- a/src/lightspeed_evaluation/core/llm/__init__.py
+++ b/src/lightspeed_evaluation/core/llm/__init__.py
@@ -1,11 +1,11 @@
 """LLM management for Evaluation Framework."""
 
-from ..models import LLMConfig
-from ..system.env_validator import validate_provider_env
-from ..system.exceptions import LLMError
-from .deepeval import DeepEvalLLMManager
-from .manager import LLMManager
-from .ragas import RagasLLMManager
+from lightspeed_evaluation.core.llm.deepeval import DeepEvalLLMManager
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.llm.ragas import RagasLLMManager
+from lightspeed_evaluation.core.models import LLMConfig
+from lightspeed_evaluation.core.system.env_validator import validate_provider_env
+from lightspeed_evaluation.core.system.exceptions import LLMError
 
 __all__ = [
     "LLMConfig",

--- a/src/lightspeed_evaluation/core/llm/manager.py
+++ b/src/lightspeed_evaluation/core/llm/manager.py
@@ -3,8 +3,8 @@
 import os
 from typing import Any
 
-from ..models import LLMConfig, SystemConfig
-from ..system.env_validator import validate_provider_env
+from lightspeed_evaluation.core.models import LLMConfig, SystemConfig
+from lightspeed_evaluation.core.system.env_validator import validate_provider_env
 
 
 class LLMManager:

--- a/src/lightspeed_evaluation/core/metrics/__init__.py
+++ b/src/lightspeed_evaluation/core/metrics/__init__.py
@@ -1,7 +1,7 @@
 """Metrics module for evaluation framework."""
 
-from .custom import CustomMetrics
-from .deepeval import DeepEvalMetrics
-from .ragas import RagasMetrics
+from lightspeed_evaluation.core.metrics.custom import CustomMetrics
+from lightspeed_evaluation.core.metrics.deepeval import DeepEvalMetrics
+from lightspeed_evaluation.core.metrics.ragas import RagasMetrics
 
 __all__ = ["RagasMetrics", "DeepEvalMetrics", "CustomMetrics"]

--- a/src/lightspeed_evaluation/core/metrics/custom.py
+++ b/src/lightspeed_evaluation/core/metrics/custom.py
@@ -6,9 +6,9 @@ from typing import Any, Optional
 import litellm
 from pydantic import BaseModel, Field
 
-from ..llm.manager import LLMManager
-from ..models import EvaluationScope, TurnData
-from .tool_eval import evaluate_tool_calls
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.metrics.tool_eval import evaluate_tool_calls
+from lightspeed_evaluation.core.models import EvaluationScope, TurnData
 
 
 class EvaluationPromptParams(BaseModel):

--- a/src/lightspeed_evaluation/core/metrics/deepeval.py
+++ b/src/lightspeed_evaluation/core/metrics/deepeval.py
@@ -10,9 +10,9 @@ from deepeval.metrics import (
 from deepeval.test_case import ConversationalTestCase
 from deepeval.test_case import Turn as DeepEvalTurn
 
-from ..llm.deepeval import DeepEvalLLMManager
-from ..llm.manager import LLMManager
-from ..models import EvaluationScope, TurnData
+from lightspeed_evaluation.core.llm.deepeval import DeepEvalLLMManager
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.models import EvaluationScope, TurnData
 
 
 class DeepEvalMetrics:  # pylint: disable=too-few-public-methods

--- a/src/lightspeed_evaluation/core/metrics/manager.py
+++ b/src/lightspeed_evaluation/core/metrics/manager.py
@@ -3,8 +3,8 @@
 from enum import Enum
 from typing import Any, Optional
 
-from ..models.data import EvaluationData, TurnData
-from ..models.system import SystemConfig
+from lightspeed_evaluation.core.models.data import EvaluationData, TurnData
+from lightspeed_evaluation.core.models.system import SystemConfig
 
 
 class MetricLevel(Enum):

--- a/src/lightspeed_evaluation/core/metrics/ragas.py
+++ b/src/lightspeed_evaluation/core/metrics/ragas.py
@@ -14,11 +14,11 @@ from ragas.metrics import (
     ResponseRelevancy,
 )
 
-from ..embedding.manager import EmbeddingManager
-from ..embedding.ragas import RagasEmbeddingManager
-from ..llm.manager import LLMManager
-from ..llm.ragas import RagasLLMManager
-from ..models import EvaluationScope, TurnData
+from lightspeed_evaluation.core.embedding.manager import EmbeddingManager
+from lightspeed_evaluation.core.embedding.ragas import RagasEmbeddingManager
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.llm.ragas import RagasLLMManager
+from lightspeed_evaluation.core.models import EvaluationScope, TurnData
 
 
 # Decide if Dataset will be used or not ?

--- a/src/lightspeed_evaluation/core/metrics/script_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/script_eval.py
@@ -4,8 +4,11 @@ import logging
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from ..models import EvaluationScope
-from ..script import ScriptExecutionError, ScriptExecutionManager
+from lightspeed_evaluation.core.models import EvaluationScope
+from lightspeed_evaluation.core.script import (
+    ScriptExecutionError,
+    ScriptExecutionManager,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/core/models/__init__.py
+++ b/src/lightspeed_evaluation/core/models/__init__.py
@@ -1,14 +1,18 @@
 """Data models for the evaluation framework."""
 
-from .api import APIRequest, APIResponse, AttachmentData
-from .data import (
+from lightspeed_evaluation.core.models.api import (
+    APIRequest,
+    APIResponse,
+    AttachmentData,
+)
+from lightspeed_evaluation.core.models.data import (
     EvaluationData,
     EvaluationRequest,
     EvaluationResult,
     EvaluationScope,
     TurnData,
 )
-from .system import (
+from lightspeed_evaluation.core.models.system import (
     APIConfig,
     EmbeddingConfig,
     LLMConfig,

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from ..constants import SUPPORTED_RESULT_STATUSES
+from lightspeed_evaluation.core.constants import SUPPORTED_RESULT_STATUSES
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/core/models/system.py
+++ b/src/lightspeed_evaluation/core/models/system.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from ..constants import (
+from lightspeed_evaluation.core.constants import (
     DEFAULT_API_BASE,
     DEFAULT_API_TIMEOUT,
     DEFAULT_BASE_FILENAME,

--- a/src/lightspeed_evaluation/core/output/__init__.py
+++ b/src/lightspeed_evaluation/core/output/__init__.py
@@ -1,7 +1,7 @@
 """Output handling - Reports and visualization."""
 
-from .data_persistence import save_evaluation_data
-from .generator import OutputHandler
-from .visualization import GraphGenerator
+from lightspeed_evaluation.core.output.data_persistence import save_evaluation_data
+from lightspeed_evaluation.core.output.generator import OutputHandler
+from lightspeed_evaluation.core.output.visualization import GraphGenerator
 
 __all__ = ["OutputHandler", "GraphGenerator", "save_evaluation_data"]

--- a/src/lightspeed_evaluation/core/output/data_persistence.py
+++ b/src/lightspeed_evaluation/core/output/data_persistence.py
@@ -6,8 +6,8 @@ from typing import Optional
 
 import yaml
 
-from ..constants import DEFAULT_OUTPUT_DIR
-from ..models import EvaluationData
+from lightspeed_evaluation.core.constants import DEFAULT_OUTPUT_DIR
+from lightspeed_evaluation.core.models import EvaluationData
 
 
 # Use caching

--- a/src/lightspeed_evaluation/core/output/generator.py
+++ b/src/lightspeed_evaluation/core/output/generator.py
@@ -6,15 +6,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
-from ..constants import (
+from lightspeed_evaluation.core.constants import (
     DEFAULT_OUTPUT_DIR,
     SUPPORTED_CSV_COLUMNS,
     SUPPORTED_GRAPH_TYPES,
     SUPPORTED_OUTPUT_TYPES,
 )
-from ..models import EvaluationResult
-from .statistics import calculate_basic_stats, calculate_detailed_stats
-from .visualization import GraphGenerator
+from lightspeed_evaluation.core.models import EvaluationResult
+from lightspeed_evaluation.core.output.statistics import (
+    calculate_basic_stats,
+    calculate_detailed_stats,
+)
+from lightspeed_evaluation.core.output.visualization import GraphGenerator
 
 
 class OutputHandler:

--- a/src/lightspeed_evaluation/core/output/statistics.py
+++ b/src/lightspeed_evaluation/core/output/statistics.py
@@ -3,7 +3,7 @@
 import statistics
 from typing import Any
 
-from ..models import EvaluationResult
+from lightspeed_evaluation.core.models import EvaluationResult
 
 
 def calculate_basic_stats(results: list[EvaluationResult]) -> dict[str, Any]:

--- a/src/lightspeed_evaluation/core/output/visualization.py
+++ b/src/lightspeed_evaluation/core/output/visualization.py
@@ -10,9 +10,15 @@ import pandas as pd
 import seaborn as sns
 from matplotlib.colors import BASE_COLORS
 
-from ..constants import DEFAULT_OUTPUT_DIR, SUPPORTED_GRAPH_TYPES
-from ..models import EvaluationResult
-from .statistics import calculate_basic_stats, calculate_detailed_stats
+from lightspeed_evaluation.core.constants import (
+    DEFAULT_OUTPUT_DIR,
+    SUPPORTED_GRAPH_TYPES,
+)
+from lightspeed_evaluation.core.models import EvaluationResult
+from lightspeed_evaluation.core.output.statistics import (
+    calculate_basic_stats,
+    calculate_detailed_stats,
+)
 
 CHART_COLORS = {
     "PASS": "#28a745",  # Green

--- a/src/lightspeed_evaluation/core/script/__init__.py
+++ b/src/lightspeed_evaluation/core/script/__init__.py
@@ -1,7 +1,7 @@
 """Script execution module for evaluation framework."""
 
-from ..system.exceptions import ScriptExecutionError
-from .manager import ScriptExecutionManager
+from lightspeed_evaluation.core.script.manager import ScriptExecutionManager
+from lightspeed_evaluation.core.system.exceptions import ScriptExecutionError
 
 __all__ = [
     "ScriptExecutionManager",

--- a/src/lightspeed_evaluation/core/script/manager.py
+++ b/src/lightspeed_evaluation/core/script/manager.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Union
 
-from ..system.exceptions import ScriptExecutionError
+from lightspeed_evaluation.core.system.exceptions import ScriptExecutionError
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/core/system/__init__.py
+++ b/src/lightspeed_evaluation/core/system/__init__.py
@@ -1,7 +1,7 @@
 """System configuration, validation, and utilities."""
 
 # Constants & Config
-from ..constants import (
+from lightspeed_evaluation.core.constants import (
     DEFAULT_API_BASE,
     DEFAULT_API_TIMEOUT,
     DEFAULT_BASE_FILENAME,
@@ -21,8 +21,8 @@ from ..constants import (
     SUPPORTED_ENDPOINT_TYPES,
     SUPPORTED_RESULT_STATUSES,
 )
-from ..models import SystemConfig
-from .exceptions import (
+from lightspeed_evaluation.core.models import SystemConfig
+from lightspeed_evaluation.core.system.exceptions import (
     APIError,
     ConfigurationError,
     DataValidationError,
@@ -30,9 +30,12 @@ from .exceptions import (
     LLMError,
     MetricError,
 )
-from .loader import ConfigLoader
-from .setup import setup_environment_variables, setup_logging
-from .validator import DataValidator
+from lightspeed_evaluation.core.system.loader import ConfigLoader
+from lightspeed_evaluation.core.system.setup import (
+    setup_environment_variables,
+    setup_logging,
+)
+from lightspeed_evaluation.core.system.validator import DataValidator
 
 __all__ = [
     # Configuration

--- a/src/lightspeed_evaluation/core/system/env_validator.py
+++ b/src/lightspeed_evaluation/core/system/env_validator.py
@@ -2,7 +2,7 @@
 
 import os
 
-from .exceptions import LLMError
+from lightspeed_evaluation.core.system.exceptions import LLMError
 
 
 def validate_hosted_vllm_env() -> None:

--- a/src/lightspeed_evaluation/core/system/loader.py
+++ b/src/lightspeed_evaluation/core/system/loader.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import yaml
 
-from ..models import (
+from lightspeed_evaluation.core.models import (
     APIConfig,
     EmbeddingConfig,
     EvaluationData,
@@ -15,7 +15,10 @@ from ..models import (
     SystemConfig,
     VisualizationConfig,
 )
-from .setup import setup_environment_variables, setup_logging
+from lightspeed_evaluation.core.system.setup import (
+    setup_environment_variables,
+    setup_logging,
+)
 
 # Global metric mapping sets (populated dynamically from system config)
 TURN_LEVEL_METRICS: set[str] = set()

--- a/src/lightspeed_evaluation/core/system/setup.py
+++ b/src/lightspeed_evaluation/core/system/setup.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Any
 
-from ..models import LoggingConfig
+from lightspeed_evaluation.core.models import LoggingConfig
 
 
 def setup_environment_variables(config_data: dict[str, Any]) -> None:

--- a/src/lightspeed_evaluation/core/system/validator.py
+++ b/src/lightspeed_evaluation/core/system/validator.py
@@ -7,9 +7,12 @@ from typing import Optional, Union
 import yaml
 from pydantic import ValidationError
 
-from ..models import EvaluationData
-from .exceptions import DataValidationError
-from .loader import CONVERSATION_LEVEL_METRICS, TURN_LEVEL_METRICS
+from lightspeed_evaluation.core.models import EvaluationData
+from lightspeed_evaluation.core.system.exceptions import DataValidationError
+from lightspeed_evaluation.core.system.loader import (
+    CONVERSATION_LEVEL_METRICS,
+    TURN_LEVEL_METRICS,
+)
 
 # Metric requirements mapping
 METRIC_REQUIREMENTS = {

--- a/src/lightspeed_evaluation/pipeline/__init__.py
+++ b/src/lightspeed_evaluation/pipeline/__init__.py
@@ -1,6 +1,6 @@
 """Pipeline for evaluation framework."""
 
-from .evaluation import EvaluationPipeline
+from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
 __all__ = [
     "EvaluationPipeline",

--- a/src/lightspeed_evaluation/pipeline/evaluation/__init__.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/__init__.py
@@ -1,10 +1,10 @@
 """Pipeline for the evaluation flow."""
 
-from .amender import APIDataAmender
-from .errors import EvaluationErrorHandler
-from .evaluator import MetricsEvaluator
-from .pipeline import EvaluationPipeline
-from .processor import ConversationProcessor
+from lightspeed_evaluation.pipeline.evaluation.amender import APIDataAmender
+from lightspeed_evaluation.pipeline.evaluation.errors import EvaluationErrorHandler
+from lightspeed_evaluation.pipeline.evaluation.evaluator import MetricsEvaluator
+from lightspeed_evaluation.pipeline.evaluation.pipeline import EvaluationPipeline
+from lightspeed_evaluation.pipeline.evaluation.processor import ConversationProcessor
 
 __all__ = [
     "EvaluationPipeline",

--- a/src/lightspeed_evaluation/pipeline/evaluation/amender.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/amender.py
@@ -3,9 +3,9 @@
 import logging
 from typing import Any, Optional
 
-from ...core.api import APIClient
-from ...core.models import EvaluationData
-from ...core.system.exceptions import APIError
+from lightspeed_evaluation.core.api import APIClient
+from lightspeed_evaluation.core.models import EvaluationData
+from lightspeed_evaluation.core.system.exceptions import APIError
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/errors.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/errors.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ...core.models import EvaluationData, EvaluationResult
+from lightspeed_evaluation.core.models import EvaluationData, EvaluationResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
@@ -4,16 +4,20 @@ import logging
 import time
 from typing import Optional
 
-from ...core.embedding.manager import EmbeddingManager
-from ...core.llm.manager import LLMManager
-from ...core.metrics.custom import CustomMetrics
-from ...core.metrics.deepeval import DeepEvalMetrics
-from ...core.metrics.manager import MetricLevel, MetricManager
-from ...core.metrics.ragas import RagasMetrics
-from ...core.metrics.script_eval import ScriptEvalMetrics
-from ...core.models import EvaluationRequest, EvaluationResult, EvaluationScope
-from ...core.script import ScriptExecutionManager
-from ...core.system import ConfigLoader
+from lightspeed_evaluation.core.embedding.manager import EmbeddingManager
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.metrics.custom import CustomMetrics
+from lightspeed_evaluation.core.metrics.deepeval import DeepEvalMetrics
+from lightspeed_evaluation.core.metrics.manager import MetricLevel, MetricManager
+from lightspeed_evaluation.core.metrics.ragas import RagasMetrics
+from lightspeed_evaluation.core.metrics.script_eval import ScriptEvalMetrics
+from lightspeed_evaluation.core.models import (
+    EvaluationRequest,
+    EvaluationResult,
+    EvaluationScope,
+)
+from lightspeed_evaluation.core.script import ScriptExecutionManager
+from lightspeed_evaluation.core.system import ConfigLoader
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
@@ -3,16 +3,19 @@
 import logging
 from typing import Optional
 
-from ...core.api import APIClient
-from ...core.metrics.manager import MetricManager
-from ...core.models import EvaluationData, EvaluationResult
-from ...core.output.data_persistence import save_evaluation_data
-from ...core.script import ScriptExecutionManager
-from ...core.system import ConfigLoader, DataValidator
-from .amender import APIDataAmender
-from .errors import EvaluationErrorHandler
-from .evaluator import MetricsEvaluator
-from .processor import ConversationProcessor, ProcessorComponents
+from lightspeed_evaluation.core.api import APIClient
+from lightspeed_evaluation.core.metrics.manager import MetricManager
+from lightspeed_evaluation.core.models import EvaluationData, EvaluationResult
+from lightspeed_evaluation.core.output.data_persistence import save_evaluation_data
+from lightspeed_evaluation.core.script import ScriptExecutionManager
+from lightspeed_evaluation.core.system import ConfigLoader, DataValidator
+from lightspeed_evaluation.pipeline.evaluation.amender import APIDataAmender
+from lightspeed_evaluation.pipeline.evaluation.errors import EvaluationErrorHandler
+from lightspeed_evaluation.pipeline.evaluation.evaluator import MetricsEvaluator
+from lightspeed_evaluation.pipeline.evaluation.processor import (
+    ConversationProcessor,
+    ProcessorComponents,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/processor.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/processor.py
@@ -4,13 +4,21 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from ...core.metrics.manager import MetricLevel, MetricManager
-from ...core.models import EvaluationData, EvaluationRequest, EvaluationResult, TurnData
-from ...core.script import ScriptExecutionError, ScriptExecutionManager
-from ...core.system import ConfigLoader
-from .amender import APIDataAmender
-from .errors import EvaluationErrorHandler
-from .evaluator import MetricsEvaluator
+from lightspeed_evaluation.core.metrics.manager import MetricLevel, MetricManager
+from lightspeed_evaluation.core.models import (
+    EvaluationData,
+    EvaluationRequest,
+    EvaluationResult,
+    TurnData,
+)
+from lightspeed_evaluation.core.script import (
+    ScriptExecutionError,
+    ScriptExecutionManager,
+)
+from lightspeed_evaluation.core.system import ConfigLoader
+from lightspeed_evaluation.pipeline.evaluation.amender import APIDataAmender
+from lightspeed_evaluation.pipeline.evaluation.errors import EvaluationErrorHandler
+from lightspeed_evaluation.pipeline.evaluation.evaluator import MetricsEvaluator
 
 logger = logging.getLogger(__name__)
 

--- a/src/lightspeed_evaluation/runner/__init__.py
+++ b/src/lightspeed_evaluation/runner/__init__.py
@@ -1,5 +1,5 @@
 """Runner/CLI module for LightSpeed Evaluation Framework."""
 
-from .evaluation import main, run_evaluation
+from lightspeed_evaluation.runner.evaluation import main, run_evaluation
 
 __all__ = ["main", "run_evaluation"]

--- a/src/lightspeed_evaluation/runner/evaluation.py
+++ b/src/lightspeed_evaluation/runner/evaluation.py
@@ -6,7 +6,7 @@ import traceback
 from typing import Optional
 
 # Import only lightweight modules at top level
-from ..core.system import ConfigLoader
+from lightspeed_evaluation.core.system import ConfigLoader
 
 
 def run_evaluation(  # pylint: disable=too-many-locals
@@ -35,10 +35,10 @@ def run_evaluation(  # pylint: disable=too-many-locals
 
         # Step 1: Import heavy modules once environment & logging is set
         print("\n📋 Loading Heavy Modules...")
-        from ..core.output import OutputHandler
-        from ..core.output.statistics import calculate_basic_stats
-        from ..core.system import DataValidator
-        from ..pipeline.evaluation import EvaluationPipeline
+        from lightspeed_evaluation.core.output import OutputHandler
+        from lightspeed_evaluation.core.output.statistics import calculate_basic_stats
+        from lightspeed_evaluation.core.system import DataValidator
+        from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
         # pylint: enable=import-outside-toplevel
 


### PR DESCRIPTION
Use absolute imports instead of relative for better clarity of the code structure & avoid any potential conflict with python packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded public API: more configuration objects, managers, pipeline helpers, and error types are now directly importable.
  - Simplified imports: users can import key components from stable, top-level package paths.

- Refactor
  - Standardized internal imports to absolute package paths for consistency and reliability.
  - Unified module namespaces without changing behavior or public signatures.

- Style
  - Harmonized exports across submodules for a clearer, more predictable developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->