### PR TITLE
rename proposal to agentrun

### DIFF
--- a/src/lightspeed_evaluation/core/metrics/custom/proposal_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/proposal_eval.py
@@ -221,7 +221,7 @@ def _check_analysis_option(
     """Check assertions on a single analysis option by index."""
     risk_in = expected_opt.get("risk_in")
     if risk_in is not None:
-        actual_risk = actual_opt.get("proposal", {}).get("risk", "")
+        actual_risk = actual_opt.get("remediationPlan", {}).get("risk", "")
         if actual_risk.lower() not in [r.lower() for r in risk_in]:
             return False, f"Option[{idx}] risk '{actual_risk}' not in {risk_in}"
 

--- a/src/lightspeed_evaluation/pipeline/evaluation/driver.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/driver.py
@@ -128,8 +128,8 @@ class TerminalOutcome(StrEnum):
 
 CRD_GROUP = "agentic.openshift.io"
 CRD_VERSION = "v1alpha1"
-CRD_KIND = "Proposal"
-CRD_PLURAL = "proposals"
+CRD_KIND = "AgenticRun"
+CRD_PLURAL = "agenticruns"
 CRD_API_VERSION = f"{CRD_GROUP}/{CRD_VERSION}"
 
 
@@ -179,7 +179,7 @@ class ProposalDriver(AgentDriver):
         result = self._apply(manifest)
         if result.returncode != 0:
             return (
-                f"Failed to apply Proposal CR: {result.stderr.strip()}",
+                f"Failed to apply AgenticRun CR: {result.stderr.strip()}",
                 None,
             )
 
@@ -319,7 +319,7 @@ class ProposalDriver(AgentDriver):
             )
         return {
             "apiVersion": CRD_API_VERSION,
-            "kind": "ProposalApproval",
+            "kind": "AgenticRunApproval",
             "metadata": {
                 "name": cr_name,
                 "namespace": self._config.namespace,

--- a/src/lightspeed_evaluation/pipeline/evaluation/proposal_amender.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/proposal_amender.py
@@ -132,7 +132,7 @@ def _build_analysis_section(analysis_results: list[dict[str, Any]]) -> str:
             title = option.get("title", "Untitled")
             lines.append(f"\n### Option {idx} {label}: {title}".rstrip())
             _append_diagnosis(lines, option.get("diagnosis", {}))
-            _append_proposal(lines, option.get("proposal", {}))
+            _append_proposal(lines, option.get("remediationPlan", {}))
 
     return "\n".join(lines)
 

--- a/tests/integration/test_proposal_evaluation.py
+++ b/tests/integration/test_proposal_evaluation.py
@@ -50,7 +50,7 @@ def check_crd_installed() -> bool:
     """Check if the Proposal CRD is installed on the cluster."""
     try:
         result = subprocess.run(
-            ["oc", "get", "crd", "proposals.agentic.openshift.io"],
+            ["oc", "get", "crd", "agenticruns.agentic.openshift.io"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -88,7 +88,7 @@ class TestProposalPrerequisites:
         """Verify that Proposal CRD is installed on the cluster."""
         assert (
             check_crd_installed()
-        ), "proposals.agentic.openshift.io CRD must be installed"
+        ), "agenticruns.agentic.openshift.io CRD must be installed"
 
     def test_env_vars_configured(self) -> None:
         """Verify that required environment variables are set."""
@@ -265,7 +265,7 @@ class TestProposalDriverEvaluation:
             [
                 "oc",
                 "get",
-                "proposals",
+                "agenticruns",
                 "-n",
                 "lightspeed-evaluation-test",
                 "-o",
@@ -277,7 +277,7 @@ class TestProposalDriverEvaluation:
             check=False,
         )
         assert result.returncode == 0, (
-            "Failed to list proposals during timeout cleanup validation: "
+            "Failed to list agenticruns during timeout cleanup validation: "
             f"{result.stderr.strip()}"
         )
         lines = [

--- a/tests/unit/core/metrics/custom/test_proposal_eval_assertions.py
+++ b/tests/unit/core/metrics/custom/test_proposal_eval_assertions.py
@@ -278,7 +278,7 @@ class TestAnalysisCheck:
                 "conditions": [{"type": "Analyzed", "status": "True"}],
             },
             proposal_results={
-                "analysis": [{"options": [{"diagnosis": {}, "proposal": {}}]}],
+                "analysis": [{"options": [{"diagnosis": {}, "remediationPlan": {}}]}],
             },
         )
         score, reason = evaluate_proposal_status(None, 0, turn, False)
@@ -324,7 +324,11 @@ class TestAnalysisCheck:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"proposal": {"risk": "Low"}, "diagnosis": {}}]},
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "Low"}, "diagnosis": {}}
+                        ]
+                    },
                 ],
             },
         )
@@ -344,7 +348,11 @@ class TestAnalysisCheck:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"proposal": {"risk": "High"}, "diagnosis": {}}]},
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "High"}, "diagnosis": {}}
+                        ]
+                    },
                 ],
             },
         )
@@ -368,7 +376,7 @@ class TestAnalysisCheck:
                 "analysis": [
                     {
                         "options": [
-                            {"diagnosis": {"confidence": "High"}, "proposal": {}}
+                            {"diagnosis": {"confidence": "High"}, "remediationPlan": {}}
                         ]
                     },
                 ],
