### PR TITLE
[LEADS-195] feat: Add majority voting & avg to panel aggregation

### DIFF
--- a/docs/EVALUATION_GUIDE.md
+++ b/docs/EVALUATION_GUIDE.md
@@ -742,21 +742,17 @@ judge_panel:
   judges:
     - judge-4o-mini
     - judge-4.1-mini
-  aggregation_strategy: max  # Currently only 'max' is implemented
+  aggregation_strategy: max  # or: average, majority_vote
   # enabled_metrics: ["ragas:faithfulness"]  # Optional: limit to specific metrics
   # If enabled_metrics not set, ALL LLM metrics use the full panel
 ```
+
+**Aggregation:** `max` (highest score), `average` (mean vs threshold), or `majority_vote` (more than half of judges must individually meet the threshold — ties fail). See [Configuration Guide](configuration.md#judge-panel).
 
 **Benefits:**
 - Reduces bias from a single model
 - More robust evaluation scores
 - Per-judge token tracking for cost analysis
-
-**Current Limitations:**
-- Only `max` aggregation is implemented (`average`, `majority_vote` coming soon)
-- Per-metric thresholds for panel not yet supported
-
-See [Configuration Guide](configuration.md#llm-pool).
 
 ### Evaluation Data (`evaluation_data.yaml`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,15 @@ Use multiple LLMs as judges to reduce bias and improve evaluation accuracy.
 |---------|-------------|
 | `judge_panel.judges` | List of model IDs from `llm_pool.models` (required) |
 | `judge_panel.enabled_metrics` | Metrics using full panel (if unset, all LLM metrics use panel) |
-| `judge_panel.aggregation_strategy` | `max` (default, currently only implemented), `average`, `majority_vote` coming soon |
+| `judge_panel.aggregation_strategy` | How to combine judge scores: `max`, `average`, or `majority_vote` (see below) |
+
+**Aggregation strategies** (multiple judges only; errored judges are excluded):
+
+| Strategy | Score | Pass / fail |
+|----------|-------|-------------|
+| `max` (default) | Highest score | Score vs metric threshold |
+| `average` | Mean of scores | Mean vs metric threshold |
+| `majority_vote` | Mean of scores | **Strict majority** of judges individually meet the metric threshold — more than half must pass (Ties fail). |
 
 ```yaml
 judge_panel:

--- a/src/lightspeed_evaluation/core/constants.py
+++ b/src/lightspeed_evaluation/core/constants.py
@@ -2,6 +2,8 @@
 
 from ragas.metrics.collections import DistanceMeasure
 
+DEFAULT_METRIC_THRESHOLD = 0.5
+
 # NLP Metrics Constants - BLEU
 DEFAULT_BLEU_MAX_NGRAM = 4  # Standard BLEU uses up to 4-grams
 MIN_BLEU_NGRAM = 1

--- a/src/lightspeed_evaluation/core/models/system.py
+++ b/src/lightspeed_evaluation/core/models/system.py
@@ -636,9 +636,8 @@ class JudgePanelConfig(BaseModel):
     aggregation_strategy: str = Field(
         default="max",
         description=(
-            "Strategy for aggregating scores from multiple judges. "
-            "Options: 'max', 'average', 'majority_vote'. "
-            "Note: Currently only 'max' is implemented; others coming soon."
+            "Strategy for aggregating scores: 'max', 'average', or "
+            "'majority_vote' (average reported; PASS if a strict majority vote)."
         ),
     )
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
@@ -30,7 +30,10 @@ from lightspeed_evaluation.core.system.validator import (
     METRIC_REQUIREMENTS,
     check_metric_required_data,
 )
-from lightspeed_evaluation.core.constants import NON_LLM_FRAMEWORKS
+from lightspeed_evaluation.core.constants import (
+    DEFAULT_METRIC_THRESHOLD,
+    NON_LLM_FRAMEWORKS,
+)
 from lightspeed_evaluation.pipeline.evaluation.judges import JudgeOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -710,7 +713,7 @@ class MetricsEvaluator:
     def _determine_status(self, score: float, threshold: Optional[float]) -> str:
         """Determine evaluation status based on score and threshold."""
         if threshold is None:
