### PR TITLE
feat: add support for extra_request_params

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -86,6 +86,10 @@ api:
   model: "gpt-4o-mini"                 # Model to use for queries
   no_tools: null                       # Whether to bypass tools and MCP servers (optional)
   system_prompt: null                  # System prompt (default None)
+  # Extra parameters merged into API request payload (per-turn override in eval.yaml takes priority)
+  # Example: extra_request_params:
+  #            mode: troubleshooting
+  extra_request_params: null
 
   cache_dir: ".caches/api_cache"  # Directory with lightspeed-stack cache
   cache_enabled: true                  # Is lightspeed-stack cache enabled?

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -232,6 +232,12 @@ class APIClient:
             for key, value in extra.items():
                 if key not in reserved and key not in payload:
                     payload[key] = value
+        try:
+            json.dumps(payload)
+        except TypeError as e:
+            raise ValueError(
+                "extra_request_params must contain only JSON-serializable values"
+            ) from e
         return payload
 
     def _standard_query(self, api_request: APIRequest) -> APIResponse:

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -9,12 +9,12 @@ from typing import Any, Optional, cast
 import httpx
 from diskcache import Cache
 from tenacity import (
+    RetryError,
+    before_sleep_log,
     retry,
     retry_if_exception,
     stop_after_attempt,
     wait_exponential,
-    before_sleep_log,
-    RetryError,
 )
 
 from lightspeed_evaluation.core.api.streaming_parser import parse_streaming_response
@@ -118,7 +118,6 @@ class APIClient:
             and self.config.mcp_headers.enabled
             and self.config.mcp_headers.servers
         ):
-
             mcp_headers = {}
             for server_name, server_config in self.config.mcp_headers.servers.items():
                 # Get token from environment variable
@@ -379,10 +378,17 @@ class APIClient:
             "no_tools",
             "system_prompt",
             "attachments",
-            "extra_request_params",
         ]
-        str_request = ",".join([str(request_dict[k]) for k in keys_to_hash])
+        parts = [str(request_dict[k]) for k in keys_to_hash]
 
