### PR TITLE
bump lightspeed evaluation version

### DIFF
--- a/lsc_agent_eval/pyproject.toml
+++ b/lsc_agent_eval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lsc-agent-eval"
-version = "0.1.0"
+version = "0.2.0"
 description = "Agent evaluation package for lightspeed-core systems"
 authors = []
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lightspeed-evaluation"
-version = "0.1.0"
+version = "0.2.0"
 description = "LSC Evaluation Framework - Comprehensive evaluation tooling for GenAI applications"
 authors = []
 requires-python = ">=3.11,<3.13"

--- a/src/lightspeed_evaluation/__init__.py
+++ b/src/lightspeed_evaluation/__init__.py
@@ -6,7 +6,7 @@ Main components:
 - Core modules organized by functionality (config, llm, metrics, output)
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # Core components
 from lightspeed_evaluation.core.api import APIClient

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "lightspeed-evaluation"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
v0.1.0 is tagged now: https://github.com/lightspeed-core/lightspeed-evaluation/releases/tag/v0.1.0
Updating source code version to 0.2.0
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated project version to 0.2.0 across the package.
  * No changes to features, behavior, or public APIs.
  * Dependencies and configuration remain unchanged.
  * Metadata-only release to align versioning.
  * No migration steps required; safe to upgrade without code modifications.
  * Tooling, builds, and runtime compatibility unaffected.
  * Documentation and user workflows remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->