-            threshold = 0.5  # This will also handle binary metrics
+            threshold = DEFAULT_METRIC_THRESHOLD  # This will also handle binary metrics
         return "PASS" if score >= float(threshold) else "FAIL"
 
     def _extract_metadata_for_csv(self, request: EvaluationRequest) -> Optional[str]:

--- a/src/lightspeed_evaluation/pipeline/evaluation/judges.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/judges.py
@@ -1,8 +1,10 @@
 """Judge orchestration module - handles multi-judge evaluation and aggregation."""
 
 import logging
+from statistics import mean
 from typing import Any, Callable, Optional
 
+from lightspeed_evaluation.core.constants import DEFAULT_METRIC_THRESHOLD
 from lightspeed_evaluation.core.llm.manager import LLMManager
 from lightspeed_evaluation.core.llm.token_tracker import TokenTracker
 from lightspeed_evaluation.core.models import (
@@ -53,9 +55,6 @@ class JudgeOrchestrator:
         # Cache for judge-specific handlers (keyed by judge_id -> framework -> handler)
         self._judge_handlers: dict[str, dict[str, Any]] = {}
 
-        # Flag to avoid warning spam for unimplemented aggregation strategies
-        self._warned_aggregation_strategy = False
-
     def evaluate_with_judges(
         self,
         request: EvaluationRequest,
@@ -63,20 +62,19 @@ class JudgeOrchestrator:
         token_tracker: TokenTracker,
         threshold: Optional[float],
     ) -> MetricResult:
-        """Execute metric evaluation using appropriate judges.
+        """Evaluate a metric with the appropriate judges and aggregate results.
 
-        For metrics in enabled_metrics (or when enabled_metrics is None),
-        uses all panel judges. Otherwise uses only primary judge.
-        Always returns a list of JudgeScore entries (even for single judge).
+        Uses all panel judges for enabled metrics, or the primary judge only.
 
         Args:
-            request: Evaluation request (contains metric_identifier and conv_data)
-            evaluation_scope: Scope with turn/conversation context
-            token_tracker: Token usage tracker
-            threshold: Score threshold for pass/fail
+            request: Contains metric identifier and conversation data.
+            evaluation_scope: Turn or conversation context for the evaluation.
+            token_tracker: Tracks token usage per judge call.
+            threshold: Metric pass threshold from metadata. Defaults to 0.5
+                when not specified.
 
         Returns:
-            MetricResult with aggregated score and individual judge scores
+            MetricResult with aggregated score and individual judge scores.
         """
         # Extract framework and metric_name from identifier
         framework, metric_name = request.metric_identifier.split(":", 1)
@@ -102,10 +100,14 @@ class JudgeOrchestrator:
             token_tracker,
         )
 
-        # Aggregate scores
-        aggregated_score, aggregated_reason = self.aggregate_scores(judge_scores)
+        # Aggregate scores (majority_vote sets PASS/FAIL without re-applying threshold to mean)
+        aggregated_score, aggregated_reason, status_override = self.aggregate_scores(
+            judge_scores, threshold
+        )
 
-        if aggregated_score is not None:
+        if status_override is not None:
+            status = status_override
+        elif aggregated_score is not None:
             status = self._status_determiner(aggregated_score, threshold)
         else:
             status = "ERROR"
@@ -131,8 +133,16 @@ class JudgeOrchestrator:
     ) -> tuple[list[JudgeScore], int, int]:
         """Evaluate metric with all judges and collect results.
 
+        Args:
+            judge_managers: LLM managers for each judge to evaluate with.
+            framework: Metric framework name (e.g. ragas, deepeval).
+            metric_name: Name of the metric within the framework.
+            request: Contains conversation data for evaluation.
+            evaluation_scope: Turn or conversation context.
+            token_tracker: Tracks token usage per judge call.
+
         Returns:
-            Tuple of (judge_scores, total_input_tokens, total_output_tokens)
+            Tuple of (judge_scores, total_input_tokens, total_output_tokens).
         """
         judge_scores: list[JudgeScore] = []
         total_input_tokens = 0
@@ -164,8 +174,19 @@ class JudgeOrchestrator:
     ) -> tuple[JudgeScore, int, int]:
         """Evaluate metric with a single judge.
 
+        On evaluation error, returns a JudgeScore with score=None instead
+        of propagating the exception.
+
+        Args:
+            judge_manager: LLM manager for this judge.
+            framework: Metric framework name (e.g. ragas, deepeval).
+            metric_name: Name of the metric within the framework.
+            request: Contains conversation data for evaluation.
+            evaluation_scope: Turn or conversation context.
+            token_tracker: Tracks token usage for this call.
+
         Returns:
-            Tuple of (JudgeScore, input_tokens, output_tokens)
+            Tuple of (JudgeScore, input_tokens, output_tokens).
         """
         # Use judge_id from manager (pool key) - ensures uniqueness even when
         # multiple pool entries use the same underlying model
@@ -220,8 +241,15 @@ class JudgeOrchestrator:
     def _get_handler_for_judge(self, framework: str, judge_manager: LLMManager) -> Any:
         """Get or create a metric handler for a specific judge.
 
-        For primary manager, reuses existing handlers from primary_handlers.
-        For other judges, handlers are cached by judge_id (pool key) to avoid recreation.
+        Reuses existing handlers for the primary manager. For other judges,
+        creates and caches handlers by judge_id to avoid recreation.
+
+        Args:
+            framework: Metric framework name (e.g. ragas, deepeval).
+            judge_manager: LLM manager for the judge.
+
+        Returns:
+            The metric handler instance for the given framework and judge.
         """
         # Reuse existing handler if this is the primary manager
         if judge_manager is self.llm_manager:
@@ -244,50 +272,104 @@ class JudgeOrchestrator:
         return handler
 
     def aggregate_scores(
-        self, judge_scores: list[JudgeScore]
-    ) -> tuple[Optional[float], str]:
-        """Aggregate scores from multiple judges.
+        self,
+        judge_scores: list[JudgeScore],
+        threshold: Optional[float] = None,
+    ) -> tuple[Optional[float], str, Optional[str]]:
+        """Aggregate scores from multiple judges based on the panel strategy.
 
-        Currently implements 'max' strategy only. Other strategies (average,
-        majority_vote) are planned for future implementation.
-        For single judge, returns the judge's score and reason directly (even if None).
+        Judges that errored (score is None) are excluded from aggregation.
+        With a single judge, its score and reason are returned directly.
+
+        Strategies for multiple judges:
+            - max: uses the highest valid score.
+            - average: uses the mean of valid scores.
+            - majority_vote: reports the mean as the score but determines
+              pass/fail by strict majority of judges meeting the threshold.
 
         Args:
-            judge_scores: List of JudgeScore from all judges
+            judge_scores: List of score entries, one per judge.
+            threshold: Metric pass threshold. Defaults to 0.5 when not set.
 
         Returns:
-            Tuple of (aggregated_score, aggregated_reason)
+            Tuple of (aggregated_score, reason, status_override).
+            status_override is only set for majority_vote (PASS/FAIL);
+            None for other strategies.
         """