+        # Add individual extra_request_params keys in sorted order
+        # for deterministic cache keys
+        extra = request_dict.get("extra_request_params")
+        if extra:
+            for key in sorted(extra):
+                parts.append(f"{key}={extra[key]}")
+
+        str_request = ",".join(parts)
         return hashlib.sha256(str_request.encode()).hexdigest()
 
     def _add_response_to_cache(

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -159,6 +159,7 @@ class APIClient:
         query: str,
         conversation_id: Optional[str] = None,
         attachments: Optional[list[str]] = None,
+        extra_request_params: Optional[dict[str, Any]] = None,
     ) -> APIResponse:
         """Query the API using the configured endpoint type.
 
@@ -166,6 +167,7 @@ class APIClient:
             query: The question/query to ask
             conversation_id: Optional conversation ID for context
             attachments: Optional list of attachments
+            extra_request_params: Optional per-turn extra params (overrides system defaults)
 
         Returns:
             APIResponse with Response, Tool calls, Conversation ID
@@ -174,7 +176,9 @@ class APIClient:
             raise APIError("API client not initialized")
 
         try:
-            api_request = self._prepare_request(query, conversation_id, attachments)
+            api_request = self._prepare_request(
+                query, conversation_id, attachments, extra_request_params
+            )
             if self.config.cache_enabled:
                 cached_response = self._get_cached_response(api_request)
                 if cached_response is not None:
@@ -201,8 +205,13 @@ class APIClient:
         query: str,
         conversation_id: Optional[str] = None,
         attachments: Optional[list[str]] = None,
+        extra_request_params: Optional[dict[str, Any]] = None,
     ) -> APIRequest:
         """Prepare API request with common parameters."""
+        # Merge extra params: system defaults, then per-turn overrides
+        resolved_extra = {**(self.config.extra_request_params or {})}
+        if extra_request_params:
+            resolved_extra.update(extra_request_params)
         return APIRequest.create(
             query=query,
             provider=self.config.provider,
@@ -211,7 +220,20 @@ class APIClient:
             conversation_id=conversation_id,
             system_prompt=self.config.system_prompt,
             attachments=attachments,
+            extra_request_params=resolved_extra or None,
         )
+
+    @staticmethod
+    def _serialize_request(api_request: APIRequest) -> dict[str, Any]:
+        """Serialize API request, flattening extra_request_params into the payload."""
+        payload = api_request.model_dump(exclude_none=True)
+        extra = payload.pop("extra_request_params", None)
+        if extra:
+            reserved = set(APIRequest.model_fields)
+            for key, value in extra.items():
+                if key not in reserved and key not in payload:
+                    payload[key] = value
+        return payload
 
     def _standard_query(self, api_request: APIRequest) -> APIResponse:
         """Query the API using non-streaming endpoint with retry on 429."""
@@ -220,7 +242,7 @@ class APIClient:
         try:
             response = self.client.post(
                 f"/{self.config.version}/query",
-                json=api_request.model_dump(exclude_none=True),
+                json=self._serialize_request(api_request),
             )
             response.raise_for_status()
 
@@ -277,7 +299,7 @@ class APIClient:
             with self.client.stream(
                 "POST",
                 f"/{self.config.version}/streaming_query",
-                json=api_request.model_dump(exclude_none=True),
+                json=self._serialize_request(api_request),
             ) as response:
                 self._handle_response_errors(response)
                 raw_data = parse_streaming_response(response)
@@ -357,6 +379,7 @@ class APIClient:
             "no_tools",
             "system_prompt",
             "attachments",
+            "extra_request_params",
         ]
         str_request = ",".join([str(request_dict[k]) for k in keys_to_hash])
 

--- a/src/lightspeed_evaluation/core/models/api.py
+++ b/src/lightspeed_evaluation/core/models/api.py
@@ -47,6 +47,9 @@ class APIRequest(BaseModel):
     attachments: Optional[list[AttachmentData]] = Field(
         default=None, description="File attachments"
     )
+    extra_request_params: Optional[dict[str, Any]] = Field(
+        default=None, description="Extra parameters merged into the API request payload"
+    )
 
     @classmethod
     def create(
@@ -62,6 +65,7 @@ class APIRequest(BaseModel):
         conversation_id = kwargs.get("conversation_id")
         system_prompt = kwargs.get("system_prompt")
         attachments = kwargs.get("attachments")
+        extra_request_params = kwargs.get("extra_request_params")
         attachment_data = None
         if attachments:
             attachment_data = [
@@ -76,6 +80,7 @@ class APIRequest(BaseModel):
             conversation_id=conversation_id,
             system_prompt=system_prompt,
             attachments=attachment_data,
+            extra_request_params=extra_request_params,
         )
 
 

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -43,6 +43,10 @@ class TurnData(StreamingMetricsMixin):
     attachments: Optional[list[str]] = Field(
         default=None, min_length=0, description="Attachments"
     )
+    extra_request_params: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Extra parameters merged into API request payload (overrides system defaults)",
+    )
     response: Optional[str] = Field(
         default=None,
         min_length=1,

--- a/src/lightspeed_evaluation/core/models/system.py
+++ b/src/lightspeed_evaluation/core/models/system.py
@@ -288,6 +288,7 @@ class APIConfig(BaseModel):
     system_prompt: Optional[str] = Field(
         default=None, description="System prompt for API calls"
     )
+    extra_request_params: Optional[dict[str, Any]] = Field(default=None)
     cache_dir: str = Field(
         default=DEFAULT_API_CACHE_DIR,
         min_length=1,

--- a/src/lightspeed_evaluation/pipeline/evaluation/amender.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/amender.py
@@ -41,6 +41,7 @@ class APIDataAmender:
                 query=turn_data.query,
                 conversation_id=conversation_id,
                 attachments=turn_data.attachments,
+                extra_request_params=turn_data.extra_request_params,
             )
 
             # AMEND EVALUATION DATA: This modifies the loaded TurnData object in-place

--- a/tests/unit/core/api/test_client.py
+++ b/tests/unit/core/api/test_client.py
@@ -536,6 +536,157 @@ class TestAPIClientConfiguration:
         assert result.conversation_id == "conv_123"
 
 
+class TestExtraRequestParams:
+    """Tests for extra_request_params support in APIClient."""
+
+    def test_api_config_extra_request_params(self) -> None:
+        """Test APIConfig accepts extra_request_params."""
+        config = APIConfig(
+            enabled=True,
+            api_base="http://localhost:8080",
+            endpoint_type="query",
+            timeout=30,
+            extra_request_params={"mode": "troubleshooting"},
+        )
+        assert config.extra_request_params == {"mode": "troubleshooting"}
+
+    def test_api_config_extra_request_params_none_default(self) -> None:
+        """Test APIConfig defaults extra_request_params to None."""
+        config = APIConfig(
+            enabled=True,
+            api_base="http://localhost:8080",
+            endpoint_type="query",
+            timeout=30,
+        )
+        assert config.extra_request_params is None
+
+    def test_prepare_request_with_turn_extra_params(
+        self, basic_api_config_streaming_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test request preparation with per-turn extra params."""
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(basic_api_config_streaming_endpoint)
+        request = client._prepare_request(
+            "Test query",
+            extra_request_params={"mode": "troubleshooting"},
+        )
+
+        assert request.extra_request_params == {"mode": "troubleshooting"}
+
+    def test_prepare_request_extra_params_falls_back_to_config(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test extra params fall back to system config when not provided per-turn."""
+        config = APIConfig(
+            enabled=True,
+            api_base="http://localhost:8080",
+            endpoint_type="query",
+            timeout=30,
+            cache_enabled=False,
+            extra_request_params={"mode": "ask"},
+        )
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(config)
+        request = client._prepare_request("Test query")
+
+        assert request.extra_request_params == {"mode": "ask"}
+
+    def test_prepare_request_turn_extra_params_overrides_config(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test per-turn extra params override system config values."""
+        config = APIConfig(
+            enabled=True,
+            api_base="http://localhost:8080",
+            endpoint_type="query",
+            timeout=30,
+            cache_enabled=False,
+            extra_request_params={"mode": "ask", "system_key": "default"},
+        )
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(config)
+        request = client._prepare_request(
+            "Test query",
+            extra_request_params={"mode": "troubleshooting"},
+        )
+
+        # Per-turn overrides mode, system_key is inherited
+        assert request.extra_request_params == {
+            "mode": "troubleshooting",
+            "system_key": "default",
+        }
+
+    def test_cache_key_differs_by_extra_params(
+        self, basic_api_config_streaming_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that different extra params produce different cache keys."""
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(basic_api_config_streaming_endpoint)
+        request_ask = client._prepare_request(
+            "Test query", extra_request_params={"mode": "ask"}
+        )
+        request_troubleshooting = client._prepare_request(
+            "Test query", extra_request_params={"mode": "troubleshooting"}
+        )
+
+        key_ask = client._get_cache_key(request_ask)
+        key_troubleshooting = client._get_cache_key(request_troubleshooting)
+
+        assert key_ask != key_troubleshooting
+
+    def test_query_flattens_extra_params_in_payload(
+        self, basic_api_config_query_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that extra_request_params are flattened into the API payload."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "response": "Test response",
+            "conversation_id": "conv_123",
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_query_endpoint)
+        client.query("Test query", extra_request_params={"mode": "ask"})
+
+        call_kwargs = mock_client.post.call_args
+        request_data = call_kwargs[1]["json"]
+        # mode should be flattened into top-level, not nested
+        assert request_data["mode"] == "ask"
+        assert "extra_request_params" not in request_data
+
+    def test_serialize_request_skips_reserved_fields(
+        self, basic_api_config_streaming_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that extra_request_params cannot overwrite core request fields."""
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(basic_api_config_streaming_endpoint)
+        request = client._prepare_request(
+            "Original query",
+            extra_request_params={"query": "injected", "mode": "troubleshooting"},
+        )
+
+        payload = client._serialize_request(request)
+
+        # Core field must not be overwritten
+        assert payload["query"] == "Original query"
+        # Non-reserved field should be added
+        assert payload["mode"] == "troubleshooting"
+
+
 class TestRetryLogic:
     """Unit tests for retry logic in APIClient."""
 

--- a/tests/unit/core/models/test_api_additional.py
+++ b/tests/unit/core/models/test_api_additional.py
@@ -107,6 +107,33 @@ class TestAPIRequest:
             == "file1"
         )
 
+    def test_create_request_with_extra_params(self) -> None:
+        """Test creating request with extra_request_params."""
+        request = APIRequest.create(
+            query="Test query",
+            extra_request_params={"mode": "ask"},
+        )
+
+        assert request.extra_request_params == {"mode": "ask"}
+
+    def test_create_request_without_extra_params(self) -> None:
+        """Test that extra_request_params is excluded from serialization when None."""
+        request = APIRequest.create(query="Test query")
+
+        assert request.extra_request_params is None
+        dumped = request.model_dump(exclude_none=True)
+        assert "extra_request_params" not in dumped
+
+    def test_create_request_extra_params_in_serialization(self) -> None:
+        """Test that extra_request_params is included in serialization when set."""
+        request = APIRequest.create(
+            query="Test query",
+            extra_request_params={"mode": "troubleshooting"},
+        )
+
+        dumped = request.model_dump(exclude_none=True)
+        assert dumped["extra_request_params"] == {"mode": "troubleshooting"}
+
     def test_request_empty_query_validation(self) -> None:
         """Test that empty query fails validation."""
         with pytest.raises(ValidationError):

--- a/tests/unit/core/models/test_data.py
+++ b/tests/unit/core/models/test_data.py
@@ -44,6 +44,33 @@ class TestTurnData:
         assert turn.turn_metrics_metadata == {"geval:custom": {"threshold": 0.8}}
 
 
+class TestTurnDataExtraRequestParams:
+    """Test cases for TurnData extra_request_params field."""
+
+    def test_extra_request_params_accepted(self) -> None:
+        """Test TurnData accepts extra_request_params dict."""
+        turn = TurnData(
+            turn_id="turn1",
+            query="Q",
+            extra_request_params={"mode": "troubleshooting"},
+        )
+        assert turn.extra_request_params == {"mode": "troubleshooting"}
+
+    def test_extra_request_params_none_default(self) -> None:
+        """Test TurnData defaults extra_request_params to None."""
+        turn = TurnData(turn_id="turn1", query="Q")
+        assert turn.extra_request_params is None
+
+    def test_extra_request_params_multiple_keys(self) -> None:
+        """Test TurnData accepts multiple extra params."""
+        turn = TurnData(
+            turn_id="turn1",
+            query="Q",
+            extra_request_params={"mode": "ask", "custom_flag": True},
+        )
+        assert turn.extra_request_params == {"mode": "ask", "custom_flag": True}
+
+
 class TestTurnDataToolCallsValidation:
     """Test cases for TurnData expected_tool_calls field validation and conversion."""
 

--- a/tests/unit/pipeline/evaluation/test_amender.py
+++ b/tests/unit/pipeline/evaluation/test_amender.py
@@ -45,7 +45,10 @@ class TestAPIDataAmender:
 
         # API client should be called once
         mock_client.query.assert_called_once_with(
-            query="Test query", conversation_id=None, attachments=None
+            query="Test query",
+            conversation_id=None,
+            attachments=None,
+            extra_request_params=None,
         )
 
         # Turn data should be amended
@@ -78,7 +81,10 @@ class TestAPIDataAmender:
 
         # API client should be called with existing conversation ID
         mock_client.query.assert_called_once_with(
-            query="Follow-up query", conversation_id="conv_123", attachments=None
+            query="Follow-up query",
+            conversation_id="conv_123",
+            attachments=None,
+            extra_request_params=None,
         )
 
         # Turn data should be amended
@@ -142,6 +148,7 @@ class TestAPIDataAmender:
             query="Attachment query",
             conversation_id=None,
             attachments=["file1.txt", "file2.pdf"],
+            extra_request_params=None,
         )
 
         # Turn data should be amended
