### PR TITLE
[LEADS-415] Responses endpoint support

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -70,7 +70,7 @@ api:
   enabled: true                        # Enable API calls instead of using pre-filled data
   api_base: http://localhost:8080      # Base API URL (without version)
   version: v1                          # API version (e.g., v1, v2)
-  endpoint_type: streaming             # Use "streaming" or "query" endpoint
+  endpoint_type: streaming             # Supported endpoint types: "query", "streaming", "infer" (lightspeed-stack) and "responses" (lightspeed-stack)
   timeout: 300                         # API request timeout in seconds
 
   # Retry configuration for 429 Too Many Requests API errors

--- a/examples/03_endpoints/responses/README.md
+++ b/examples/03_endpoints/responses/README.md
@@ -1,0 +1,29 @@
+# Responses Endpoint — OKP Vector Store
+
+Evaluation of the **Responses API** endpoint implemented in the Lightspeed stack (OpenAI-compatible) with a `file_search` tool backed by the **OKP vector store**.
+
+## Run Example
+
+```bash
+# From project root
+export OPENAI_API_KEY="your-key"
+uv run lightspeed-eval \
+  --system-config examples/03_endpoints/responses/system.yaml \
+  --eval-data examples/03_endpoints/responses/eval_data.yaml
+```
+
+## What This Example Demonstrates
+
+- **Endpoint**: `responses` — targets the Lightspeed Responses API endpoint (`api.endpoint_type: responses`)
+- **Tool use**: `file_search` is required on every turn via `tool_choice.mode: "required"` (with `allowed_tools`), searching the `okp` vector store
+- **Tool evaluation**: `custom:tool_eval` validates that the correct tool was called with the expected arguments (exact/ordered match)
+- **Response quality**: `ragas:response_relevancy` measures how well the response addresses the query (threshold: 0.8)
+
+## Metrics
+
+| Metric | Description | Threshold |
+|--------|-------------|-----------|
+| `ragas:response_relevancy` | How relevant the response is to the query | 0.8 |
+| `custom:tool_eval` | Binary validation that `file_search` was called with expected arguments | pass/fail |
+
+Results written to: `examples/03_endpoints/responses/eval_output/`

--- a/examples/03_endpoints/responses/eval_data.yaml
+++ b/examples/03_endpoints/responses/eval_data.yaml
@@ -1,0 +1,10 @@
+- conversation_group_id: responses_test
+  description: Test Responses endpoint for coding assistance
+  turns:
+    - turn_id: turn_1
+      query: What is new in Openshift 4.21?
+      expected_tool_calls:
+      - - tool_name: file_search
+          arguments:
+            queries: .*
+      expected_response: "OpenShift 4.21 introduces several new features and improvements primarily focused on monitoring, metrics, and alert management. Here are the key updates:\n\n1. **Enhanced Metrics Collection**: OpenShift 4.21 allows cluster components to be monitored by scraping metrics from service endpoints. Users can also configure metrics for their own workloads, which can be exposed via Prometheus client libraries at the application level. Metrics are made accessible through an HTTP service endpoint under the `/metrics` canonical name. Developers can list available metrics for a service using a simple curl command on the endpoint.\n\n2. **User Workload Monitoring**: There are updated resources for configuring metrics specific to user workloads, which allow for better insight into how applications are performing within the cluster.\n\n3. **Alert Management**: The Alerting UI has been improved to manage alerts effectively. This includes features for creating alerting rules that define conditions under which alerts are triggered, managing alerts raised by these rules, and silencing them to prevent notifications while issues are being resolved.\n\n4. **Documentation Resources**: OpenShift 4.21 comes with extensive documentation that outlines first steps in both core platform monitoring and user workload monitoring, providing guidance on managing alerts as both administrators and developers.\n\nThese enhancements aim to provide users with better tools for monitoring and managing their applications and cluster performance more effectively."