-        # Warn once if non-max strategy is configured (not yet implemented)
         panel = (
             self.llm_manager.system_config.judge_panel
             if self.llm_manager.system_config
             else None
         )
-        if (
-            panel
-            and panel.aggregation_strategy != "max"
-            and not self._warned_aggregation_strategy
-        ):
-            logger.warning(
-                "Aggregation strategy '%s' is not yet implemented. "
-                "Using 'max' instead. Other strategies coming soon.",
-                panel.aggregation_strategy,
-            )
-            self._warned_aggregation_strategy = True
+        strategy = panel.aggregation_strategy if panel else "max"
 
         # Single judge: return its score and reason directly (even if None)
         if len(judge_scores) == 1:
-            return judge_scores[0].score, judge_scores[0].reason
+            return judge_scores[0].score, judge_scores[0].reason, None
 
-        # Multiple judges: filter valid scores and aggregate
-        # Extract scores directly, filtering out None values
+        # Multiple judges: collect valid scores
         scores: list[float] = [js.score for js in judge_scores if js.score is not None]
 
         if not scores:
-            # All judges failed
-            return None, "All judges failed to produce a score"
+            return None, "All judges failed to produce a score", None
 
-        # Multiple judges: max score
+        n_valid = len(scores)
+
+        if strategy == "average":
+            avg_score = mean(scores)
+            return (
+                avg_score,
+                f"Average of {n_valid} judges: {avg_score:.3f}",
+                None,
+            )
+
+        if strategy == "majority_vote":
+            return self._aggregate_majority_vote(scores, threshold)
+
+        # max (default)
         max_score = max(scores)
