### PR TITLE
docs: add agentic lightspeed evaluation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ The `agents:` block in `system.yaml` is a generic configuration layer for agent-
 
 **Backward Compatibility:** When `agents:` is absent, the existing `api:` block auto-migrates to `agents:` with a single `http_api` agent. When both are present, `agents:` takes precedence.
 
-**Config Resolution:** Agent configuration follows a 2-level priority chain (per-key merge):
+**Config Resolution:** Agent configuration follows a 3-level priority chain (per-key merge):
 
 ```
 eval_data.agent_config  >  agents.<name> typed fields  >  default.agent_config
@@ -410,6 +410,10 @@ For field tables, full YAML examples (file-only, file + SQLite, file + Postgres)
 | `description`         | string           | ❌       | Human-readable label for reports (falls back to query) | ❌              |
 | `proposal_spec`       | dict             | 📋       | Inline proposal spec for CRD-based agents | ❌                    |
 | `expected_proposal_status` | dict        | 📋       | Assertions to check against proposal status | ❌                  |
+| `expected_outcome`    | string           | 📋       | Expected outcome for proposal evaluation correctness | ❌           |
+| `expected_analysis_outcome` | string     | ❌       | Optional per-phase expected outcome for analysis/diagnosis | ❌     |
+| `expected_execution_outcome` | string    | ❌       | Optional per-phase expected outcome for execution/actions | ❌      |
+| `expected_verification_outcome` | string | ❌       | Optional per-phase expected outcome for verification | ❌           |
 | `turn_metrics`        | list[string]     | ❌       | Turn-specific metrics to evaluate    | ❌                    |
 | `turn_metrics_metadata` | dict           | ❌       | Turn-specific metric configuration   | ❌                    |
 
@@ -424,6 +428,8 @@ Examples
 > - `response`: Required for most metrics (auto-populated if API enabled)
 > - `proposal_spec`: Required for `custom:proposal_status` (CRD-based agent workflows)
 > - `expected_proposal_status`: Required for `custom:proposal_status`
+> - `expected_outcome`: Required for `custom:proposal_evaluation_correctness`
+> - `expected_analysis_outcome`, `expected_execution_outcome`, `expected_verification_outcome`: Optional per-phase outcomes for `custom:proposal_evaluation_correctness` (refine scoring precision)
 
 **Multiple `expected responses`**: For metrics that include `expected_response` in their `required_fields` (defined in [`METRIC_REQUIREMENTS`](./src/lightspeed_evaluation/core/system/validator.py)), you can provide `expected_response` as a list of strings. The evaluator will test each expected response until one passes. If all fail, it returns the maximum `score` from all attempts and logs all scores with their reasons into `reason`. Note: This feature only works for metrics explicitly listed in [`METRIC_REQUIREMENTS`](./src/lightspeed_evaluation/core/system/validator.py). For other metrics (e.g. GEval), only the first item in the list will be used. See example config for multiple expected responses ([evaluation_data_multiple_expected_responses.yaml](./config/evaluation_data_multiple_expected_responses.yaml)).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive framework for evaluating GenAI applications.
 - **LLM Provider Flexibility**: OpenAI, Watsonx, Gemini, vLLM and others
 - **Panel of Judges**: Use multiple LLMs as judges to reduce bias and improve evaluation accuracy with configurable aggregation strategies
 - **API Integration**: Direct integration with external API for real-time data generation (if enabled)
+- **Agentic Lightspeed Evaluation**: Support for Agentic Lightspeed evaluation via Proposal CRD workflow
 - **Setup/Cleanup Scripts**: Support for running setup and cleanup scripts before/after each conversation evaluation (applicable when API is enabled)
 - **Token Usage Tracking**: Track input/output tokens for both API calls and Judge LLM evaluations (per-judge tracking for panel mode)
 - **API Latency Tracking**: Measure and analyze API response times with percentile statistics (p50, p95, p99) for performance monitoring
@@ -191,6 +192,17 @@ export OPENAI_API_KEY="your-key"
 uv run lightspeed-eval --system-config <CONFIG.yaml> --eval-data <EVAL_DATA.yaml>
 ```
 
