### PR TITLE
fix: custom metrics ref link in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ uv run lightspeed-eval --system-config <AGENTS_CONFIG.yaml> --eval-data <PROPOSA
     - [`context_precision_with_reference`](https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/context_precision/#context-precision-with-reference)
 - **Custom**
   - Response Evaluation
-    - [`answer_correctness`](src/lightspeed_evaluation/core/metrics/custom.py)
-    - [`intent_eval`](src/lightspeed_evaluation/core/metrics/custom.py) - Evaluates whether the response demonstrates the expected intent or purpose
+    - [`answer_correctness`](src/lightspeed_evaluation/core/metrics/custom/custom.py)
+    - [`intent_eval`](src/lightspeed_evaluation/core/metrics/custom/custom.py) - Evaluates whether the response demonstrates the expected intent or purpose
     - [`keywords_eval`](src/lightspeed_evaluation/core/metrics/custom/keywords_eval.py) - Keywords evaluation with alternatives (ALL keywords must match, case insensitive)
   - Tool Evaluation
-    - [`tool_eval`](src/lightspeed_evaluation/core/metrics/custom.py) - Validates tool calls, arguments, and optional results with regex pattern matching
+    - [`tool_eval`](src/lightspeed_evaluation/core/metrics/custom/tool_eval.py) - Validates tool calls, arguments, and optional results with regex pattern matching
   - Agentic Workflow Evaluation
     - [`proposal_status`](src/lightspeed_evaluation/core/metrics/custom/proposal_eval.py) - Deterministic assertions on proposal CRD status (phase, timing, analysis, execution, verification)
     - [`proposal_evaluation_correctness`](src/lightspeed_evaluation/core/metrics/custom/custom.py) - LLM-as-judge evaluation of agentic remediation workflow quality (diagnosis, actions, risk, verification)


### PR DESCRIPTION
## Description

fix: custom metrics ref link in main readme

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README links for several custom turn-level metrics to point to their current locations.
  * Improved navigation for `answer_correctness`, `intent_eval`, `tool_eval`, and `keywords_eval` references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->