-        return max_score, f"Max of {len(scores)} judges: {max_score:.3f}"
+        return (
+            max_score,
+            f"Max of {n_valid} judges: {max_score:.3f}",
+            None,
+        )
+
+    def _aggregate_majority_vote(
+        self,
+        scores: list[float],
+        threshold: Optional[float],
+    ) -> tuple[float, str, Optional[str]]:
+        """Aggregate using majority vote strategy.
+
+        Reports the mean of valid scores as the score. Pass/fail is decided by
+        whether a strict majority of judges individually meet the threshold
+        (passes > n/2). Ties fail (e.g. 1/2 is FAIL, 2/3 is PASS).
+
+        A status_override is returned so the caller does not re-compare the
+        mean against the metric threshold.
+
+        Args:
+            scores: Valid (non-None) judge scores.
+            threshold: Metric pass threshold. Defaults to 0.5 when not set.
+
+        Returns:
+            Tuple of (mean_score, reason, status_override).
+        """
+        n_valid = len(scores)
+        avg_score = mean(scores)
+        effective_threshold = (
+            float(threshold) if threshold is not None else DEFAULT_METRIC_THRESHOLD
+        )
+        passes = sum(1 for s in scores if s >= effective_threshold)
+        majority_pass = passes > n_valid / 2
+        status_override = "PASS" if majority_pass else "FAIL"
+        thr_label = (
+            f"{effective_threshold:.3f}"
+            if threshold is not None
+            else f"{effective_threshold:.3f} (default)"
+        )
+        reason = (
+            f"Majority vote ({passes}/{n_valid} pass threshold {thr_label}): "
+            f"mean score {avg_score:.3f}"
+        )
+        return avg_score, reason, status_override

--- a/tests/unit/core/models/test_system.py
+++ b/tests/unit/core/models/test_system.py
@@ -320,7 +320,6 @@ class TestJudgePanelConfig:
         assert panel.enabled_metrics is not None
         assert len(panel.enabled_metrics) == 2
 
