### PR TITLE
chore: remove redundant proposal cleanup from infra scripts

### DIFF
--- a/tests/integration/agentic/scripts/_cleanup_infra-claude-vertex.sh
+++ b/tests/integration/agentic/scripts/_cleanup_infra-claude-vertex.sh
@@ -8,8 +8,6 @@
 OPERATOR_NS="${OPERATOR_NS:-openshift-lightspeed}"
 TEST_NS="${TEST_NS:-lightspeed-evaluation-test}"
 
-oc delete proposals --all -n "$TEST_NS" --ignore-not-found
-oc delete proposalapprovals --all -n "$TEST_NS" --ignore-not-found
 oc delete agent eval-default --ignore-not-found
 oc delete llmprovider eval-vertex-ai --ignore-not-found
 oc delete secret eval-llm-credentials -n "$OPERATOR_NS" --ignore-not-found

--- a/tests/integration/agentic/scripts/_cleanup_infra-openai.sh
+++ b/tests/integration/agentic/scripts/_cleanup_infra-openai.sh
@@ -7,8 +7,6 @@
 OPERATOR_NS="${OPERATOR_NS:-openshift-lightspeed}"
 TEST_NS="${TEST_NS:-lightspeed-evaluation-test}"
 
-oc delete proposals --all -n "$TEST_NS" --ignore-not-found
-oc delete proposalapprovals --all -n "$TEST_NS" --ignore-not-found
 oc delete agent eval-default --ignore-not-found
 oc delete llmprovider eval-openai --ignore-not-found
 oc delete secret eval-llm-credentials -n "$OPERATOR_NS" --ignore-not-found


### PR DESCRIPTION
## Summary
- Removed `oc delete proposals` and `oc delete proposalapprovals` from `_cleanup_infra-openai.sh` and `_cleanup_infra-claude-vertex.sh`
- Proposal CR cleanup is already managed by the framework via the `cleanup_proposals` agent config option (`ProposalDriver._cleanup()`), making these lines redundant and potentially contradictory when `cleanup_proposals` is set to `false`

## Test plan
- [ ] Verify integration tests still pass with `cleanup_proposals: true` (default) — proposals cleaned up by the framework
- [ ] Verify integration tests with `cleanup_proposals: false` — proposals are intentionally preserved after evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined cleanup scripts for agentic infrastructure tests to preserve certain Kubernetes resources during test teardown.
  * Updates apply to both Claude/Vertex AI and OpenAI testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->