+#### 3. Agentic Workflow Evaluation (CRD-based)
+```bash
+# Set required environment variable(s) for Judge-LLM and cluster access
+export OPENAI_API_KEY="your-key"
+export KUBECONFIG="/path/to/your/kubeconfig"
+
+# Use system configuration with agents.enabled: true and a proposal agent
+# Evaluation data should contain proposal_spec and expected_proposal_status
+uv run lightspeed-eval --system-config <AGENTS_CONFIG.yaml> --eval-data <PROPOSAL_EVAL_DATA.yaml>
+```
+
 ## 📊 Supported Metrics
 
 ### Turn-Level (Single Query)
@@ -211,6 +223,7 @@ uv run lightspeed-eval --system-config <CONFIG.yaml> --eval-data <EVAL_DATA.yaml
   - Tool Evaluation
     - [`tool_eval`](src/lightspeed_evaluation/core/metrics/custom.py) - Validates tool calls, arguments, and optional results with regex pattern matching
   - Agentic Workflow Evaluation
+    - [`proposal_status`](src/lightspeed_evaluation/core/metrics/custom/proposal_eval.py) - Deterministic assertions on proposal CRD status (phase, timing, analysis, execution, verification)
     - [`proposal_evaluation_correctness`](src/lightspeed_evaluation/core/metrics/custom/custom.py) - LLM-as-judge evaluation of agentic remediation workflow quality (diagnosis, actions, risk, verification)
 - **Script-based**
   - Action Evaluation
@@ -246,6 +259,55 @@ metrics_metadata:
 ### System Config
 
 See [`docs/configuration.md`](docs/configuration.md) for the detailed description.
+
+### Agents Config
+
+The `agents:` block in `system.yaml` is a generic configuration layer for agent-based evaluation. It supports multiple agent types through pluggable drivers:
+
+| Type | Description |
+|------|-------------|
+| `http_api` | Wraps the existing HTTP API client (query/streaming endpoint). This is the type that the legacy `api:` block auto-migrates to. |
+| `proposal` | Manages the full lifecycle of Proposal CRDs on OpenShift clusters (create → poll → auto-approve → cleanup). Used for OpenShift Agentic Lightspeed. |
+
+**Backward Compatibility:** When `agents:` is absent, the existing `api:` block auto-migrates to `agents:` with a single `http_api` agent. When both are present, `agents:` takes precedence.
+
+**Config Resolution:** Agent configuration follows a 2-level priority chain (per-key merge):
+
+```
+eval_data.agent_config  >  agents.<name> typed fields  >  default.agent_config
+(highest priority)         (agent definition)              (fallback for unset fields)
+```
+
+**Example — HTTP API agent:**
+```yaml
+agents:
+  enabled: true
+  default:
+    agent: ols_api
+  ols_api:
+    type: http_api
+    api_base: http://localhost:8080
+    endpoint_type: streaming
+    provider: openai
+    model: gpt-4o
+```
+
+**Example — Proposal CRD agent:**
+```yaml
+agents:
+  enabled: true
+  default:
+    agent: openshift_agentic_lightspeed
+  openshift_agentic_lightspeed:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: true
+    timeout: 900
+    poll_interval: 2
+```
+
+For proposal agent configuration fields, evaluation data structure, assertion reference, and full examples, see **[Agentic Lightspeed Evaluation](docs/agentic_lightspeed_evaluation.md)**.
 
 ### Storage Configuration
 
@@ -326,6 +388,8 @@ For field tables, full YAML examples (file-only, file + SQLite, file + Postgres)
 | `cleanup_script`                | string         | ❌       | Path to cleanup script (Optional, used when API is enabled)          |
 | `conversation_metrics`          | list[string]   | ❌       | Conversation-level metrics (Optional, if override is required)       |
 | `conversation_metrics_metadata` | dict           | ❌       | Conversation-level metric config (Optional, if override is required) |
+| `agent`                         | string         | ❌       | Agent to use for this conversation group (overrides default)         |
+| `agent_config`                  | dict           | ❌       | Per-conversation agent config overrides                              |
 | `turns`                         | list[TurnData] | ✅       | List of conversation turns           |
 
 #### Turn Data Fields