@@ -390,7 +398,11 @@ class TestAnalysisCheck:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"diagnosis": {"confidence": "Low"}, "proposal": {}}]},
+                    {
+                        "options": [
+                            {"diagnosis": {"confidence": "Low"}, "remediationPlan": {}}
+                        ]
+                    },
                 ],
             },
         )
@@ -417,7 +429,7 @@ class TestAnalysisCheck:
                                 "diagnosis": {
                                     "summary": "Pod crash due to bad image pull",
                                 },
-                                "proposal": {},
+                                "remediationPlan": {},
                             },
                         ],
                     },
@@ -442,7 +454,10 @@ class TestAnalysisCheck:
                 "analysis": [
                     {
                         "options": [
-                            {"diagnosis": {"summary": "Pod crash"}, "proposal": {}},
+                            {
+                                "diagnosis": {"summary": "Pod crash"},
+                                "remediationPlan": {},
+                            },
                         ],
                     },
                 ],
@@ -595,8 +610,16 @@ class TestAnalysisCheck:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"proposal": {"risk": "High"}, "diagnosis": {}}]},
-                    {"options": [{"proposal": {"risk": "Low"}, "diagnosis": {}}]},
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "High"}, "diagnosis": {}}
+                        ]
+                    },
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "Low"}, "diagnosis": {}}
+                        ]
+                    },
                 ],
             },
         )
@@ -619,7 +642,11 @@ class TestAnalysisCheck:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"proposal": {"risk": "Low"}, "diagnosis": {}}]},
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "Low"}, "diagnosis": {}}
+                        ]
+                    },
                 ],
             },
         )
@@ -905,7 +932,7 @@ class TestCheckOrdering:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"diagnosis": {}, "proposal": {}}]},
+                    {"options": [{"diagnosis": {}, "remediationPlan": {}}]},
                 ],
                 "execution": [
                     {

--- a/tests/unit/core/metrics/custom/test_proposal_eval_helpers.py
+++ b/tests/unit/core/metrics/custom/test_proposal_eval_helpers.py
@@ -158,7 +158,11 @@ class TestLatestTerminalResult:
             },
             proposal_results={
                 "analysis": [
-                    {"options": [{"proposal": {"risk": "Low"}, "diagnosis": {}}]},
+                    {
+                        "options": [
+                            {"remediationPlan": {"risk": "Low"}, "diagnosis": {}}
+                        ]
+                    },
                     {"conditions": [{"type": "Started", "reason": "StepStarted"}]},
                 ],
             },

--- a/tests/unit/pipeline/evaluation/test_proposal_amender.py
+++ b/tests/unit/pipeline/evaluation/test_proposal_amender.py
@@ -83,7 +83,7 @@ DIAGNOSIS_STATUS: dict[str, Any] = {
                 "confidence": "High",
                 "rootCause": "Memory limit 256Mi too low",
             },
-            "proposal": {
+            "remediationPlan": {
                 "description": "Patch deployment memory",
                 "actions": [
                     {"type": "patch", "description": "Set memory limit to 512Mi"},
@@ -100,7 +100,7 @@ DIAGNOSIS_STATUS: dict[str, Any] = {
                 "confidence": "Medium",
                 "rootCause": "Single replica under load",
             },
-            "proposal": {
+            "remediationPlan": {
                 "description": "Add replicas",
                 "actions": [
                     {"type": "scale", "description": "Scale to 3 replicas"},

--- a/tests/unit/pipeline/evaluation/test_proposal_driver.py
+++ b/tests/unit/pipeline/evaluation/test_proposal_driver.py
@@ -262,7 +262,7 @@ class TestBuildCR:
         cr = driver._build_proposal_cr(turn, "eval-abc123")
 
         assert cr["apiVersion"] == "agentic.openshift.io/v1alpha1"
-        assert cr["kind"] == "Proposal"
+        assert cr["kind"] == "AgenticRun"
         assert cr["metadata"]["name"] == "eval-abc123"
         assert cr["metadata"]["namespace"] == "openshift-lightspeed"
         assert cr["spec"]["request"] == "Pod is crash looping"
@@ -304,7 +304,7 @@ class TestBuildCR:
         driver = self._make_driver(mocker)
         cr = driver._build_approval_cr("eval-abc", SPEC_ANALYSIS_ONLY)
 
-        assert cr["kind"] == "ProposalApproval"
+        assert cr["kind"] == "AgenticRunApproval"
         assert len(cr["spec"]["stages"]) == 1
         assert cr["spec"]["stages"][0]["type"] == "Analysis"
         assert cr["spec"]["stages"][0]["decision"] == "Approved"
@@ -503,7 +503,7 @@ class TestExecuteTurn:
         turn = TurnData(turn_id="t1", query="Q")
         error, conv_id = driver.execute_turn(turn)
 
-        assert error == "Failed to apply Proposal CR: connection refused"
+        assert error == "Failed to apply AgenticRun CR: connection refused"
         assert conv_id is None
 
     def test_timeout(self, mocker: MockerFixture, driver: ProposalDriver) -> None:


### PR DESCRIPTION
## Description

rename proposal to agentrun (minimal change), internal naming consistency and doc changes will be handled later.
Ref: https://github.com/openshift/lightspeed-agentic-operator/pull/285

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the system to use the new **AgenticRun** resource naming instead of **Proposal** for run creation, tracking, and cleanup.
  * Approval handling now uses the matching **AgenticRunApproval** resource.
  * Error messages during resource application now reference the updated resource name for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->