### PR TITLE
add agent-eval deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,10 +410,6 @@ make check-types
 uv run pytest tests --cov=src
 ```
 
-## Agent Evaluation
-For a detailed walkthrough of the new agent-evaluation framework, refer
-[lsc_agent_eval/README.md](lsc_agent_eval/README.md)
-
 ## Generate answers (optional - for creating test data)
 For generating answers (optional) refer [README-generate-answers](README-generate-answers.md)
 

--- a/lsc_agent_eval/README.md
+++ b/lsc_agent_eval/README.md
@@ -2,6 +2,8 @@
 
 A framework for evaluating AI agent performance.
 
+**This evaluation tool is currently not maintained and is scheduled for deprecation once all features are migrated and teams have transitioned to the new [evaluation tool](../README.md).**
+
 ## Features
 
 - **Agent Goal Evaluation**: Evaluate whether an agent successfully achieves specified goals


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed Agent Evaluation documentation section from the main README.
* Added a deprecation notice to the evaluation tool documentation indicating the tool is not maintained and will be deprecated following migration to a new evaluation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->