@@ -343,6 +407,9 @@ For field tables, full YAML examples (file-only, file + SQLite, file + Postgres)
 | `expected_tool_calls` | list[list[list[dict]]] | 📋 | Expected tool call sequences (multiple alternative sets) | ❌ |
 | `tool_calls`          | list[list[dict]] | ❌       | Actual tool calls from API           | ✅ (if API enabled)   |
 | `verify_script`       | string           | 📋       | Path to verification script          | ❌                    |
+| `description`         | string           | ❌       | Human-readable label for reports (falls back to query) | ❌              |
+| `proposal_spec`       | dict             | 📋       | Inline proposal spec for CRD-based agents | ❌                    |
+| `expected_proposal_status` | dict        | 📋       | Assertions to check against proposal status | ❌                  |
 | `turn_metrics`        | list[string]     | ❌       | Turn-specific metrics to evaluate    | ❌                    |
 | `turn_metrics_metadata` | dict           | ❌       | Turn-specific metric configuration   | ❌                    |
 
@@ -355,6 +422,8 @@ Examples
 > - `expected_tool_calls`: Required for `custom:tool_eval` (multiple alternative sets format)
 > - `verify_script`: Required for `script:action_eval` (used when API is enabled)
 > - `response`: Required for most metrics (auto-populated if API enabled)
+> - `proposal_spec`: Required for `custom:proposal_status` (CRD-based agent workflows)
+> - `expected_proposal_status`: Required for `custom:proposal_status`
 
 **Multiple `expected responses`**: For metrics that include `expected_response` in their `required_fields` (defined in [`METRIC_REQUIREMENTS`](./src/lightspeed_evaluation/core/system/validator.py)), you can provide `expected_response` as a list of strings. The evaluator will test each expected response until one passes. If all fail, it returns the maximum `score` from all attempts and logs all scores with their reasons into `reason`. Note: This feature only works for metrics explicitly listed in [`METRIC_REQUIREMENTS`](./src/lightspeed_evaluation/core/system/validator.py). For other metrics (e.g. GEval), only the first item in the list will be used. See example config for multiple expected responses ([evaluation_data_multiple_expected_responses.yaml](./config/evaluation_data_multiple_expected_responses.yaml)).
 
@@ -461,6 +530,37 @@ Script paths in evaluation data can be specified in multiple ways:
 - **Absolute Paths**: Used as-is
 - **Home Directory Paths**: Expands to user's home directory
 
+#### Agentic Workflow Evaluation
+
+The framework supports evaluation of event-driven agentic workflows via Kubernetes CRDs. The `proposal` agent type manages the full Proposal CR lifecycle: create, poll status, auto-approve, capture results, and cleanup.
+
+```yaml
+- conversation_group_id: full_lifecycle
+  description: OOMKill remediation — full lifecycle
+  setup_script: agentic/scripts/setup.sh
+  cleanup_script: agentic/scripts/cleanup.sh
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: >-
+          A pod named oomkill-demo in namespace test-ns is in CrashLoopBackOff
+          due to OOMKill. Analyze, fix, and verify.
+        targetNamespaces: [test-ns]
+        analysis: { agent: eval-default }
+        execution: { agent: eval-default }
+        verification: { agent: eval-default }
+      expected_proposal_status:
+        phase: Completed
+        max_duration: "15m"
+        execution: { phase: Succeeded }
+        verification: { passed: true }
+      turn_metrics:
+        - custom:proposal_status
+        - custom:proposal_evaluation_correctness
+```
+
+For prerequisites, configuration, assertion reference, and full examples, see **[Agentic Lightspeed Evaluation](docs/agentic_lightspeed_evaluation.md)**.
+
 ## 🔑 Authentication & Environment
 
 ### Required Environment Variables