@@ -222,3 +229,37 @@ class TestAPIDataAmender:
         # has empty tool_calls)
         assert turn.response == "No tools response"
         assert turn.tool_calls is None
+
+    def test_amend_single_turn_with_extra_request_params(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test amending turn data passes extra_request_params to API client."""
+        mock_client = mocker.Mock()
+        api_response = APIResponse(
+            response="Troubleshoot response",
+            conversation_id="conv_extra",
+            contexts=[],
+            tool_calls=[],
+        )
+        mock_client.query.return_value = api_response
+
+        amender = APIDataAmender(mock_client)
+
+        turn = TurnData(
+            turn_id="8",
+            query="Troubleshoot query",
+            response=None,
+            extra_request_params={"mode": "troubleshooting"},
+        )
+
+        error_msg, conversation_id = amender.amend_single_turn(turn)
+
+        assert error_msg is None
+        assert conversation_id == "conv_extra"
+
+        mock_client.query.assert_called_once_with(
+            query="Troubleshoot query",
+            conversation_id=None,
+            attachments=None,
+            extra_request_params={"mode": "troubleshooting"},
+        )


### PR DESCRIPTION
## Description

This PR introduces the support of `extra_request_params` dynamic argument to be included in lightspeed api requests.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by:  Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional extra request parameters configurable at the system level and overrideable per-turn. These are merged into outgoing API payloads (per-turn overrides take precedence), do not overwrite reserved request fields, and are included in cache-key computation so cached responses vary by these parameters.
* **Tests**
  * Added unit tests covering config persistence, per-turn overrides, payload flattening/merging, reserved-field protection, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->