### PR TITLE
[LEADS-389] Support user-defined metadata in evaluation data format for GDS quality grading and traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ For field tables, full YAML examples (file-only, file + SQLite, file + Postgres)
 | Field                           | Type           | Required | Description                                                          |
 |---------------------------------|----------------|----------|----------------------------------------------------------------------|
 | `conversation_group_id`         | string         | ✅       | Unique identifier for conversation                                   |
+| `metadata`                      | ConversationMetadata | ❌ | User-defined metadata for traceability and quality grading           |
 | `description`                   | string         | ❌       | Optional description                                                 |
 | `tag`                           | string         | ❌       | Tag for grouping eval conversations (default: "eval")             |
 | `setup_script`                  | string         | ❌       | Path to setup script (Optional, used when API is enabled)            |

--- a/src/lightspeed_evaluation/__init__.py
+++ b/src/lightspeed_evaluation/__init__.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from lightspeed_evaluation.core.llm import LLMManager
     from lightspeed_evaluation.core.models import (
         APIConfig,
+        ConversationMetadata,
+        DatasetMetadata,
         EvaluationData,
         EvaluationResult,
         LLMConfig,
@@ -79,6 +81,11 @@ _LAZY_IMPORTS = {
     "VisualizationConfig": ("lightspeed_evaluation.core.models", "VisualizationConfig"),
     "EvaluationData": ("lightspeed_evaluation.core.models", "EvaluationData"),
     "TurnData": ("lightspeed_evaluation.core.models", "TurnData"),
+    "ConversationMetadata": (
+        "lightspeed_evaluation.core.models",
+        "ConversationMetadata",
+    ),
+    "DatasetMetadata": ("lightspeed_evaluation.core.models", "DatasetMetadata"),
     "EvaluationResult": ("lightspeed_evaluation.core.models", "EvaluationResult"),
     "EvaluationSummary": (
         "lightspeed_evaluation.core.models.summary",

--- a/src/lightspeed_evaluation/api.py
+++ b/src/lightspeed_evaluation/api.py
@@ -23,7 +23,7 @@ For structured results with computed statistics::
     print(summary.by_metric)
 """
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from lightspeed_evaluation.core.models import (
     EvaluationData,
@@ -35,22 +35,31 @@ from lightspeed_evaluation.core.models.summary import EvaluationSummary
 from lightspeed_evaluation.core.system import ConfigLoader
 from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
+if TYPE_CHECKING:
+    from lightspeed_evaluation.core.models.data import DatasetMetadata
+
 
 def evaluate(
     config: SystemConfig,
     data: list[EvaluationData],
     output_dir: Optional[str] = None,
+    original_data_path: Optional[str] = None,
+    dataset_metadata: Optional["DatasetMetadata"] = None,
 ) -> list[EvaluationResult]:
     """Run evaluation on the provided data using the given configuration.
 
     Creates a fully-initialized pipeline from the ``SystemConfig``, runs
-    evaluation on every conversation in *data*, and returns the raw results.
+    evaluation on every conversations in *data*, and returns the raw results.
     No reports are generated -- file I/O is the caller's responsibility.
 
     Args:
         config: A pre-built SystemConfig instance.
         data: List of EvaluationData conversations to evaluate.
         output_dir: Optional override for the output directory.
+        original_data_path: Path to the original evaluation data file.
+            Required for saving amended data when agents are enabled.
+        dataset_metadata: Optional dataset-level metadata to preserve in
+            amended output files.
 
     Returns:
         List of EvaluationResult objects (one per metric per turn/conversation).
@@ -61,7 +70,11 @@ def evaluate(
     loader = ConfigLoader.from_config(config)
     pipeline = EvaluationPipeline(loader, output_dir)
     try:
-        return pipeline.run_evaluation(data)
+        return pipeline.run_evaluation(
+            data,
+            original_data_path=original_data_path,
+            dataset_metadata=dataset_metadata,
+        )
     finally:
         pipeline.close()
 

--- a/src/lightspeed_evaluation/core/models/__init__.py
+++ b/src/lightspeed_evaluation/core/models/__init__.py
@@ -14,6 +14,8 @@ from lightspeed_evaluation.core.models.api import (
     AttachmentData,
 )
 from lightspeed_evaluation.core.models.data import (
+    ConversationMetadata,
+    DatasetMetadata,
     EvaluationData,
     EvaluationRequest,
     EvaluationResult,
@@ -62,6 +64,8 @@ __all__ = [
     # Data models
     "TurnData",
     "EvaluationData",
+    "ConversationMetadata",
+    "DatasetMetadata",
     "EvaluationRequest",
     "JudgeScore",
     "MetricResult",

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -12,6 +12,89 @@ from lightspeed_evaluation.core.models.mixins import StreamingMetricsMixin
 logger = logging.getLogger(__name__)
 
 
+class ConversationMetadata(BaseModel):
+    """Optional user-defined metadata for a conversation group."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_category: Optional[str] = Field(
+        default=None,
+        description=(
+            "Scenario category (e.g. Core/Happy path,"
+            " Edge Case, Negative/Adversarial,"
+            " Negative/Ambiguous, Negative/I-dont-know)"
+        ),
+    )
+    use_case: Optional[str] = Field(
+        default=None,
+        description="System capability (e.g. RAG, Agent/Tools)",
+    )
+    interaction_type: Optional[str] = Field(
+        default=None,
+        description="Interaction type (e.g. Single-turn, Multi-turn)",
+    )
+    topic: Optional[str] = Field(
+        default=None,
+        description="Domain subject area (e.g. networking, storage)",
+    )
+    jtbd_reference: Optional[str] = Field(
+        default=None, description="Jobs-to-be-done reference (Job/Task)"
+    )
+    complexity: Optional[str] = Field(
+        default=None,
+        description="Complexity level (e.g. Simple, Moderate, Complex)",
+    )
+    data_source: Optional[str] = Field(
+        default=None,
+        description="Data source (e.g. Human-written, Production log, Synthetic)",
+    )
+    human_verified: Optional[bool] = Field(
+        default=None, description="Whether a domain expert verified this conversation"
+    )
+    verified_by: Optional[str] = Field(default=None, description="Verifier name or ID")
+    persona: Optional[str] = Field(
+        default=None,
+        description="User persona represented (e.g. developer, admin, beginner)",
+    )
+    additional_metadata: Optional[dict[str, Any]] = Field(
+        default=None, description="Arbitrary key-value pairs for extra metadata"
+    )
+
+
+class DatasetMetadata(BaseModel):
+    """Optional user-defined metadata for the entire evaluation dataset."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: Optional[str] = Field(
+        default=None, description="Brief description of the dataset"
+    )
+    jtbd_source: Optional[str] = Field(
+        default=None, description="Jobs-to-be-done source reference"
+    )
+    team_product: Optional[str] = Field(
+        default=None, description="Owning team or product (with contact details)"
+    )
+    dataset_version: Optional[str] = Field(
+        default=None, description="Dataset version for tracking iterations"
+    )
+    pii_confirmed_removed: Optional[bool] = Field(
+        default=None, description="Whether PII has been confirmed removed"
+    )
+    generation_tools: Optional[list[str]] = Field(
+        default=None, description="Tools used for synthetic data generation"
+    )
+    llms_used: Optional[list[str]] = Field(
+        default=None, description="LLMs used in the generation pipeline"
+    )
+    last_updated: Optional[str] = Field(
+        default=None, description="Date the dataset was last updated (e.g. 2025-06-15)"
+    )
+    additional_metadata: Optional[dict[str, Any]] = Field(
+        default=None, description="Arbitrary key-value pairs for extra metadata"
+    )
+
+
 def _validate_and_deduplicate_metrics(
     metrics: list[str], metric_type: str = "metric"
 ) -> list[str]:
@@ -427,6 +510,10 @@ class EvaluationData(BaseModel):
 
     conversation_group_id: str = Field(
         ..., min_length=1, description="Unique conversation group identifier"
+    )
+    metadata: Optional[ConversationMetadata] = Field(
+        default=None,
+        description="User-defined metadata for traceability and quality grading",
     )
     description: Optional[str] = Field(
         default=None,

--- a/src/lightspeed_evaluation/core/output/data_persistence.py
+++ b/src/lightspeed_evaluation/core/output/data_persistence.py
@@ -2,21 +2,28 @@
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 
 from lightspeed_evaluation.core.constants import DEFAULT_OUTPUT_DIR
 from lightspeed_evaluation.core.models import EvaluationData
+from lightspeed_evaluation.core.models.data import DatasetMetadata
 
 
-# Use caching
 def save_evaluation_data(
     evaluation_data: list[EvaluationData],
     original_data_path: str,
     output_dir: str = DEFAULT_OUTPUT_DIR,
+    dataset_metadata: Optional[DatasetMetadata] = None,
 ) -> Optional[str]:
-    """Save amended evaluation data to output directory with timestamp."""
+    """Save amended evaluation data to output directory with timestamp.
+
+    When *dataset_metadata* is provided the file is written in the dict
+    format (``metadata`` + ``conversations`` keys) so that dataset-level
+    metadata is preserved across amend cycles.  Without metadata the
+    original list format is used for backward compatibility.
+    """
     original_path = Path(original_data_path)
     amended_data_path = None
 
@@ -33,10 +40,21 @@ def save_evaluation_data(
             / f"{original_path.stem}_amended_{timestamp}{original_path.suffix}"
         )
 
+        conversations = [
+            conv_data.model_dump(mode="json") for conv_data in evaluation_data
+        ]
+
+        output_data: Any = conversations
+        if dataset_metadata is not None:
+            output_data = {
+                "metadata": dataset_metadata.model_dump(mode="json", exclude_none=True),
+                "conversations": conversations,
+            }
+
         # Save amended data to output directory
         with open(amended_data_path, "w", encoding="utf-8") as f:
             yaml.dump(
-                [conv_data.model_dump(mode="json") for conv_data in evaluation_data],
+                output_data,
                 f,
                 default_flow_style=False,
                 sort_keys=False,

--- a/src/lightspeed_evaluation/core/system/validator.py
+++ b/src/lightspeed_evaluation/core/system/validator.py
@@ -8,6 +8,7 @@ import yaml
 from pydantic import ValidationError
 
 from lightspeed_evaluation.core.models import EvaluationData, TurnData
+from lightspeed_evaluation.core.models.data import DatasetMetadata
 from lightspeed_evaluation.core.system.exceptions import DataValidationError
 
 if TYPE_CHECKING:
@@ -167,6 +168,7 @@ class DataValidator:  # pylint: disable=too-few-public-methods
         """
         self.validation_errors: list[str] = []
         self.evaluation_data: Optional[list[EvaluationData]] = None
+        self.dataset_metadata: Optional[DatasetMetadata] = None
         self.api_enabled = api_enabled
         self.original_data_path: Optional[str] = None
         self.fail_on_invalid_data = fail_on_invalid_data
@@ -188,6 +190,15 @@ class DataValidator:  # pylint: disable=too-few-public-methods
 
     def _load_and_parse_yaml(self, data_path: str) -> list[EvaluationData]:
         """Load a YAML file and convert each entry to an EvaluationData model.
+
+        Supports two root formats for backward compatibility:
+
+        1. **List format** (original): YAML root is a list of conversations.
+        2. **Dict format** (new): YAML root is a dict with optional ``metadata``
+           and required ``conversations`` keys.
+
+        When the dict format is used, dataset-level metadata is parsed and
+        stored on ``self.dataset_metadata``.
 
         Args:
             data_path: Path to the evaluation data YAML file.
@@ -211,13 +222,12 @@ class DataValidator:  # pylint: disable=too-few-public-methods
 
         if raw_data is None:
             raise DataValidationError("Empty or invalid YAML file")
-        if not isinstance(raw_data, list):
-            raise DataValidationError(
-                f"YAML root must be a list, got {type(raw_data).__name__}"
-            )
+
+        self.dataset_metadata = None
+        raw_conversations = self._extract_conversations_and_metadata(raw_data)
 
         evaluation_data = []
-        for i, data_dict in enumerate(raw_data):
+        for i, data_dict in enumerate(raw_conversations):
             try:
                 eval_data = EvaluationData(**data_dict)
                 evaluation_data.append(eval_data)
@@ -234,6 +244,57 @@ class DataValidator:  # pylint: disable=too-few-public-methods
                     f"Failed to parse evaluation data item {i + 1}: {e}"
                 ) from e
         return evaluation_data
+
+    def _extract_conversations_and_metadata(self, raw_data: object) -> list[dict]:
+        """Extract conversation list and optional dataset metadata from raw YAML.
+
+        Args:
+            raw_data: Parsed YAML data (list or dict).
+
+        Returns:
+            List of raw conversation dicts.
+
+        Raises:
+            DataValidationError: If the structure is invalid.
+        """
+        if isinstance(raw_data, list):
+            return raw_data
+
+        if isinstance(raw_data, dict):
+            if "conversations" not in raw_data:
+                raise DataValidationError(
+                    "YAML root is a dict but missing required 'conversations' key. "
+                    "Expected either a list of conversations or a dict with "
+                    "'conversations' (and optional 'metadata') keys."
+                )
+
+            metadata_raw = raw_data.get("metadata")
+            if metadata_raw is not None:
+                if not isinstance(metadata_raw, dict):
+                    raise DataValidationError(
+                        f"'metadata' must be a mapping, "
+                        f"got {type(metadata_raw).__name__}"
+                    )
+                try:
+                    self.dataset_metadata = DatasetMetadata(**metadata_raw)
+                except ValidationError as e:
+                    error_details = format_pydantic_error(e)
+                    raise DataValidationError(
+                        f"Invalid dataset metadata: {error_details}"
+                    ) from e
+
+            raw_conversations = raw_data["conversations"]
+            if not isinstance(raw_conversations, list):
+                raise DataValidationError(
+                    "'conversations' must be a list, "
+                    f"got {type(raw_conversations).__name__}"
+                )
+            return raw_conversations
+
+        raise DataValidationError(
+            f"YAML root must be a list or a dict with 'conversations' key, "
+            f"got {type(raw_data).__name__}"
+        )
 
     def _apply_metrics_filter(
         self, evaluation_data: list[EvaluationData], metrics: list[str]

--- a/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
@@ -4,7 +4,7 @@ import asyncio
 import concurrent.futures
 import logging
 from collections.abc import Callable, Coroutine
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import litellm
 import tqdm
@@ -37,6 +37,9 @@ from lightspeed_evaluation.pipeline.evaluation.processor import (
     ProcessorComponents,
 )
 from lightspeed_evaluation.pipeline.evaluation.registry import AgentDriverRegistry
+
+if TYPE_CHECKING:
+    from lightspeed_evaluation.core.models.data import DatasetMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -167,12 +170,15 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
         self,
         evaluation_data: list[EvaluationData],
         original_data_path: Optional[str] = None,
+        dataset_metadata: Optional["DatasetMetadata"] = None,
     ) -> list[EvaluationResult]:
         """Run evaluation on provided data.
 
         Args:
             evaluation_data: List of conversation data to evaluate
             original_data_path: Path to original data file for saving updates
+            dataset_metadata: Optional dataset-level metadata to preserve in
+                amended output.
 
         Returns:
             List of evaluation results.
@@ -194,7 +200,7 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
 
         if self.system_config.agents is not None and self.system_config.agents.enabled:
             logger.info("Saving amended evaluation data")
-            self._save_amended_data(evaluation_data)
+            self._save_amended_data(evaluation_data, dataset_metadata)
 
         logger.info("Evaluation complete: %d results generated", len(results))
         return results
@@ -235,7 +241,11 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
             if is_per_conversation:
                 driver.close()
 
-    def _save_amended_data(self, evaluation_data: list[EvaluationData]) -> None:
+    def _save_amended_data(
+        self,
+        evaluation_data: list[EvaluationData],
+        dataset_metadata: Optional["DatasetMetadata"] = None,
+    ) -> None:
         """Save amended evaluation data with API amendments to output directory."""
         if not self.original_data_path:
             logger.warning("No original data path available, cannot save amended data")
@@ -243,7 +253,10 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
 
         try:
             amended_file = save_evaluation_data(
-                evaluation_data, self.original_data_path, self.output_dir
+                evaluation_data,
+                self.original_data_path,
+                self.output_dir,
+                dataset_metadata=dataset_metadata,
             )
             if amended_file:
                 logger.info("Amended data saved: %s", amended_file)

--- a/src/lightspeed_evaluation/runner/evaluation.py
+++ b/src/lightspeed_evaluation/runner/evaluation.py
@@ -148,17 +148,19 @@ def run_evaluation(  # pylint: disable=too-many-locals
         print("✅ Configuration loaded & Setup is done !")
 
         # Load, filter, and validate evaluation data
-        evaluation_data = DataValidator(
+        data_validator = DataValidator(
             api_enabled=system_config.agents is not None
             and system_config.agents.enabled,
             fail_on_invalid_data=system_config.core.fail_on_invalid_data,
             system_config=system_config,
-        ).load_evaluation_data(
+        )
+        evaluation_data = data_validator.load_evaluation_data(
             eval_args.eval_data,
             tags=eval_args.tags,
             conv_ids=eval_args.conv_ids,
             metrics=eval_args.metrics,
         )
+        dataset_metadata = data_validator.dataset_metadata
 
         print(
             f"✅ System config: {system_config.llm.provider}/{system_config.llm.model}"
@@ -175,7 +177,11 @@ def run_evaluation(  # pylint: disable=too-many-locals
 
         print("\n🔄 Running Evaluation...")
         results = evaluate(
-            system_config, evaluation_data, output_dir=eval_args.output_dir
+            system_config,
+            evaluation_data,
+            output_dir=eval_args.output_dir,
+            original_data_path=eval_args.eval_data,
+            dataset_metadata=dataset_metadata,
         )
 
         file_entries = [

--- a/tests/unit/core/models/test_data.py
+++ b/tests/unit/core/models/test_data.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from lightspeed_evaluation.core.models.data import (
+    ConversationMetadata,
+    DatasetMetadata,
     EvaluationData,
     EvaluationResult,
     JudgeScore,
@@ -719,3 +721,107 @@ class TestEvaluationDataAgentFields:
                 agent="",
                 turns=[TurnData(turn_id="t1", query="Q")],
             )
+
+
+class TestConversationMetadata:
+    """Tests for ConversationMetadata model."""
+
+    def test_defaults_to_none_and_accepts_all_fields(self) -> None:
+        """Empty construction defaults to None; all fields are assignable."""
+        assert ConversationMetadata().scenario_category is None
+
+        meta = ConversationMetadata(
+            scenario_category="Core/Happy path",
+            use_case="RAG",
+            interaction_type="Multi-turn",
+            topic="networking",
+            jtbd_reference="JTBD-001",
+            complexity="Complex",
+            data_source="Human-written",
+            human_verified=True,
+            verified_by="jane.doe",
+            persona="admin",
+            additional_metadata={"region": "EMEA"},
+        )
+        assert meta.scenario_category == "Core/Happy path"
+        assert meta.use_case == "RAG"
+        assert meta.complexity == "Complex"
+        assert meta.human_verified is True
+        assert meta.persona == "admin"
+        assert meta.additional_metadata == {"region": "EMEA"}
+
+    def test_extra_fields_forbidden(self) -> None:
+        """ConversationMetadata rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            ConversationMetadata.model_validate({"unknown": "x"})
+
+    def test_optional_on_evaluation_data(self) -> None:
+        """EvaluationData accepts metadata and defaults to None without it."""
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        assert data.metadata is None
+
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            turns=[TurnData(turn_id="t1", query="Q")],
+            metadata=ConversationMetadata(scenario_category="Edge Case"),
+        )
+        assert data.metadata is not None
+        assert data.metadata.scenario_category == "Edge Case"
+
+    def test_serialization_round_trip(self) -> None:
+        """ConversationMetadata survives model_dump / model_validate."""
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            turns=[TurnData(turn_id="t1", query="Q")],
+            metadata=ConversationMetadata(
+                use_case="Agent/Tools", additional_metadata={"region": "EMEA"}
+            ),
+        )
+        restored = EvaluationData.model_validate(data.model_dump(mode="json"))
+        assert restored.metadata is not None
+        assert restored.metadata.use_case == "Agent/Tools"
+
+
+class TestDatasetMetadata:
+    """Tests for DatasetMetadata model."""
+
+    def test_defaults_to_none_and_accepts_all_fields(self) -> None:
+        """Empty construction defaults to None; all fields are assignable."""
+        assert DatasetMetadata().team_product is None
+
+        meta = DatasetMetadata(
+            description="OLS evaluation dataset",
+            jtbd_source="JTBD-2025-Q2",
+            team_product="Team LEADS / OLS",
+            dataset_version="1.2.0",
+            pii_confirmed_removed=True,
+            generation_tools=["SDG-hub", "Ragas"],
+            llms_used=["gpt-4o", "granite-3.2"],
+            last_updated="2025-06-15",
+            additional_metadata={"env": "staging"},
+        )
+        assert meta.description == "OLS evaluation dataset"
+        assert meta.jtbd_source == "JTBD-2025-Q2"
+        assert meta.team_product == "Team LEADS / OLS"
+        assert meta.pii_confirmed_removed is True
+        assert meta.generation_tools == ["SDG-hub", "Ragas"]
+        assert meta.last_updated == "2025-06-15"
+
+    def test_extra_fields_forbidden(self) -> None:
+        """DatasetMetadata rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            DatasetMetadata.model_validate({"bad_field": 123})
+
+    def test_serialization_round_trip(self) -> None:
+        """DatasetMetadata survives model_dump / model_validate."""
+        meta = DatasetMetadata(
+            team_product="OLS",
+            pii_confirmed_removed=True,
+            additional_metadata={"grade": "Gold"},
+        )
+        restored = DatasetMetadata.model_validate(meta.model_dump(mode="json"))
+        assert restored.team_product == "OLS"
+        assert restored.additional_metadata == {"grade": "Gold"}

--- a/tests/unit/core/output/test_data_persistence.py
+++ b/tests/unit/core/output/test_data_persistence.py
@@ -5,6 +5,10 @@ from pathlib import Path
 import yaml
 
 from lightspeed_evaluation.core.models import EvaluationData, TurnData
+from lightspeed_evaluation.core.models.data import (
+    ConversationMetadata,
+    DatasetMetadata,
+)
 from lightspeed_evaluation.core.output.data_persistence import save_evaluation_data
 
 
@@ -180,3 +184,119 @@ def test_save_evaluation_data_error_handling(tmp_path: Path) -> None:
 
     # Should return None on error
     assert result is None
+
+
+def test_save_evaluation_data_with_dataset_metadata(tmp_path: Path) -> None:
+    """Test that dataset metadata is preserved in the dict-format output."""
+    dataset_meta = DatasetMetadata(
+        team_product="Team LEADS",
+        dataset_version="1.0",
+        pii_confirmed_removed=True,
+        generation_tools=["SDG-hub"],
+        llms_used=["gpt-4o"],
+        additional_metadata={"grade": "Gold"},
+    )
+    evaluation_data = [
+        EvaluationData(
+            conversation_group_id="conv1",
+            turns=[TurnData(turn_id="t1", query="Q", response="A")],
+        )
+    ]
+
+    temp_eval_file = tmp_path / "test_eval.yaml"
+    temp_eval_file.write_text("# placeholder\n")
+
+    output_file = save_evaluation_data(
+        evaluation_data=evaluation_data,
+        original_data_path=str(temp_eval_file),
+        output_dir=str(tmp_path),
+        dataset_metadata=dataset_meta,
+    )
+
+    assert output_file is not None
+    with open(output_file, "r", encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+
+    # Should be dict format with metadata + conversations
+    assert isinstance(saved, dict)
+    assert "metadata" in saved
+    assert "conversations" in saved
+    assert saved["metadata"]["team_product"] == "Team LEADS"
+    assert saved["metadata"]["dataset_version"] == "1.0"
+    assert saved["metadata"]["pii_confirmed_removed"] is True
+    assert saved["metadata"]["generation_tools"] == ["SDG-hub"]
+    assert saved["metadata"]["llms_used"] == ["gpt-4o"]
+    assert saved["metadata"]["additional_metadata"] == {"grade": "Gold"}
+    assert len(saved["conversations"]) == 1
+    assert saved["conversations"][0]["conversation_group_id"] == "conv1"
+
+
+def test_save_evaluation_data_without_dataset_metadata_uses_list(
+    tmp_path: Path,
+) -> None:
+    """Test that omitting dataset metadata keeps the original list format."""
+    evaluation_data = [
+        EvaluationData(
+            conversation_group_id="conv1",
+            turns=[TurnData(turn_id="t1", query="Q", response="A")],
+        )
+    ]
+
+    temp_eval_file = tmp_path / "test_eval.yaml"
+    temp_eval_file.write_text("# placeholder\n")
+
+    output_file = save_evaluation_data(
+        evaluation_data=evaluation_data,
+        original_data_path=str(temp_eval_file),
+        output_dir=str(tmp_path),
+    )
+
+    assert output_file is not None
+    with open(output_file, "r", encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+
+    assert isinstance(saved, list)
+    assert len(saved) == 1
+
+
+def test_save_preserves_conversation_metadata(tmp_path: Path) -> None:
+    """Test that conversation-level metadata round-trips via save."""
+    evaluation_data = [
+        EvaluationData(
+            conversation_group_id="conv1",
+            metadata=ConversationMetadata(
+                scenario_category="Edge Case",
+                use_case="RAG",
+                complexity="Complex",
+                human_verified=True,
+                additional_metadata={"priority": "high"},
+            ),
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="Q",
+                    response="A",
+                )
+            ],
+        )
+    ]
+
+    temp_eval_file = tmp_path / "test_eval.yaml"
+    temp_eval_file.write_text("# placeholder\n")
+
+    output_file = save_evaluation_data(
+        evaluation_data=evaluation_data,
+        original_data_path=str(temp_eval_file),
+        output_dir=str(tmp_path),
+    )
+
+    assert output_file is not None
+    with open(output_file, "r", encoding="utf-8") as f:
+        saved = yaml.safe_load(f)
+
+    conv = saved[0]
+    assert conv["metadata"]["scenario_category"] == "Edge Case"
+    assert conv["metadata"]["use_case"] == "RAG"
+    assert conv["metadata"]["complexity"] == "Complex"
+    assert conv["metadata"]["human_verified"] is True
+    assert conv["metadata"]["additional_metadata"] == {"priority": "high"}

--- a/tests/unit/core/system/test_validator.py
+++ b/tests/unit/core/system/test_validator.py
@@ -344,15 +344,17 @@ class TestDataValidator:
         finally:
             Path(temp_path).unlink()
 
-    def test_load_evaluation_data_not_list(self) -> None:
-        """Test loading YAML with non-list root raises error."""
+    def test_load_evaluation_data_dict_without_conversations_key(self) -> None:
+        """Test loading YAML dict without 'conversations' key raises error."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("conversation_group_id: test\n")
             temp_path = f.name
 
         try:
             validator = DataValidator()
-            with pytest.raises(DataValidationError, match="must be a list"):
+            with pytest.raises(
+                DataValidationError, match="missing required 'conversations' key"
+            ):
                 validator.load_evaluation_data(temp_path)
         finally:
             Path(temp_path).unlink()
@@ -711,3 +713,213 @@ class TestMetricsFilter:
             metrics=["deepeval:conversation_completeness"],
         )
         assert result[0].conversation_metrics == ["deepeval:conversation_completeness"]
+
+
+class TestMetadataLoading:
+    """Tests for user-defined metadata loading at dataset, conversation, and turn levels."""
+
+    def test_scalar_root_raises(self) -> None:
+        """Test loading YAML with a scalar root raises error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("just a string\n")
+            temp_path = f.name
+
+        try:
+            validator = DataValidator()
+            with pytest.raises(DataValidationError, match="must be a list or a dict"):
+                validator.load_evaluation_data(temp_path)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_dict_format_with_dataset_metadata(self, mocker: MockerFixture) -> None:
+        """Dict root with metadata and additional_metadata loads correctly."""
+        yaml_data = {
+            "metadata": {
+                "team_product": "Team LEADS",
+                "dataset_version": "1.0",
+                "pii_confirmed_removed": True,
+                "additional_metadata": {"grade": "Gold"},
+            },
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert len(result) == 1
+        assert validator.dataset_metadata is not None
+        assert validator.dataset_metadata.team_product == "Team LEADS"
+        assert validator.dataset_metadata.pii_confirmed_removed is True
+        assert validator.dataset_metadata.additional_metadata == {"grade": "Gold"}
+
+    def test_dict_format_without_metadata_key(self, mocker: MockerFixture) -> None:
+        """Dict root without metadata key still loads conversations."""
+        yaml_data = {
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert len(result) == 1
+        assert validator.dataset_metadata is None
+
+    def test_null_metadata_treated_as_absent(self, mocker: MockerFixture) -> None:
+        """metadata: null is silently ignored (same as omitted)."""
+        yaml_data = {
+            "metadata": None,
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert len(result) == 1
+        assert validator.dataset_metadata is None
+
+    def test_non_dict_metadata_raises(self, mocker: MockerFixture) -> None:
+        """Non-mapping metadata value raises DataValidationError."""
+        yaml_data = {
+            "metadata": "not a mapping",
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        with pytest.raises(DataValidationError, match="'metadata' must be a mapping"):
+            validator.load_evaluation_data("dummy.yaml")
+
+    def test_invalid_dataset_metadata_raises(self, mocker: MockerFixture) -> None:
+        """Unknown field in dataset metadata raises DataValidationError."""
+        yaml_data = {
+            "metadata": {"unknown_field": "bad"},
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        with pytest.raises(DataValidationError, match="Invalid dataset metadata"):
+            validator.load_evaluation_data("dummy.yaml")
+
+    def test_dict_conversations_not_list_raises(self, mocker: MockerFixture) -> None:
+        """Non-list conversations value in dict format raises error."""
+        yaml_data = {"conversations": "not a list"}
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        with pytest.raises(DataValidationError, match="'conversations' must be a list"):
+            validator.load_evaluation_data("dummy.yaml")
+
+    def test_conversation_metadata(self, mocker: MockerFixture) -> None:
+        """Conversation-level metadata is parsed from YAML."""
+        yaml_data = [
+            {
+                "conversation_group_id": "conv1",
+                "metadata": {
+                    "scenario_category": "Core/Happy path",
+                    "use_case": "RAG",
+                    "complexity": "Complex",
+                    "human_verified": True,
+                    "persona": "developer",
+                },
+                "turns": [
+                    {
+                        "turn_id": "t1",
+                        "query": "Q",
+                        "response": "A",
+                    }
+                ],
+            },
+        ]
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert result[0].metadata is not None
+        assert result[0].metadata.scenario_category == "Core/Happy path"
+        assert result[0].metadata.use_case == "RAG"
+        assert result[0].metadata.complexity == "Complex"
+        assert result[0].metadata.human_verified is True
+        assert result[0].metadata.persona == "developer"
+
+    def test_dataset_and_conversation_metadata_together(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Dataset and conversation metadata coexist in one file."""
+        yaml_data = {
+            "metadata": {"team_product": "OLS Team"},
+            "conversations": [
+                {
+                    "conversation_group_id": "conv1",
+                    "metadata": {
+                        "scenario_category": "Edge Case",
+                        "complexity": "Simple",
+                        "additional_metadata": {"priority": "high"},
+                    },
+                    "turns": [
+                        {
+                            "turn_id": "t1",
+                            "query": "Q",
+                            "response": "A",
+                        }
+                    ],
+                },
+            ],
+        }
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert validator.dataset_metadata is not None
+        assert validator.dataset_metadata.team_product == "OLS Team"
+        assert result[0].metadata is not None
+        assert result[0].metadata.scenario_category == "Edge Case"
+        assert result[0].metadata.complexity == "Simple"
+        assert result[0].metadata.additional_metadata == {"priority": "high"}
+
+    def test_no_metadata_backward_compatibility(self, mocker: MockerFixture) -> None:
+        """Existing list-format files without metadata still work unchanged."""
+        yaml_data = [
+            {
+                "conversation_group_id": "conv1",
+                "turns": [{"turn_id": "t1", "query": "Q", "response": "A"}],
+            },
+        ]
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+        mocker.patch("yaml.safe_load", return_value=yaml_data)
+        validator = DataValidator()
+        result = validator.load_evaluation_data("dummy.yaml")
+
+        assert len(result) == 1
+        assert validator.dataset_metadata is None
+        assert result[0].metadata is None

--- a/tests/unit/runner/test_evaluation.py
+++ b/tests/unit/runner/test_evaluation.py
@@ -170,8 +170,14 @@ class TestRunEvaluation:
         assert result is not None
         assert result["TOTAL"] == 1
         assert result["PASS"] == 1
-        mock_evaluate.assert_called_once_with(
-            mock_config, mock_eval_data, output_dir=None
+        mock_evaluate.assert_called_once()
+        call_args = mock_evaluate.call_args
+        assert call_args[0] == (mock_config, mock_eval_data)
+        assert call_args[1]["output_dir"] is None
+        assert call_args[1]["original_data_path"] == "config/evaluation_data.yaml"
+        assert (
+            call_args[1]["dataset_metadata"]
+            is mock_validator.return_value.dataset_metadata
         )
 
     def test_run_evaluation_with_output_dir_override(
@@ -216,9 +222,14 @@ class TestRunEvaluation:
 
         run_evaluation(_make_eval_args(output_dir="/custom/output"))
 
-        # Verify custom output dir was passed to evaluate()
-        mock_evaluate.assert_called_once_with(
-            mock_config, mock_eval_data, output_dir="/custom/output"
+        mock_evaluate.assert_called_once()
+        call_args = mock_evaluate.call_args
+        assert call_args[0] == (mock_config, mock_eval_data)
+        assert call_args[1]["output_dir"] == "/custom/output"
+        assert call_args[1]["original_data_path"] == "config/evaluation_data.yaml"
+        assert (
+            call_args[1]["dataset_metadata"]
+            is mock_validator.return_value.dataset_metadata
         )
 
     def test_run_evaluation_file_not_found(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -44,7 +44,9 @@ class TestEvaluate:
         results = evaluate(config, data)
 
         assert results == mock_results
-        mock_pipeline.run_evaluation.assert_called_once_with(data)
+        mock_pipeline.run_evaluation.assert_called_once_with(
+            data, original_data_path=None, dataset_metadata=None
+        )
         mock_pipeline.close.assert_called_once()
 
     def test_evaluate_empty_data(self) -> None:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit optional `metadata` support for dataset, conversation, and turn levels in evaluation inputs/outputs.
  * Evaluation now preserves dataset-level metadata through execution and amended output persistence.
  * YAML inputs/outputs now support dict-root format with optional dataset `metadata`, while maintaining list-root backward compatibility.
  * Exposed `ConversationMetadata`, `DatasetMetadata`, and `TurnMetadata` as top-level public attributes.

* **Documentation**
  * Updated README “Input File Data Structure Details” to document the new `metadata` fields and API-population behavior.

* **Tests**
  * Expanded unit tests for metadata model validation, YAML parsing across shapes, and metadata persistence/round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->