-        # All aggregation strategies accepted (runtime warning for non-max)
         for strategy in ["max", "average", "majority_vote"]:
             panel = JudgePanelConfig(
                 judges=["gpt-4o-mini"], aggregation_strategy=strategy

--- a/tests/unit/pipeline/evaluation/test_judges.py
+++ b/tests/unit/pipeline/evaluation/test_judges.py
@@ -2,7 +2,6 @@
 
 """Unit tests for JudgeOrchestrator - multi-judge evaluation and aggregation."""
 
-import logging
 from typing import Any
 
 import pytest
@@ -10,6 +9,22 @@ from pytest_mock import MockerFixture
 
 from lightspeed_evaluation.core.models import JudgeScore
 from lightspeed_evaluation.pipeline.evaluation.judges import JudgeOrchestrator
+
+
+def _make_orchestrator(
+    mocker: MockerFixture,
+    strategy: str,
+    status_determiner: Any = None,
+) -> JudgeOrchestrator:
+    """Create a JudgeOrchestrator with a given aggregation strategy."""
+    mock_manager = mocker.MagicMock()
+    mock_manager.system_config.judge_panel.aggregation_strategy = strategy
+    return JudgeOrchestrator(
+        llm_manager=mock_manager,
+        primary_handlers={},
+        handler_factory=mocker.MagicMock(),
+        status_determiner=status_determiner or (lambda s, _: "PASS"),
+    )
 
 
 class TestAggregateScores:
@@ -20,22 +35,6 @@ class TestAggregateScores:
         """Create a mock LLM manager without system_config (no panel)."""
         manager = mocker.MagicMock()
         manager.system_config = None
-        manager.judge_id = "primary"
-        return manager
-
-    @pytest.fixture
-    def mock_llm_manager_with_panel(self, mocker: MockerFixture) -> Any:
-        """Create a mock LLM manager with panel config set to max strategy."""
-        manager = mocker.MagicMock()
-        manager.system_config.judge_panel.aggregation_strategy = "max"
-        manager.judge_id = "primary"
-        return manager
-
-    @pytest.fixture
-    def mock_llm_manager_with_average_strategy(self, mocker: MockerFixture) -> Any:
-        """Create a mock LLM manager with panel config set to average strategy."""
-        manager = mocker.MagicMock()
-        manager.system_config.judge_panel.aggregation_strategy = "average"
         manager.judge_id = "primary"
         return manager
 
@@ -59,10 +58,11 @@ class TestAggregateScores:
             JudgeScore(judge_id="judge-1", score=0.85, reason="Good answer")
         ]
 
-        score, reason = orchestrator.aggregate_scores(judge_scores)
+        score, reason, override = orchestrator.aggregate_scores(judge_scores)
 
         assert score == 0.85
         assert reason == "Good answer"
+        assert override is None
 
     def test_single_judge_with_none_score(
         self, orchestrator: JudgeOrchestrator
@@ -74,10 +74,11 @@ class TestAggregateScores:
             )
         ]
 
-        score, reason = orchestrator.aggregate_scores(judge_scores)
+        score, reason, override = orchestrator.aggregate_scores(judge_scores)
 
         assert score is None
         assert reason == "Evaluation error: timeout"
+        assert override is None
 
     def test_multiple_judges_returns_max(self, orchestrator: JudgeOrchestrator) -> None:
         """Multiple judges return max score."""
@@ -87,11 +88,12 @@ class TestAggregateScores:
             JudgeScore(judge_id="judge-3", score=0.75, reason="Good"),
         ]
 
-        score, reason = orchestrator.aggregate_scores(judge_scores)
+        score, reason, override = orchestrator.aggregate_scores(judge_scores)
 
         assert score == 0.9
         assert "Max of 3 judges" in reason
         assert "0.900" in reason
+        assert override is None
 
     def test_multiple_judges_with_one_failure(
         self, orchestrator: JudgeOrchestrator
@@ -103,10 +105,11 @@ class TestAggregateScores:
             JudgeScore(judge_id="judge-3", score=0.85, reason="Great"),
         ]
 
-        score, reason = orchestrator.aggregate_scores(judge_scores)
+        score, reason, override = orchestrator.aggregate_scores(judge_scores)
 
         assert score == 0.85
         assert "Max of 2 judges" in reason
+        assert override is None
 
     def test_all_judges_failed(self, orchestrator: JudgeOrchestrator) -> None:
         """All judges failing returns None with appropriate message."""
@@ -115,75 +118,100 @@ class TestAggregateScores:
             JudgeScore(judge_id="judge-2", score=None, reason="Error 2"),
         ]
 
