### PR TITLE
change default agent to list

### DIFF
--- a/src/lightspeed_evaluation/core/models/agents.py
+++ b/src/lightspeed_evaluation/core/models/agents.py
@@ -1,5 +1,6 @@
 """Agent configuration models for the evaluation framework."""
 
+import logging
 import os
 from typing import Any, Literal, Optional
 
@@ -15,6 +16,8 @@ from lightspeed_evaluation.core.constants import (
     SUPPORTED_ENDPOINT_TYPES,
 )
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 
 class MCPServerConfig(BaseModel):
@@ -170,12 +173,29 @@ class AgentDefaultConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    agent: Optional[str] = Field(
+    agent: Optional[list[str]] = Field(
         default=None,
         min_length=1,
-        pattern=r"\S",
-        description="Name of the default agent when eval_data doesn't specify one",
+        description="List of agent names to evaluate against",
     )
+
+    @field_validator("agent", mode="before")
+    @classmethod
+    def normalize_and_validate_agent(cls, v: Any) -> Any:
+        """Normalize string to list and validate each agent name."""
+        if isinstance(v, str):
+            v = [v]
+        if isinstance(v, list):
+            stripped = []
+            for name in v:
+                if not isinstance(name, str) or not name.strip():
+                    raise ValueError(
+                        f"Agent names must be non-empty strings, got: {name!r}"
+                    )
+                stripped.append(name.strip())
+            return stripped
+        return v
+
     agent_config: Optional[dict[str, Any]] = Field(
         default=None,
         description="Shared default agent config overrides applied to all agents",
@@ -251,7 +271,8 @@ class AgentsConfig(BaseModel):
         are applied on top.
 
         Args:
-            agent_name: Explicit agent name. Falls back to default.agent.
+            agent_name: Explicit agent name. Falls back to first agent in
+                default.agent list.
             agent_config_override: Per-evaluation config overrides (highest priority).
 
         Returns:
@@ -260,7 +281,19 @@ class AgentsConfig(BaseModel):
         Raises:
             ConfigurationError: If no agent can be resolved or agent not found.
         """
-        name = agent_name or self.default.agent
+        default_agents: list[str] = self.default.agent or []
+        if agent_name:
+            name = agent_name
+        elif default_agents:
+            if len(default_agents) > 1:
+                logger.warning(
+                    "Multi-agent evaluation not yet implemented. "
+                    "Using first agent: %s",
+                    default_agents[0],
+                )
+            name = default_agents[0]
+        else:
+            name = None
         if name is None:
             raise ConfigurationError(
                 "No agent specified and no default agent configured"

--- a/src/lightspeed_evaluation/core/models/system.py
+++ b/src/lightspeed_evaluation/core/models/system.py
@@ -252,21 +252,22 @@ class SystemConfig(BaseModel):
         agent_fields["type"] = "http_api"
         data["agents"] = {
             "enabled": api_enabled,
-            "default": {"agent": "http_api" if api_enabled else None},
+            "default": {"agent": ["http_api"] if api_enabled else None},
             "http_api": agent_fields,
         }
         return data
 
     @model_validator(mode="after")
     def validate_agents_config(self) -> "SystemConfig":
-        """Validate that default.agent references a defined agent."""
-        if self.agents is not None:
-            default_agent = self.agents.default.agent
-            if default_agent is not None and default_agent not in self.agents.agents:
-                raise ConfigurationError(
-                    f"Default agent '{default_agent}' not found in agents "
-                    f"definitions. Available: {list(self.agents.agents.keys())}"
-                )
+        """Validate that all agents in default.agent list are defined."""
+        if self.agents is not None and self.agents.default.agent is not None:
+            available = list(self.agents.agents.keys())
+            for agent_name in self.agents.default.agent:
+                if agent_name not in self.agents.agents:
+                    raise ConfigurationError(
+                        f"Default agent '{agent_name}' not found in agents "
+                        f"definitions. Available: {available}"
+                    )
         return self
 
     @field_validator(

--- a/tests/integration/system-config-agents-proposal.yaml
+++ b/tests/integration/system-config-agents-proposal.yaml
@@ -9,7 +9,8 @@ core:
 agents:
   enabled: true
   default:
-    agent: proposal_agent
+    agent:
+      - proposal_agent
   proposal_agent:
     type: proposal
     namespace: lightspeed-evaluation-test

--- a/tests/integration/system-config-agents-query.yaml
+++ b/tests/integration/system-config-agents-query.yaml
@@ -31,7 +31,8 @@ embedding:
 # Agent Configuration (native agents: format)
 agents:
   default:
-    agent: http_api
+    agent:
+      - http_api
   http_api:
     type: http_api
     api_base: http://localhost:8080

--- a/tests/integration/system-config-agents-streaming.yaml
+++ b/tests/integration/system-config-agents-streaming.yaml
@@ -31,7 +31,8 @@ embedding:
 # Agent Configuration (native agents: format)
 agents:
   default:
-    agent: http_api
+    agent:
+      - http_api
   http_api:
     type: http_api
     api_base: http://localhost:8080

--- a/tests/integration/test_full_evaluation.py
+++ b/tests/integration/test_full_evaluation.py
@@ -48,7 +48,7 @@ def get_agent_info(system_config: SystemConfig) -> tuple[bool, str]:
     api: is present.
     """
     if system_config.agents and system_config.agents.default.agent:
-        name = system_config.agents.default.agent
+        name = system_config.agents.default.agent[0]
         agent_def = system_config.agents.agents[name]
         return system_config.agents.enabled, agent_def.endpoint_type
     return False, "query"

--- a/tests/unit/core/models/test_agents.py
+++ b/tests/unit/core/models/test_agents.py
@@ -101,23 +101,48 @@ class TestAgentDefaultConfig:
         assert config.agent_config is None
 
     def test_with_agent_config(self) -> None:
-        """Test setting agent and agent_config."""
+        """Test setting agent list and agent_config."""
         config = AgentDefaultConfig(
-            agent="my_agent",
+            agent=["my_agent"],
             agent_config={"timeout": 600, "num_retries": 5},
         )
-        assert config.agent == "my_agent"
+        assert config.agent == ["my_agent"]
         assert config.agent_config == {"timeout": 600, "num_retries": 5}
 
-    def test_empty_agent_name_rejected(self) -> None:
+    def test_multi_agent_list(self) -> None:
+        """Test setting multiple agents in list."""
+        config = AgentDefaultConfig(agent=["agent_a", "agent_b"])
+        assert config.agent == ["agent_a", "agent_b"]
+
+    def test_string_agent_normalized_to_list(self) -> None:
+        """Test string agent is auto-converted to single-element list."""
+        config = AgentDefaultConfig.model_validate({"agent": "ols_api"})
+        assert config.agent == ["ols_api"]
+
+    def test_empty_agent_list_rejected(self) -> None:
+        """Test empty agent list is rejected."""
+        with pytest.raises(ValidationError):
+            AgentDefaultConfig(agent=[])
+
+    def test_empty_string_agent_rejected(self) -> None:
         """Test empty string agent name is rejected."""
         with pytest.raises(ValidationError):
-            AgentDefaultConfig(agent="")
+            AgentDefaultConfig.model_validate({"agent": ""})
 
-    def test_whitespace_agent_name_rejected(self) -> None:
+    def test_whitespace_agent_rejected(self) -> None:
         """Test whitespace-only agent name is rejected."""
         with pytest.raises(ValidationError):
-            AgentDefaultConfig(agent="   ")
+            AgentDefaultConfig.model_validate({"agent": "   "})
+
+    def test_padded_agent_name_stripped(self) -> None:
+        """Test whitespace-padded agent name is stripped."""
+        config = AgentDefaultConfig.model_validate({"agent": " ols_api "})
+        assert config.agent == ["ols_api"]
+
+    def test_list_with_empty_string_rejected(self) -> None:
+        """Test list containing empty string is rejected."""
+        with pytest.raises(ValidationError):
+            AgentDefaultConfig(agent=["ols_api", ""])
 
 
 class TestAgentsConfig:
@@ -127,14 +152,14 @@ class TestAgentsConfig:
         """Test YAML-style flat namespace is parsed correctly."""
         config = AgentsConfig.model_validate(
             {
-                "default": {"agent": "ols_api"},
+                "default": {"agent": ["ols_api"]},
                 "ols_api": {
                     "type": "http_api",
                     "api_base": "http://localhost:8080",
                 },
             }
         )
-        assert config.default.agent == "ols_api"
+        assert config.default.agent == ["ols_api"]
         assert "ols_api" in config.agents
         assert config.agents["ols_api"].type == "http_api"
         assert config.agents["ols_api"].api_base == "http://localhost:8080"
@@ -143,7 +168,7 @@ class TestAgentsConfig:
         """Test parsing multiple named agents."""
         config = AgentsConfig.model_validate(
             {
-                "default": {"agent": "primary"},
+                "default": {"agent": ["primary"]},
                 "primary": {
                     "type": "http_api",
                     "api_base": "http://primary:8080",
@@ -177,7 +202,7 @@ class TestAgentsConfig:
         with pytest.raises(ValidationError):
             AgentsConfig.model_validate(
                 {
-                    "default": {"agent": "ols_api"},
+                    "default": {"agent": ["ols_api"]},
                     "ols_api": {"type": "http_api"},
                     "not_a_dict": "invalid_value",
                 }
@@ -186,7 +211,7 @@ class TestAgentsConfig:
     def test_input_dict_not_mutated(self) -> None:
         """Test that the input dict is not mutated by the model validator."""
         input_data = {
-            "default": {"agent": "ols_api"},
+            "default": {"agent": ["ols_api"]},
             "ols_api": {"type": "http_api"},
         }
         original_keys = set(input_data.keys())
@@ -202,7 +227,7 @@ class TestAgentsConfigResolve:
         """Create a basic AgentsConfig for testing."""
         return AgentsConfig.model_validate(
             {
-                "default": {"agent": "ols_api"},
+                "default": {"agent": ["ols_api"]},
                 "ols_api": {"type": "http_api", "api_base": "http://localhost:8080"},
             }
         )
@@ -219,7 +244,7 @@ class TestAgentsConfigResolve:
         """Test resolving with explicit agent name."""
         config = AgentsConfig.model_validate(
             {
-                "default": {"agent": "primary"},
+                "default": {"agent": ["primary"]},
                 "primary": {"type": "http_api"},
                 "secondary": {
                     "type": "http_api",
@@ -262,7 +287,7 @@ class TestAgentsConfigResolve:
         config = AgentsConfig.model_validate(
             {
                 "default": {
-                    "agent": "ols_api",
+                    "agent": ["ols_api"],
                     "agent_config": {"timeout": 900, "num_retries": 5},
                 },
                 "ols_api": {"type": "http_api"},
@@ -277,7 +302,7 @@ class TestAgentsConfigResolve:
         config = AgentsConfig.model_validate(
             {
                 "default": {
-                    "agent": "ols_api",
+                    "agent": ["ols_api"],
                     "agent_config": {"timeout": 900, "provider": "aws"},
                 },
                 "ols_api": {"type": "http_api"},
@@ -294,7 +319,7 @@ class TestAgentsConfigResolve:
         config = AgentsConfig.model_validate(
             {
                 "default": {
-                    "agent": "ols_api",
+                    "agent": ["ols_api"],
                     "agent_config": {
                         "timeout": 900,
                         "provider": "aws",

--- a/tests/unit/core/models/test_system.py
+++ b/tests/unit/core/models/test_system.py
@@ -992,7 +992,7 @@ class TestAgentsMigration:
         config = SystemConfig(api=APIConfig(enabled=True))
         assert config.agents is not None
         assert config.agents.enabled is True
-        assert config.agents.default.agent == "http_api"
+        assert config.agents.default.agent == ["http_api"]
 
     def test_api_enabled_false_sets_no_default_agent(self) -> None:
         """When api.enabled=False, agents.enabled=False and default.agent is None."""
@@ -1005,7 +1005,7 @@ class TestAgentsMigration:
         """When agents: is explicitly provided, no migration happens."""
         agents = AgentsConfig.model_validate(
             {
-                "default": {"agent": "custom"},
+                "default": {"agent": ["custom"]},
                 "custom": {"type": "http_api", "api_base": "http://custom:9090"},
             }
         )
@@ -1039,7 +1039,7 @@ class TestAgentsMigration:
         """Programmatic construction with explicit api= kwarg triggers migration."""
         config = SystemConfig(api=APIConfig(enabled=True))
         assert config.agents is not None
-        assert config.agents.default.agent == "http_api"
+        assert config.agents.default.agent == ["http_api"]
         assert "http_api" in config.agents.agents
 
     def test_invalid_default_agent_reference_raises(self) -> None:
@@ -1047,7 +1047,7 @@ class TestAgentsMigration:
         with pytest.raises(ConfigurationError, match="not found"):
             SystemConfig(
                 agents=AgentsConfig(
-                    default=AgentDefaultConfig(agent="nonexistent"),
+                    default=AgentDefaultConfig(agent=["nonexistent"]),
                     agents={"ols_api": HttpApiAgentConfig()},
                 )
             )

--- a/tests/unit/core/system/test_loader.py
+++ b/tests/unit/core/system/test_loader.py
@@ -630,6 +630,32 @@ api:
   enabled: false
 agents:
   default:
+    agent:
+      - ols_api
+  ols_api:
+    type: http_api
+    api_base: http://localhost:8080
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            temp_path = f.name
+
+        try:
+            loader = ConfigLoader()
+            config = loader.load_system_config(temp_path)
+            assert config.agents is not None
+            assert config.agents.default.agent == ["ols_api"]
+            assert "ols_api" in config.agents.agents
+        finally:
+            Path(temp_path).unlink()
+
+    def test_load_yaml_with_string_agent_backward_compat(self) -> None:
+        """YAML with string agent is auto-converted to list."""
+        yaml_content = """
+api:
+  enabled: false
+agents:
+  default:
     agent: ols_api
   ols_api:
     type: http_api
@@ -643,8 +669,7 @@ agents:
             loader = ConfigLoader()
             config = loader.load_system_config(temp_path)
             assert config.agents is not None
-            assert config.agents.default.agent == "ols_api"
-            assert "ols_api" in config.agents.agents
+            assert config.agents.default.agent == ["ols_api"]
         finally:
             Path(temp_path).unlink()
 
@@ -664,7 +689,7 @@ api:
             loader = ConfigLoader()
             config = loader.load_system_config(temp_path)
             assert config.agents is not None
-            assert config.agents.default.agent == "http_api"
+            assert config.agents.default.agent == ["http_api"]
             assert config.agents.agents["http_api"].api_base == "http://legacy:8080"
             assert config.agents.agents["http_api"].timeout == 500
             # api field also preserved


### PR DESCRIPTION
## Description

changing default agent to list to support future multi agents eval. This is the first step with backward compatibility.
No direct impact

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default agent configuration now accepts multiple agent names (list-based).
* **Bug Fixes**
  * Default agent resolution now validates each referenced default agent and provides clearer errors when agents are missing/invalid.
  * Legacy `api`-only configurations now migrate to the list-based default agent format.
  * If multiple default agents are provided, evaluation continues using the first entry (with a warning).
* **Tests**
  * Updated integration and unit tests to match list-based default agent inputs, migration, and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->