@@ -495,6 +595,14 @@ export AZURE_API_BASE="https://your-resource.openai.azure.com/"
 # API authentication for external system (MCP)
 export API_KEY="your-api-endpoint-key"
 ```
+
+#### For Agentic Workflow Evaluation (When using `proposal` agent type)
+```bash
+# Kubernetes cluster access
+export KUBECONFIG="/path/to/your/kubeconfig"
+```
+
+> **Note:** The Agentic Lightspeed operator must be installed on the cluster and the user must have RBAC permissions for Proposal CRD operations in the target namespace. `oc` or `kubectl` must be available in PATH.
 
 ## 📈 Output & Visualization
 

--- a/docs/agentic_lightspeed_evaluation.md
+++ b/docs/agentic_lightspeed_evaluation.md
@@ -1,0 +1,235 @@
+# Agentic Lightspeed Evaluation
+
+This guide covers how to evaluate event-driven agentic workflows using the LightSpeed Evaluation Framework. While the framework's default mode evaluates synchronous HTTP request-response interactions, the agentic evaluation mode supports CRD-based workflows where the "answer" is a trajectory of events and a final cluster state.
+
+## Overview
+
+OpenShift Agentic Lightspeed systems is event-driven: Proposal CRDs are applied, workflows are executed, and cluster state changes. The evaluation framework now supports a `proposal` agent type in order to monitor the cluster state and evaluate agent results against it.
+
+## Prerequisites
+
+- OpenShift cluster with the Agentic Lightspeed operator installed
+- `oc` or `kubectl` CLI available in PATH
+- `KUBECONFIG` environment variable pointing to a valid kubeconfig
+- RBAC permissions for Proposal CRD operations in the target namespace
+- Judge LLM API key (e.g., `OPENAI_API_KEY`) for `proposal_evaluation_correctness`
+
+## Configuration
+
+```yaml
+agents:
+  enabled: true
+
+  default:
+    agent: openshift_agentic_lightspeed
+    agent_config:
+      timeout: 600
+
+  openshift_agentic_lightspeed:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: true
+    timeout: 900
+    poll_interval: 2
+```
+
+### Proposal Agent Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `namespace` | string | *(required)* | Kubernetes namespace containing Proposal resources |
+| `auto_approve` | bool | `true` | Automatically approve proposals when phase is Proposed |
+| `cleanup_proposals` | bool | `true` | Delete eval proposals after status is captured |
+| `timeout` | int | `900` | Total timeout in seconds for the proposal lifecycle |
+| `cli_timeout` | int | `30` | Timeout in seconds for individual oc/kubectl commands |
+| `poll_interval` | int | `2` | Seconds between status polls |
+| `cache_dir` | string | `null` | Location of cached queries |
+| `cache_enabled` | bool | `true` | Enable caching |
+
+### Turn Data Structure
+
+For agentic workflows, each turn uses `proposal_spec` to define the proposal and `expected_proposal_status` to define success criteria.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `description` | string | No | Human-readable label for reports (falls back to `query`) |
+| `proposal_spec` | dict | Conditional | Inline proposal spec — contains `request`, `targetNamespaces`, workflow phase gates |
+| `expected_proposal_status` | dict | Conditional | Assertions to check against the proposal status |
+| `proposal_status` | dict | No | Raw CRD status populated by the driver (framework-managed) |
+| `proposal_results` | dict | No | Child Result CRs populated by ProposalAmender (framework-managed) |
+
+> `query` remains required but can be auto-populated from `proposal_spec.request` when absent.
+
+### Example: Analysis-Only Workflow
+
+The simplest agentic evaluation — analysis phase only, no execution or verification:
+
+```yaml
+- conversation_group_id: analysis_only
+  description: Analysis-only — diagnose without remediating
+  setup_script: agentic/scripts/setup.sh
+  cleanup_script: agentic/scripts/cleanup.sh
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: >-
+          A pod named oomkill-demo in namespace test-ns
+          is in CrashLoopBackOff. Analyze the root cause.
+        targetNamespaces:
+          - test-ns
+        tools:
+          skills:
+            - image: quay.io/harpatil/agentic-skills:latest
+              paths:
+                - /skills/find-token
+        analysis:
+          agent: eval-default
+      expected_proposal_status:
+        phase: Completed
+      turn_metrics:
+        - custom:proposal_status
+```
+
+### Example: Full Lifecycle (Analysis + Execution + Verification)
+
+Complete remediation workflow with deterministic assertions and LLM-as-judge:
+
+```yaml
+- conversation_group_id: full_lifecycle
+  description: OOMKill remediation — full lifecycle with LLM-as-judge
+  setup_script: agentic/scripts/setup.sh
+  cleanup_script: agentic/scripts/cleanup.sh
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: >-
+          A pod named oomkill-demo in namespace test-ns
+          is in CrashLoopBackOff due to OOMKill. Analyze the root cause,
+          fix the memory configuration, and verify the fix.
+        targetNamespaces:
+          - test-ns
+        tools:
+          skills:
+            - image: quay.io/harpatil/agentic-skills:latest
+              paths:
+                - /skills/find-token
+        analysis:
+          agent: eval-default
+        execution:
+          agent: eval-default
+        verification:
+          agent: eval-default
+      expected_proposal_status:
+        phase: Completed
+        max_duration: "15m"
+        max_attempts: 5
+        analysis:
+          min_options: 1
+          options:
+            - risk_in: [low, medium]
+              confidence_in: [medium, high]
+        execution:
+          phase: Succeeded
+        verification:
+          passed: true
+      expected_outcome: >-
+        Root cause: the pod oomkill-demo is OOMKilled because its container
+        memory limit is too low. Remediation: increase the container memory
+        limit and verify the pod reaches Running state.
+      turn_metrics:
+        - custom:proposal_status
+        - custom:proposal_evaluation_correctness
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+```
+
+## Proposal Lifecycle
+
+The `proposal` driver manages the full Proposal CR lifecycle:
+
+1. **Build Proposal CR** — Merge `proposal_spec` + `request` + agent config
+2. **Create CR on cluster** — Auto-generated name: `eval-<uuid8>`
+3. **Poll status** — Loop every `poll_interval` seconds
+4. **Auto-approve** — If phase is `Proposed` and `auto_approve` is enabled
+5. **Terminal phase** — `Completed` / `Failed` / `Denied` / `Escalated`
+6. **Populate turn_data** — `proposal_status` (full status dict) + `proposal_results` (child Result CRs) + `response` (Markdown workflow summary)
+7. **Cleanup proposal CR** — Delete the created CR (if `cleanup_proposals` is enabled)
+8. **Metrics evaluate** — `custom:proposal_status` and/or `custom:proposal_evaluation_correctness` on enriched data
+
+Setup/cleanup scripts are only needed for **infrastructure** (deploying the workload to trigger, LLM provider CRs, sandbox CRs, etc.). The driver handles Proposal CR lifecycle autonomously.
+
+## Metrics
+
+### `custom:proposal_status` — Deterministic Assertions
+
+A single metric that runs all assertion checks from `expected_proposal_status` in sequence, failing fast at the first failure. Score is `1.0` if all checks pass, `0.0` on first failure.
+
+Checks run in order: **phase → timing → analysis → execution → verification**.
+
+#### `expected_proposal_status` Reference
+
+**Phase checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | string | Exact phase match (e.g., `Completed`, `Failed`, `Escalated`) |
+| `phase_in` | list[string] | Phase must be one of these values |
+
+**Timing checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max_duration` | string | Max elapsed time across conditions. Go-style duration: `"5m"`, `"2m30s"`, `"1h"` |
+| `max_attempts` | int | Max number of execution attempts. Read from `status.attempts` or inferred from `RetryingExecution` conditions |
+
+**Analysis checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `analysis.min_options` | int | Minimum number of analysis options required |
+| `analysis.options[].risk_in` | list[string] | Allowed risk levels for the option (case-insensitive) |
+| `analysis.options[].confidence_in` | list[string] | Allowed confidence levels (case-insensitive) |
+| `analysis.options[].diagnosis_contains` | list[string] | Substrings the diagnosis summary must contain (case-insensitive) |
+| `analysis.options[].components[].type` | string | Component type to assert on |
+| `analysis.options[].components[].match` | dict | Exact field match on component |
+| `analysis.options[].components[].match_contains` | dict | Substring match on component fields (case-insensitive) |
+| `analysis.options[].components[].required` | list[string] | Fields that must be present on the component |
+| `analysis.options[].components[].absent` | bool | Assert that this component type does not exist |
+
+**Execution checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `execution.phase` | string | Expected execution phase (e.g., `Succeeded`, `Failed`) |
+
+**Verification checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `verification.passed` | bool | Whether verification passed (`status == "True"` on `Verified` condition) |
+| `verification.summary_contains` | string | Substring the verification message must contain (case-insensitive) |
+
+**Condition checks:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions[].type` | string | Condition type to assert on (e.g., `Executed`, `Verified`) |
+| `conditions[].status` | string | Expected condition status (e.g., `"True"`, `"False"`) |
+| `conditions[].reason` | string | Expected condition reason (e.g., `Skipped`, `Succeeded`) |
+
+> On retried proposals, analysis and execution checks use the **latest** (most recent) Result CR, so assertions reflect the final execution state.
+
+### `custom:proposal_evaluation_correctness` — LLM-as-Judge
+
+Evaluates agentic remediation workflow quality using a Judge LLM. Scores 0.0–1.0 based on four aspects (only phases present in the workflow are scored):
+
+1. **Diagnosis Quality** — Is the root cause correctly identified? (highest weight)
+2. **Action Appropriateness** — Are the actions safe and well-scoped?
+3. **Risk Management** — Is the risk assessment correct?
+4. **Verification Thoroughness** — Do the checks confirm the fix?
+
+**Threshold:** 0.75
+
+**Required fields:** `response` (populated automatically during execution)

--- a/docs/agentic_lightspeed_evaluation.md
+++ b/docs/agentic_lightspeed_evaluation.md
@@ -56,6 +56,10 @@ For agentic workflows, each turn uses `proposal_spec` to define the proposal and
 | `description` | string | No | Human-readable label for reports (falls back to `query`) |
 | `proposal_spec` | dict | Conditional | Inline proposal spec — contains `request`, `targetNamespaces`, workflow phase gates |
 | `expected_proposal_status` | dict | Conditional | Assertions to check against the proposal status |
+| `expected_outcome` | string | Conditional | Expected outcome description for LLM-as-judge evaluation |
+| `expected_analysis_outcome` | string | No | Optional per-phase expected outcome for analysis/diagnosis |
+| `expected_execution_outcome` | string | No | Optional per-phase expected outcome for execution/actions |
+| `expected_verification_outcome` | string | No | Optional per-phase expected outcome for verification |
 | `proposal_status` | dict | No | Raw CRD status populated by the driver (framework-managed) |
 | `proposal_results` | dict | No | Child Result CRs populated by ProposalAmender (framework-managed) |
 
@@ -223,13 +227,12 @@ Checks run in order: **phase → timing → analysis → execution → verificat
 
 ### `custom:proposal_evaluation_correctness` — LLM-as-Judge
 
-Evaluates agentic remediation workflow quality using a Judge LLM. Scores 0.0–1.0 based on four aspects (only phases present in the workflow are scored):
+Evaluates agentic remediation workflow quality using a Judge LLM. Scores 0.0–1.0 across three dimensions (only phases present in the workflow are scored; absent dimensions are marked N/A):
 
-1. **Diagnosis Quality** — Is the root cause correctly identified? (highest weight)
-2. **Action Appropriateness** — Are the actions safe and well-scoped?
-3. **Risk Management** — Is the risk assessment correct?
-4. **Verification Thoroughness** — Do the checks confirm the fix?
+1. **Diagnosis** — Is the root cause correctly identified? Are the proposed actions sound and safe?
+2. **Execution** — Were the remediation actions carried out? Are they safe, well-scoped, and minimal?
+3. **Verification** — Do the checks confirm the specific issue was resolved?
 
 **Threshold:** 0.75
 
-**Required fields:** `response` (populated automatically during execution)
+**Required fields:** `response` (populated automatically during execution), `expected_outcome`


### PR DESCRIPTION
## Summary

- Add `docs/agentic_lightspeed_evaluation.md` — user-facing guide for the agentic evaluation feature covering proposal agent fields, eval_data structure, `expected_proposal_status` assertion reference, metrics (`proposal_status` + `proposal_evaluation_correctness`).
- Update `README.md` with agents config section, `custom:proposal_status` metric, usage scenario, authentication requirements, an example and links to the new guide


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agentic Lightspeed evaluation for event-driven agentic workflows using Kubernetes Proposal CRD.
  * Introduced new custom metrics for proposal status evaluation and correctness assessment.
  * Added agent configuration options including http_api and proposal agent types.

* **Documentation**
  * Enhanced configuration documentation with new agents configuration section.
  * Added comprehensive agentic workflow evaluation guide including YAML examples and authentication prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->