-        score, reason = orchestrator.aggregate_scores(judge_scores)
+        score, reason, override = orchestrator.aggregate_scores(judge_scores)
 
         assert score is None
         assert reason == "All judges failed to produce a score"
+        assert override is None
 
 
-class TestAggregationStrategyWarning:
-    """Tests for aggregation strategy warning deduplication."""
+class TestAggregationStrategies:
+    """Tests for average and majority_vote aggregation."""
 
-    def test_warning_emitted_once_for_unimplemented_strategy(
-        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Warning for unimplemented strategy is emitted only once."""
-        mock_manager = mocker.MagicMock()
-        mock_manager.system_config.judge_panel.aggregation_strategy = "average"
-        mock_manager.judge_id = "primary"
+    def test_average_strategy(self, mocker: MockerFixture) -> None:
+        """Average strategy returns mean of valid scores."""
+        orch = _make_orchestrator(mocker, "average")
+        judge_scores = [
+            JudgeScore(judge_id="j1", score=0.6, reason="A"),
+            JudgeScore(judge_id="j2", score=0.8, reason="B"),
+        ]
+        score, reason, override = orch.aggregate_scores(judge_scores, 0.7)
+        assert score == pytest.approx(0.7)
+        assert "Average of 2 judges" in reason
+        assert override is None
 
-        orchestrator = JudgeOrchestrator(
-            llm_manager=mock_manager,
-            primary_handlers={},
-            handler_factory=mocker.MagicMock(),
-            status_determiner=lambda s, _: "PASS",
+    def test_majority_vote_pass(self, mocker: MockerFixture) -> None:
+        """Majority vote: PASS when strict majority of judges meet metric threshold."""
+        # status_determiner returns FAIL to prove override takes precedence
+        orch = _make_orchestrator(
+            mocker, "majority_vote", status_determiner=lambda s, _: "FAIL"
         )
+        judge_scores = [
+            JudgeScore(judge_id="j1", score=0.9, reason="A"),
+            JudgeScore(judge_id="j2", score=0.9, reason="B"),
+            JudgeScore(judge_id="j3", score=0.2, reason="C"),
+        ]
+        score, reason, override = orch.aggregate_scores(judge_scores, 0.7)
+        assert score == pytest.approx((0.9 + 0.9 + 0.2) / 3)
+        assert override == "PASS"
+        assert "Majority vote (2/3" in reason
 
+    def test_majority_vote_fail(self, mocker: MockerFixture) -> None:
+        """Majority vote: FAIL when majority do not meet threshold."""
+        orch = _make_orchestrator(mocker, "majority_vote")
         judge_scores = [
             JudgeScore(judge_id="j1", score=0.8, reason="A"),
-            JudgeScore(judge_id="j2", score=0.7, reason="B"),
+            JudgeScore(judge_id="j2", score=0.2, reason="B"),
+            JudgeScore(judge_id="j3", score=0.2, reason="C"),
         ]
+        score, reason, override = orch.aggregate_scores(judge_scores, 0.7)
+        assert override == "FAIL"
+        assert "Majority vote (1/3" in reason
+        assert score == pytest.approx((0.8 + 0.2 + 0.2) / 3)
 
-        with caplog.at_level(logging.WARNING):
-            # Call aggregate multiple times
-            orchestrator.aggregate_scores(judge_scores)
-            orchestrator.aggregate_scores(judge_scores)
-            orchestrator.aggregate_scores(judge_scores)
-
-        # Warning should appear only once
-        warning_messages = [
-            r.message for r in caplog.records if "not yet implemented" in r.message
-        ]
-        assert len(warning_messages) == 1
-        assert "average" in warning_messages[0]
-
-    def test_no_warning_for_max_strategy(
-        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    def test_majority_vote_none_threshold_uses_default_half(
+        self, mocker: MockerFixture
     ) -> None:
-        """No warning emitted when using implemented 'max' strategy."""
-        mock_manager = mocker.MagicMock()
-        mock_manager.system_config.judge_panel.aggregation_strategy = "max"
-        mock_manager.judge_id = "primary"
-
-        orchestrator = JudgeOrchestrator(
-            llm_manager=mock_manager,
-            primary_handlers={},
-            handler_factory=mocker.MagicMock(),
-            status_determiner=lambda s, _: "PASS",
-        )
-
+        """Majority vote with threshold=None uses 0.5; also tests 2-judge tie (1/2 → FAIL)."""
+        orch = _make_orchestrator(mocker, "majority_vote")
         judge_scores = [
-            JudgeScore(judge_id="j1", score=0.8, reason="A"),
-            JudgeScore(judge_id="j2", score=0.7, reason="B"),
+            JudgeScore(judge_id="j1", score=0.4, reason="A"),
+            JudgeScore(judge_id="j2", score=0.6, reason="B"),
         ]
+        score, reason, override = orch.aggregate_scores(judge_scores, None)
+        assert score == pytest.approx(0.5)
+        assert override == "FAIL"  # 1/2 pass at 0.5, not strict majority
+        assert "0.500 (default)" in reason
 
-        with caplog.at_level(logging.WARNING):
-            orchestrator.aggregate_scores(judge_scores)
-
-        warning_messages = [
-            r.message for r in caplog.records if "not yet implemented" in r.message
+    def test_majority_vote_even_split_tie_is_fail(self, mocker: MockerFixture) -> None:
+        """Tie on 4 judges (2/4 pass): strict majority needs >2, so FAIL."""
+        orch = _make_orchestrator(mocker, "majority_vote")
+        judge_scores = [
+            JudgeScore(judge_id="j1", score=0.9, reason="A"),
+            JudgeScore(judge_id="j2", score=0.8, reason="B"),
+            JudgeScore(judge_id="j3", score=0.3, reason="C"),
+            JudgeScore(judge_id="j4", score=0.2, reason="D"),
         ]
-        assert len(warning_messages) == 0
+        score, reason, override = orch.aggregate_scores(judge_scores, 0.7)
+        assert override == "FAIL"
+        assert "Majority vote (2/4" in reason
+        assert score == pytest.approx(0.55)
+
+    def test_majority_vote_three_of_four_pass(self, mocker: MockerFixture) -> None:
+        """3/4 judges pass: strict majority (3 > 2), so PASS."""
+        orch = _make_orchestrator(
+            mocker, "majority_vote", status_determiner=lambda s, _: "FAIL"
+        )
+        judge_scores = [
+            JudgeScore(judge_id="j1", score=0.9, reason="A"),
+            JudgeScore(judge_id="j2", score=0.8, reason="B"),
+            JudgeScore(judge_id="j3", score=0.7, reason="C"),
+            JudgeScore(judge_id="j4", score=0.2, reason="D"),
+        ]
+        score, reason, override = orch.aggregate_scores(judge_scores, 0.7)
+        assert override == "PASS"
+        assert "Majority vote (3/4" in reason
+        assert score == pytest.approx(0.65)
 
 
 class TestHandlerCaching:


### PR DESCRIPTION
## Description

Add avg and majority vote as additional aggregation strategies

Note:
Config changes were already done in previous PR (max was default)
Override from the data is out of scope - Keeping it simple for now

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # [LEADS-195](https://redhat.atlassian.net/browse/LEADS-195) https://github.com/lightspeed-core/lightspeed-evaluation/issues/104
- Closes # [LEADS-195](https://redhat.atlassian.net/browse/LEADS-195)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregation strategies expanded: `average` (mean) and `majority_vote` (strict-majority pass/fail) now available alongside `max`
  * Introduced a default metric threshold used when none is provided

* **Documentation**
  * Evaluation and configuration docs updated to describe each aggregation behavior, tie/failure semantics for majority votes, and exclusion of errored judges during aggregation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->