--- a/examples/03_endpoints/responses/system.yaml
+++ b/examples/03_endpoints/responses/system.yaml
@@ -1,0 +1,119 @@
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+  cache_enabled: false
+  cache_base_dir: .caches
+llm_pool:
+  defaults:
+    timeout: 300
+    num_retries: 3
+    parameters:
+      temperature: 0.0
+      max_completion_tokens: 1024
+  models:
+    judge_gpt_4o_mini:
+      provider: openai
+      model: gpt-4o-mini
+judge_panel:
+  judges:
+    - judge_gpt_4o_mini
+embedding:
+  provider: "openai"
+  model: "text-embedding-3-small"
+  provider_kwargs: {}
+api:
+  enabled: true
+  api_base: http://localhost:8080
+  version: v1
+  endpoint_type: responses
+  timeout: 300
+  num_retries: 3
+  provider: "openai"
+  model: "gpt-4o-mini"
+  no_tools: null
+  system_prompt: null
+  extra_request_params: {
+    tool_choice: {
+      type: "allowed_tools",
+      tools: [{"type": "file_search"}],
+      mode: "required"
+    },
+    tools: [
+      {
+        type: "file_search",
+        vector_store_ids: ["okp"]
+      }
+    ]
+  }
+  mcp_headers:
+    enabled: false
+    servers:
+      filesystem-tools:
+        env_var: API_KEY
+metrics_metadata:
+  turn_level:
+    ragas:response_relevancy:
+      threshold: 0.8
+      description: "How relevant the response is to the question"
+      default: true
+    custom:tool_eval:
+      description: Binary validation of tool calls (exact/regex matching)
+      default: true
+      ordered: true
+      full_match: true
+storage:
+  - type: "file"
+    output_dir: "examples/03_endpoints/responses/eval_output/"
+    base_filename: "evaluation"
+    enabled_outputs:
+      - csv
+      - json
+      - txt
+    csv_columns:
+      - "conversation_group_id"
+      - "turn_id"
+      - "metric_identifier"
+      - "metric_metadata"
+      - "result"
+      - "score"
+      - "threshold"
+      - "reason"
+      - "execution_time"
+      - "evaluation_latency"
+      - "query"
+      - "response"
+      - "api_input_tokens"
+      - "api_output_tokens"
+      - "agent_latency"
+      - "judge_llm_input_tokens"
+      - "judge_llm_output_tokens"
+      - "embedding_tokens"
+      - "judge_scores"
+      - "tool_calls"
+      - "contexts"
+      - "expected_response"
+      - "expected_intent"
+      - "expected_keywords"
+      - "expected_tool_calls"
+    summary_config_sections:
+      - core
+      - llm_pool
+      - judge_panel
+      - embedding
+      - api
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "pass_rates"
+    - "score_distribution"
+    - "conversation_heatmap"
+    - "status_breakdown"
+environment:
+  LITELLM_LOG: ERROR
+logging:
+  source_level: INFO
+  package_level: WARNING
+  log_format: '%(asctime)s - %(levelname)s - %(message)s'
+  show_timestamps: true

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -72,6 +72,7 @@ class APIClient:
         self._standard_query_with_retry = retry_decorator(self._standard_query)
         self._streaming_query_with_retry = retry_decorator(self._streaming_query)
         self._rlsapi_infer_query_with_retry = retry_decorator(self._rlsapi_infer_query)
