### PR TITLE
fix: evaluate metrics when proposal reaches Failed or Escalated state

### DIFF
--- a/src/lightspeed_evaluation/pipeline/evaluation/driver.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/driver.py
@@ -213,7 +213,8 @@ class ProposalDriver(AgentDriver):
 
         self._amend_turn_data(turn_data, status_dict)
         self._cleanup(cr_name)
-        return self._outcome_to_result(outcome, cr_name)
+        logger.info("Proposal '%s' reached terminal state: %s", cr_name, outcome)
+        return (None, None)
 
     def _amend_turn_data(
         self, turn_data: TurnData, status_dict: dict[str, Any]
@@ -226,29 +227,6 @@ class ProposalDriver(AgentDriver):
                 turn_data.response = self._extract_summary(status_dict)
             if not turn_data.proposal_status:
                 turn_data.proposal_status = status_dict
-
-    # Failed/Escalated → error (pipeline marks remaining turns as ERROR,
-    # metrics are NOT evaluated). Denied/Completed → no error (metrics run).
-    _OUTCOME_ERRORS: dict[TerminalOutcome, str] = {
-        TerminalOutcome.FAILED: "Proposal '{cr_name}' execution failed",
-        TerminalOutcome.ESCALATED: (
-            "Proposal '{cr_name}' escalated after verification failure"
-        ),
-    }
-
-    @staticmethod
-    def _outcome_to_result(
-        outcome: Optional[TerminalOutcome], cr_name: str
-    ) -> tuple[Optional[str], None]:
-        """Map a terminal outcome to an (error_message, None) result tuple."""
-        template = ProposalDriver._OUTCOME_ERRORS.get(outcome)  # type: ignore[arg-type]
-        if template:
-            return (template.format(cr_name=cr_name), None)
-        if outcome != TerminalOutcome.COMPLETED:
-            logger.warning(
-                "Proposal '%s' terminated with outcome: %s", cr_name, outcome
-            )
-        return (None, None)
 
     @staticmethod
     def _resolve_cli() -> str:

--- a/tests/unit/pipeline/evaluation/test_driver.py
+++ b/tests/unit/pipeline/evaluation/test_driver.py
@@ -218,18 +218,6 @@ class TestProposalDriverExecuteTurn:
 
         assert error is None
 
-    def test_failed_returns_error(
-        self, mocker: MockerFixture, _proposal_driver: ProposalDriver
-    ) -> None:
-        """Test FAILED outcome returns an error message."""
-        self._stub_terminal(mocker, _proposal_driver, TerminalOutcome.FAILED)
-        turn = TurnData(turn_id="1", query="Q")
-
-        error, _ = _proposal_driver.execute_turn(turn)
-
-        assert error is not None
-        assert "execution failed" in error
-
     def test_denied_returns_no_error(
         self, mocker: MockerFixture, _proposal_driver: ProposalDriver
     ) -> None:
@@ -240,18 +228,6 @@ class TestProposalDriverExecuteTurn:
         error, _ = _proposal_driver.execute_turn(turn)
 
         assert error is None
-
-    def test_escalated_returns_error(
-        self, mocker: MockerFixture, _proposal_driver: ProposalDriver
-    ) -> None:
-        """Test ESCALATED outcome returns an error message."""
-        self._stub_terminal(mocker, _proposal_driver, TerminalOutcome.ESCALATED)
-        turn = TurnData(turn_id="1", query="Q")
-
-        error, _ = _proposal_driver.execute_turn(turn)
-
-        assert error is not None
-        assert "escalated" in error
 
 
 class TestAgentDriverBase:

--- a/tests/unit/pipeline/evaluation/test_proposal_driver.py
+++ b/tests/unit/pipeline/evaluation/test_proposal_driver.py
@@ -579,29 +579,6 @@ class TestExecuteTurn:
 
         assert mock_apply.call_count == 1
 
-    def test_failed_terminal(
-        self, mocker: MockerFixture, driver: ProposalDriver
-    ) -> None:
-        """Test failed proposal returns error with outcome."""
-        mock_time = mocker.patch(f"{MODULE}.time")
-        mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, 1.0]
-
-        mock_apply = mocker.patch.object(driver, "_apply")
-        mock_apply.return_value = mocker.Mock(returncode=0)
-
-        status: dict[str, Any] = {
-            "conditions": [_cond("Analyzed", "False", message="LLM error")]
-        }
-        mocker.patch.object(driver, "_get_status", return_value=(status, None))
-        mocker.patch.object(driver, "_cleanup")
-
-        turn = TurnData(turn_id="t1", query="Q", proposal_spec=SPEC_FULL)
-        error, _ = driver.execute_turn(turn)
-
-        assert error is not None
-        assert "failed" in error
-        assert turn.proposal_status == status
-
     def test_denied_terminal(
         self, mocker: MockerFixture, driver: ProposalDriver
     ) -> None:


### PR DESCRIPTION
## Summary

- When a proposal ended with `Failed` or `Escalated` state, the `ProposalDriver` returned an error message that caused the processor to mark **all metrics as ERROR** with `score=None` and a generic reason (e.g. "Proposal 'eval-xxx' execution failed"). No actual metric evaluation happened — `custom:proposal_status`, `custom:proposal_evaluation_correctness`, and all other metrics were skipped entirely.
- The turn data (`proposal_status`, `response`) was already populated by `_amend_turn_data` **before** the error was returned, so all data needed for evaluation was available but unused.
- With this fix, all terminal outcomes (`Completed`, `Failed`, `Denied`, `Escalated`) let evaluation proceed normally. The `custom:proposal_status` metric now produces a proper score (`0.0` or `1.0`) with a specific reason indicating exactly which assertion failed (e.g. "Phase mismatch: expected 'Completed', got 'Failed'", "Verification passed: expected True, got False").

### What changed

- **`driver.py`**: removed `_OUTCOME_ERRORS` dict and `_outcome_to_result` method. All terminal outcomes now return `(None, None)`, allowing metrics to be evaluated. Added `logger.info` to log the terminal state reached.
- **`test_driver.py`**: removed `test_failed_returns_error` and `test_escalated_returns_error` (no longer applicable).
- **`test_proposal_driver.py`**: removed `test_failed_terminal` (no longer applicable).

### Why

The original design treated `Failed` and `Escalated` as infrastructure errors, but they are valid proposal lifecycle outcomes. When analysis, execution, or verification fails, the evaluation framework should provide diagnostic feedback (score + specific reason from assertion checks) rather than a generic ERROR that hides what went wrong.

## Test plan

- [x] All 1181 tests pass
- [x] `make pre-commit` passes (bandit, pyright, ruff, pylint, black, docstyle)
- [x] Run an agentic evaluation where a proposal reaches `Failed` state and verify that `custom:proposal_status` produces `score=0.0` with a specific failure reason instead of `ERROR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how terminal outcomes are processed during evaluation execution.

* **Tests**
  * Updated unit tests to reflect refactored outcome handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->