### PR TITLE
[LEADS-505] Move no_tools to extra_request_params

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -90,10 +90,11 @@ agents:
     provider: "openai"                 # LLM provider for queries
     model: "gpt-4o-mini"               # Model to use for queries
     system_prompt: null                # System prompt (default None)
-    no_tools: null                     # Whether to bypass tools and MCP servers (optional)
+    # no_tools: null                   # Deprecated: use extra_request_params: {no_tools: true} instead
     # Extra parameters merged into API request payload (per-turn override in eval.yaml takes priority)
     # Example: extra_request_params:
     #            mode: troubleshooting
+    #            no_tools: true        # Preferred way to disable tools
     extra_request_params: null
 
     # MCP Server Authentication Configuration

--- a/examples/03_endpoints/responses/system.yaml
+++ b/examples/03_endpoints/responses/system.yaml
@@ -43,7 +43,6 @@ agents:
     provider: "openai"
     model: "gpt-4o-mini"
     system_prompt: null
-    no_tools: null
     extra_request_params: {
       tool_choice: {
         type: "allowed_tools",

--- a/src/lightspeed_evaluation/core/api/client.py
+++ b/src/lightspeed_evaluation/core/api/client.py
@@ -236,7 +236,6 @@ class APIClient:
             query=query,
             provider=self.config.provider,
             model=self.config.model,
-            no_tools=self.config.no_tools,
             conversation_id=conversation_id,
             system_prompt=self.config.system_prompt,
             attachments=attachments,
@@ -725,7 +724,6 @@ class APIClient:
             "query",
             "provider",
             "model",
-            "no_tools",
             "system_prompt",
             "attachments",
         ]

--- a/src/lightspeed_evaluation/core/models/agents.py
+++ b/src/lightspeed_evaluation/core/models/agents.py
@@ -1,5 +1,6 @@
 """Agent configuration models for the evaluation framework."""
 
+import logging
 import os
 from typing import Any, Literal, Optional
 
@@ -15,6 +16,8 @@ from lightspeed_evaluation.core.constants import (
     SUPPORTED_ENDPOINT_TYPES,
 )
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 
 class MCPServerConfig(BaseModel):
@@ -94,7 +97,11 @@ class HttpApiBaseFields(BaseModel):
     provider: Optional[str] = Field(default=None, description="LLM provider for API")
     model: Optional[str] = Field(default=None, description="LLM model for API")
     no_tools: Optional[bool] = Field(
-        default=None, description="Disable tool usage in API calls"
+        default=None,
+        description=(
+            "Deprecated: use extra_request_params.no_tools instead. "
+            "Disable tool usage in API calls."
+        ),
     )
     system_prompt: Optional[str] = Field(
         default=None, description="System prompt for API calls"
@@ -120,6 +127,25 @@ class HttpApiBaseFields(BaseModel):
         if v not in SUPPORTED_ENDPOINT_TYPES:
             raise ValueError(f"Endpoint type must be one of {SUPPORTED_ENDPOINT_TYPES}")
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_no_tools(cls, data: Any) -> Any:
+        """Emit a deprecation warning when no_tools is set at the top level."""
+        if not isinstance(data, dict):
+            return data
+        no_tools = data.get("no_tools")
+        if no_tools is not None:
+            logger.warning(
+                "no_tools is deprecated as a top-level field. "
+                "Set it inside extra_request_params instead: "
+                "extra_request_params: {no_tools: %s}",
+                no_tools,
+            )
+            extra = dict(data.get("extra_request_params") or {})
+            extra["no_tools"] = no_tools
+            data = {**data, "extra_request_params": extra}
+        return data
 
 
 class HttpApiAgentConfig(HttpApiBaseFields):

--- a/src/lightspeed_evaluation/core/models/api.py
+++ b/src/lightspeed_evaluation/core/models/api.py
@@ -37,7 +37,6 @@ class APIRequest(BaseModel):
     query: str = Field(..., min_length=1, description="User query")
     provider: Optional[str] = Field(default=None, description="LLM provider")
     model: Optional[str] = Field(default=None, description="LLM model")
-    no_tools: Optional[bool] = Field(default=None, description="Disable tool usage")
     conversation_id: Optional[str] = Field(
         default=None, description="Conversation ID for context"
     )
@@ -61,7 +60,6 @@ class APIRequest(BaseModel):
         # Extract parameters with defaults
         provider = kwargs.get("provider")
         model = kwargs.get("model")
-        no_tools = kwargs.get("no_tools")
         conversation_id = kwargs.get("conversation_id")
         system_prompt = kwargs.get("system_prompt")
         attachments = kwargs.get("attachments")
@@ -76,7 +74,6 @@ class APIRequest(BaseModel):
             query=query,
             provider=provider,
             model=model,
-            no_tools=no_tools,
             conversation_id=conversation_id,
             system_prompt=system_prompt,
             attachments=attachment_data,

--- a/tests/integration/system-config-agents-query.yaml
+++ b/tests/integration/system-config-agents-query.yaml
@@ -40,7 +40,6 @@ agents:
     timeout: 300
     provider: "openai"
     model: "gpt-4o-mini"
-    no_tools: null
     system_prompt: null
     cache_dir: ".caches/api_cache"
     cache_enabled: false

--- a/tests/integration/system-config-agents-streaming.yaml
+++ b/tests/integration/system-config-agents-streaming.yaml
@@ -40,7 +40,6 @@ agents:
     timeout: 300
     provider: "openai"
     model: "gpt-4o-mini"
-    no_tools: null
     system_prompt: null
     cache_dir: ".caches/api_cache"
     cache_enabled: false

--- a/tests/integration/system-config-query.yaml
+++ b/tests/integration/system-config-query.yaml
@@ -40,7 +40,6 @@ api:
   # API input configuration
   provider: "openai"                   # LLM provider for queries
   model: "gpt-4o-mini"                 # Model to use for queries
-  no_tools: null                       # Whether to bypass tools and MCP servers (optional)
   system_prompt: null                  # System prompt (default None)
 
   cache_dir: ".caches/api_cache"  # Directory with lightspeed-stack cache

--- a/tests/integration/system-config-streaming.yaml
+++ b/tests/integration/system-config-streaming.yaml
@@ -40,7 +40,6 @@ api:
   # API input configuration
   provider: "openai"                   # LLM provider for queries
   model: "gpt-4o-mini"                 # Model to use for queries
-  no_tools: null                       # Whether to bypass tools and MCP servers (optional)
   system_prompt: null                  # System prompt (default None)
 
   cache_dir: ".caches/api_cache"  # Directory with lightspeed-stack cache

--- a/tests/unit/core/api/test_client.py
+++ b/tests/unit/core/api/test_client.py
@@ -2,6 +2,7 @@
 
 """Unit tests for core API client module."""
 
+import logging
 from pathlib import Path
 
 import httpx
@@ -681,6 +682,31 @@ class TestExtraRequestParams:
         assert payload["query"] == "Original query"
         # Non-reserved field should be added
         assert payload["mode"] == "troubleshooting"
+
+    def test_top_level_no_tools_still_works_with_deprecation_warning(
+        self,
+        mocker: MockerFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test backward compat: top-level no_tools is still applied with a warning."""
+        config = APIConfig(
+            enabled=True,
+            api_base="http://localhost:8080",
+            endpoint_type="query",
+            timeout=30,
+            cache_enabled=False,
+            no_tools=True,
+        )
+        mocker.patch("lightspeed_evaluation.core.api.client.httpx.Client")
+
+        client = APIClient(config)
+        with caplog.at_level(
+            logging.WARNING, logger="lightspeed_evaluation.core.models.agents"
+        ):
+            request = client._prepare_request("Test query")
+
+        assert request.extra_request_params == {"no_tools": True}
+        assert any("deprecated" in r.message.lower() for r in caplog.records)
 
 
 class TestRetryLogic:

--- a/tests/unit/core/models/test_agents.py
+++ b/tests/unit/core/models/test_agents.py
@@ -1,5 +1,7 @@
 """Tests for agent configuration models."""
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -89,6 +91,29 @@ class TestHttpApiAgentConfig:
         """Test unknown fields are rejected."""
         with pytest.raises(ValidationError):
             HttpApiAgentConfig.model_validate({"unknown_field": "value"})
+
+    def test_no_tools_top_level_emits_deprecation_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that setting no_tools at the top level emits a deprecation warning."""
+        with caplog.at_level(
+            logging.WARNING, logger="lightspeed_evaluation.core.models.agents"
+        ):
+            config = HttpApiAgentConfig(no_tools=True)
+
+        assert config.no_tools is True
+        assert any("deprecated" in r.message.lower() for r in caplog.records)
+
+    def test_no_tools_none_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that no_tools=None (default) does not emit a warning."""
+        with caplog.at_level(
+            logging.WARNING, logger="lightspeed_evaluation.core.models.agents"
+        ):
+            HttpApiAgentConfig()
+
+        assert not any("no_tools" in r.message for r in caplog.records)
 
 
 class TestAgentDefaultConfig:

--- a/tests/unit/core/models/test_api_additional.py
+++ b/tests/unit/core/models/test_api_additional.py
@@ -78,7 +78,6 @@ class TestAPIRequest:
             query="Test query",
             provider="openai",
             model="gpt-4",
-            no_tools=True,
             conversation_id="conv123",
             system_prompt="Custom prompt",
         )
@@ -86,7 +85,6 @@ class TestAPIRequest:
         assert request.query == "Test query"
         assert request.provider == "openai"
         assert request.model == "gpt-4"
-        assert request.no_tools is True
         assert request.conversation_id == "conv123"
         assert request.system_prompt == "Custom prompt"
 


### PR DESCRIPTION
## Description

Migrating `agents.no_tools` under `agents.extra_request_params`.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request handling so “no tools” is applied consistently via supported request parameters.
  * Top-level `no_tools` is now deprecated: the setting is automatically migrated into request parameters with a deprecation warning.
  * Cache keys no longer vary by the deprecated top-level flag.

* **Documentation**
  * Updated example and integration configurations to remove the deprecated option and use the supported request-parameters approach.

* **Tests**
  * Expanded unit and integration coverage to verify backward compatibility and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->