+        self._responses_query_with_retry = retry_decorator(self._responses_query)
 
     def _create_retry_decorator(self) -> Any:
         return retry(
@@ -201,6 +202,8 @@ class APIClient:
                 response = self._streaming_query_with_retry(api_request)
             elif self.config.endpoint_type == "infer":
                 response = self._rlsapi_infer_query_with_retry(api_request)
+            elif self.config.endpoint_type == "responses":
+                response = self._responses_query_with_retry(api_request)
             else:
                 response = self._standard_query_with_retry(api_request)
 
@@ -497,6 +500,160 @@ class APIClient:
             raise
         except Exception as e:
             raise self._handle_unexpected_error(e, "infer query") from e
+
+    def _build_responses_request(self, api_request: APIRequest) -> dict[str, Any]:
+        """Build request payload for the /responses endpoint.
+
+        Maps APIRequest fields to the OpenAI Responses API format and merges
+        any extra_request_params (e.g. explicit tools, store, stream) on top.
+
+        Args:
+            api_request: The prepared API request.
+
+        Returns:
+            Dictionary suitable for posting to the /responses endpoint.
+        """
+        # Combine provider and model into a single "provider/model" string
+        if api_request.provider and api_request.model:
+            model_str = f"{api_request.provider}/{api_request.model}"
+        else:
+            model_str = api_request.model or api_request.provider
+
+        payload: dict[str, Any] = {"input": api_request.query}
+        if model_str:
+            payload["model"] = model_str
+        if api_request.system_prompt:
+            payload["instructions"] = api_request.system_prompt
+        if api_request.conversation_id:
+            payload["conversation"] = api_request.conversation_id
+
+        # Merge extra_request_params last so callers can override or add fields
+        # (e.g. tools, store, stream). Reserved response-payload keys are not
+        # blocked here — extra_request_params takes explicit precedence.
+        if api_request.extra_request_params:
+            for key, value in api_request.extra_request_params.items():
+                payload[key] = value
+
+        return payload
+
+    @staticmethod
+    def _parse_mcp_call_item(item: dict[str, Any]) -> dict[str, Any]:
+        """Parse a single mcp_call output item into a tool call dict.
+
+        Args:
+            item: A single output item with type 'mcp_call'.
+
+        Returns:
+            Tool call dict with tool_name, arguments, and optional result/error.
+        """
+        raw_args = item.get("arguments") or {}
+        if isinstance(raw_args, str):
+            try:
+                raw_args = json.loads(raw_args)
+            except (json.JSONDecodeError, ValueError):
+                raw_args = {}
+        tool_call: dict[str, Any] = {
+            "tool_name": item.get("name", ""),
+            "arguments": raw_args,
+        }
+        output = item.get("output")
+        if output is not None:
+            tool_call["result"] = output
+        error = item.get("error")
+        if error is not None:
+            tool_call["error"] = error
+        return tool_call
+
+    def _extract_responses_data(self, response_data: dict[str, Any]) -> None:
+        """Extract and promote fields from the /responses endpoint response.
+
+        Mutates response_data in place, mapping OpenAI Responses API fields
+        to the top-level keys expected by APIResponse.from_raw_response().
+
+        Args:
+            response_data: The raw JSON response dict to update.
+        """
+        if "output_text" in response_data:
+            response_data["response"] = response_data["output_text"]
+        if "conversation" in response_data:
+            response_data["conversation_id"] = response_data["conversation"]
+        usage = response_data.get("usage", {})
+        if "input_tokens" in usage:
+            response_data["input_tokens"] = usage["input_tokens"]
+        if "output_tokens" in usage:
+            response_data["output_tokens"] = usage["output_tokens"]
+
+        # Collect RAG chunks and tool calls from output items
+        rag_chunks: list[dict[str, str]] = []
+        tool_calls: list[list[dict[str, Any]]] = []
+        for item in response_data.get("output", []):
+            item_type = item.get("type")
+            if item_type == "file_search_call":
+                for result in item.get("results", []):
+                    text = result.get("text")
+                    if text:
+                        rag_chunks.append({"content": text})
+                tool_calls.append(
+                    [
+                        {
+                            "tool_name": "file_search",
+                            "arguments": {"queries": item.get("queries", [])},
+                        }
+                    ]
+                )
+            elif item_type == "mcp_call":
+                tool_calls.append([self._parse_mcp_call_item(item)])
+        if rag_chunks:
+            response_data["rag_chunks"] = rag_chunks
+        if tool_calls:
+            response_data["tool_calls"] = tool_calls
+
+    def _responses_query(self, api_request: APIRequest) -> APIResponse:
+        """Query the /responses endpoint.
+
+        Uses the OpenAI Responses API request/response format, adapting fields
+        to and from the internal APIRequest/APIResponse models.
+
+        Args:
+            api_request: The prepared API request.
+
+        Returns:
+            APIResponse with response text, token counts, and RAG contexts.
+
+        Raises:
+            APIError: If the request fails or response is invalid.
+        """
+        if not self.client:
+            raise APIError("HTTP client not initialized")
+        try:
+            responses_request = self._build_responses_request(api_request)
+
+            response = self.client.post(
+                f"/{self.config.version}/responses",
+                json=responses_request,
+            )
+            response.raise_for_status()
+
+            response_data = response.json()
+            self._extract_responses_data(response_data)
+
+            if "response" not in response_data:
+                raise APIError("API response missing 'response' field")
+
+            return APIResponse.from_raw_response(response_data)
+
+        except httpx.TimeoutException as e:
+            raise self._handle_timeout_error("responses", self.config.timeout) from e
+        except httpx.HTTPStatusError as e:
+            if _is_retryable_server_error(e):
+                raise
+            raise self._handle_http_error(e) from e
+        except ValueError as e:
+            raise self._handle_validation_error(e) from e
+        except APIError:
+            raise
+        except Exception as e:
+            raise self._handle_unexpected_error(e, "responses query") from e
 
     def _handle_response_errors(self, response: httpx.Response) -> None:
         """Handle HTTP response errors for streaming endpoint."""

--- a/src/lightspeed_evaluation/core/constants.py
+++ b/src/lightspeed_evaluation/core/constants.py
@@ -60,7 +60,7 @@ DEFAULT_API_BASE = "http://localhost:8080"
 DEFAULT_API_VERSION = "v1"
 DEFAULT_API_TIMEOUT = 300
 DEFAULT_ENDPOINT_TYPE = "streaming"
-SUPPORTED_ENDPOINT_TYPES = ["streaming", "query", "infer"]
+SUPPORTED_ENDPOINT_TYPES = ["streaming", "query", "infer", "responses"]
 
 DEFAULT_API_NUM_RETRIES = 3
 

--- a/src/lightspeed_evaluation/core/metrics/custom/tool_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/tool_eval.py
@@ -298,6 +298,15 @@ def _compare_single_tool_call(expected: dict[str, Any], actual: dict[str, Any]) 
     expected_name = expected.get("tool_name")
     actual_name = actual.get("tool_name")
 
+    # Surface tool-level errors reported by the server
+    if actual.get("error") is not None:
+        logger.debug(
+            "Tool call '%s' returned an error: %s",
+            actual_name,
+            actual["error"],
+        )
+        return False
+
     if expected_name != actual_name:
         logger.debug(
             "Tool name mismatch: expected '%s', got '%s'",
@@ -517,6 +526,25 @@ def _create_success_message(
     return True, f"{pattern_type} matched: {message}"
 
 
+def _extract_tool_errors(actual: list[list[dict[str, Any]]]) -> str:
+    """Extract error messages from actual tool calls, if any.
+
+    Args:
+        actual: Actual tool call sequences from API response.
+
+    Returns:
+        Comma-separated string of 'tool_name: error' pairs, or empty string.
+    """
+    errors = []
+    for sequence in actual:
+        for tool_call in sequence:
+            error = tool_call.get("error")
+            if error is not None:
+                tool_name = tool_call.get("tool_name", "unknown")
+                errors.append(f"{tool_name}: {error}")
+    return "; ".join(errors)
+
+
 def _create_failure_message(
     expected: list[list[list[dict[str, Any]]]],
     actual: list[list[dict[str, Any]]],
@@ -542,9 +570,12 @@ def _create_failure_message(
             "No actual tool calls made and this is not set as an expected alternative",
         )
 
+    tool_errors = _extract_tool_errors(actual)
+    error_suffix = f"; tool errors: [{tool_errors}]" if tool_errors else ""
+
     base_msg = (
         f"Tool calls made but didn't match any of the {len(expected)} "
-        f"expected pattern(s)"
+        f"expected pattern(s){error_suffix}"
     )
 
     if best_stats and not full_match:

--- a/tests/unit/core/api/conftest.py
+++ b/tests/unit/core/api/conftest.py
@@ -49,6 +49,21 @@ def basic_api_config_infer_endpoint() -> APIConfig:
 
 
 @pytest.fixture
+def basic_api_config_responses_endpoint() -> APIConfig:
+    """Create test API config for responses endpoint."""
+    return APIConfig(
+        enabled=True,
+        api_base="http://localhost:8080",
+        version="v1",
+        endpoint_type="responses",
+        timeout=30,
+        provider="openai",
+        model="gpt-4o-mini",
+        cache_enabled=False,
+    )
+
+
+@pytest.fixture
 def mock_response(mocker: MockerFixture) -> Any:
     """Create a mock streaming response."""
     response = mocker.Mock()

--- a/tests/unit/core/api/test_client_responses.py
+++ b/tests/unit/core/api/test_client_responses.py
@@ -1,0 +1,313 @@
+# pylint: disable=protected-access,duplicate-code
+
+"""Unit tests for APIClient /responses endpoint support."""
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from lightspeed_evaluation.core.api.client import APIClient
+from lightspeed_evaluation.core.models import APIConfig, APIResponse
+from lightspeed_evaluation.core.system.exceptions import APIError
+
+
+class TestResponsesEndpoint:
+    """Tests for /responses endpoint support."""
+
+    def test_query_responses_endpoint_success(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test successful query to responses endpoint with field mapping."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "output_text": "Test response text.",
+            "conversation": "conv-123",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        # Test that the client correctly maps response fields to APIResponse attributes
+        client = APIClient(basic_api_config_responses_endpoint)
+        result = client.query("test query")
+        assert isinstance(result, APIResponse)
+        assert result.response == "Test response text."
+        assert result.conversation_id == "conv-123"
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+
+        # Verify the correct endpoint was called with preprocessed request body
+        call_kwargs = mock_client.post.call_args
+        request_body = call_kwargs[1]["json"]
+        assert request_body["model"] == "openai/gpt-4o-mini"
+
+    def test_responses_extra_request_params_merged(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that extra_request_params (e.g. tools) are merged into the request."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "output_text": "Answer",
+            "conversation": "conv_abc",
+            "usage": {},
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        tools = [
+            {"type": "file_search", "vector_store_ids": ["okp"]},
+            {
+                "type": "mcp",
+                "server_label": "test-mcp",
+                "server_url": "http://host.docker.internal:3000",
+            },
+        ]
+
+        client = APIClient(basic_api_config_responses_endpoint)
+        client.query(
+            "test query",
+            conversation_id="conv_abc",
+            extra_request_params={"tools": tools, "store": True},
+        )
+
+        request_body = mock_client.post.call_args[1]["json"]
+        assert request_body["tools"] == tools
+        assert request_body["store"] is True
+
+    def test_responses_extracts_file_search_call_as_tool_call_and_rag_chunk(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that file_search_call items produce both RAG chunks and tool_calls."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "output_text": "Answer.",
+            "conversation": "conv_abc",
+            "usage": {},
+            "output": [
+                {"type": "mcp_list_tools", "tools": [{"name": "mock_tool"}]},
+                {
+                    "type": "file_search_call",
+                    "queries": ["test search query"],
+                    "results": [{"text": "Relevant chunk", "score": 1}],
+                },
+                {"type": "message", "content": []},
+            ],
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+        result = client.query("test query", conversation_id="conv_abc")
+
+        assert result.contexts == ["Relevant chunk"]
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0][0]["tool_name"] == "file_search"
+        assert result.tool_calls[0][0]["arguments"] == {
+            "queries": ["test search query"]
+        }
+
+    def test_responses_extracts_tool_calls_from_mcp_call_output_items(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that mcp_call output items are extracted as tool_calls."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "output_text": "Answer.",
+            "conversation": "conv_abc",
+            "usage": {},
+            "output": [
+                {"type": "mcp_list_tools", "tools": [{"name": "mock_tool_e2e"}]},
+                {
+                    "type": "mcp_call",
+                    "name": "mock_tool_e2e",
+                    "arguments": {"message": "hello"},
+                    "output": "tool result text",
+                },
+                {
+                    "type": "file_search_call",
+                    "results": [{"text": "RAG chunk", "score": 1}],
+                },
+            ],
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+        result = client.query("test query", conversation_id="conv_abc")
+
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0][0]["tool_name"] == "mock_tool_e2e"
+        assert result.tool_calls[0][0]["arguments"] == {"message": "hello"}
+        assert result.tool_calls[0][0]["result"] == "tool result text"
+        assert result.tool_calls[1][0]["tool_name"] == "file_search"
+        assert result.contexts == ["RAG chunk"]
+
+    def test_responses_mcp_call_with_error_field(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that mcp_call items with an error field capture it on the tool_call."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "output_text": "Answer.",
+            "conversation": "conv_abc",
+            "usage": {},
+            "output": [
+                {
+                    "type": "mcp_call",
+                    "name": "jira_get_issue",
+                    "arguments": {"issue_key": "PROJ-123"},
+                    "error": "Tool execution failed: permission denied",
+                },
+            ],
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+        result = client.query("test query", conversation_id="conv_abc")
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0][0]["tool_name"] == "jira_get_issue"
+        assert (
+            result.tool_calls[0][0]["error"]
+            == "Tool execution failed: permission denied"
+        )
+        assert "result" not in result.tool_calls[0][0]
+
+    def test_responses_missing_output_text_raises_error(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test that missing output_text raises APIError."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "conversation": "conv_abc",
+            "usage": {},
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+
+        with pytest.raises(APIError, match="missing 'response' field"):
+            client.query("test query", conversation_id="conv_abc")
+
+    def test_responses_query_timeout_error(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test responses query handles timeout."""
+        mock_client = mocker.Mock()
+        mock_client.post.side_effect = httpx.TimeoutException("Timeout")
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+
+        with pytest.raises(APIError, match="timeout"):
+            client.query("test query", conversation_id="conv_abc")
+
+    def test_responses_query_http_error_non_retryable(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test responses query raises APIError for non-retryable HTTP errors."""
+        mock_response = mocker.Mock(status_code=400, text="Bad request")
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400 error", request=mocker.Mock(), response=mock_response
+        )
+
+        mock_client = mocker.Mock()
+        mock_client.post.return_value = mock_response
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+
+        with pytest.raises(APIError, match="API error: 400"):
+            client.query("test query", conversation_id="conv_abc")
+
+    def test_responses_query_retries_on_429(
+        self, basic_api_config_responses_endpoint: APIConfig, mocker: MockerFixture
+    ) -> None:
+        """Test responses query retries on 429 then succeeds."""
+        mocker.patch("time.sleep")
+        mock_response_429 = mocker.Mock(status_code=429)
+        mock_response_429.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "429 error", request=mocker.Mock(), response=mock_response_429
+        )
+
+        mock_response_success = mocker.Mock(status_code=200)
+        mock_response_success.json.return_value = {
+            "output_text": "Success after retry",
+            "conversation": "conv_abc",
+            "usage": {},
+        }
+
+        mock_client = mocker.Mock()
+        mock_client.post.side_effect = [mock_response_429, mock_response_success]
+        mock_client.headers = {}
+
+        mocker.patch(
+            "lightspeed_evaluation.core.api.client.httpx.Client",
+            return_value=mock_client,
+        )
+
+        client = APIClient(basic_api_config_responses_endpoint)
+        result = client.query("test query", conversation_id="conv_abc")
+
+        assert result.response == "Success after retry"
+        assert mock_client.post.call_count == 2

--- a/tests/unit/core/metrics/custom/test_tool_eval.py
+++ b/tests/unit/core/metrics/custom/test_tool_eval.py
@@ -832,3 +832,56 @@ class TestToolCallWithResult:
 
         success, _ = evaluate_tool_calls(expected, actual)
         assert success is True
+
+
+class TestToolCallErrorHandling:
+    """Test cases for tool call error field handling."""
+
+    def test_actual_tool_call_with_error_fails(self) -> None:
+        """Tool call with an error field is treated as a mismatch."""
+        expected = {"tool_name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}}
+        actual = {
+            "tool_name": "jira_get_issue",
+            "arguments": {"issue_key": "PROJ-1"},
+            "error": "permission denied",
+        }
+
+        result = _compare_single_tool_call(expected, actual)
+        assert result is False
+
+    def test_actual_tool_call_without_error_passes(self) -> None:
+        """Tool call without error field compares normally."""
+        expected = {"tool_name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}}
+        actual = {"tool_name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}}
+
+        result = _compare_single_tool_call(expected, actual)
+        assert result is True
+
+    def test_failure_message_includes_multiple_tool_errors(self) -> None:
+        """Failure reason includes all tool errors when multiple calls errored."""
+        expected = [
+            [
+                [{"tool_name": "tool_a", "arguments": {}}],
+                [{"tool_name": "tool_b", "arguments": {}}],
+            ]
+        ]
+        actual = [
+            [{"tool_name": "tool_a", "arguments": {}, "error": "timeout"}],
+            [{"tool_name": "tool_b", "arguments": {}, "error": "not found"}],
+        ]
+
+        success, reason = evaluate_tool_calls(expected, actual)
+        assert success is False
+        assert "timeout" in reason
+        assert "not found" in reason
+
+    def test_no_error_field_failure_message_unchanged(self) -> None:
+        """Failure reason does not mention tool errors when none occurred."""
+        expected = [
+            [[{"tool_name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}}]]
+        ]
+        actual = [[{"tool_name": "wrong_tool", "arguments": {}}]]
+
+        success, reason = evaluate_tool_calls(expected, actual)
+        assert success is False
+        assert "tool errors" not in reason


### PR DESCRIPTION
## Description

- Added basic support for lightspeed stacks `/responses` endpoint.
- Working example with okp added to `examples/`
- Added unit test coverage
- support for `stream=True` is not covered in this PR!

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `responses` API endpoint type in evaluation configurations
  * Enhanced tool-call error reporting to include error details in evaluation feedback

* **Documentation**
  * Added example evaluation demonstrating the `responses` endpoint with file search integration

* **Tests**
  * Added comprehensive test coverage for responses endpoint functionality and tool-call error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->