### PR TITLE
[LEADS-503] Add MLflow storage backend

### DIFF
--- a/src/lightspeed_evaluation/core/storage/__init__.py
+++ b/src/lightspeed_evaluation/core/storage/__init__.py
@@ -33,6 +33,7 @@ from lightspeed_evaluation.core.storage.config import (
     DatabaseBackendConfig,
     FileBackendConfig,
     LangfuseBackendConfig,
+    MLflowBackendConfig,
     StorageBackendConfig,
 )
 from lightspeed_evaluation.core.storage.factory import (
@@ -42,6 +43,7 @@ from lightspeed_evaluation.core.storage.factory import (
     get_file_config,
 )
 from lightspeed_evaluation.core.storage.file_storage import FileStorageBackend
+from lightspeed_evaluation.core.storage.mlflow_storage import MLflowStorageBackend
 from lightspeed_evaluation.core.storage.protocol import BaseStorageBackend, RunInfo
 from lightspeed_evaluation.core.storage.sql_storage import (
     EvaluationResultDB,
@@ -58,10 +60,12 @@ __all__ = [
     "FileBackendConfig",
     "DatabaseBackendConfig",
     "LangfuseBackendConfig",
+    "MLflowBackendConfig",
     "StorageBackendConfig",
     "CompositeStorageBackend",
     "NoOpStorageBackend",
     "FileStorageBackend",
+    "MLflowStorageBackend",
     "create_database_backend",
     "create_pipeline_storage_backend",
     "get_database_config",

--- a/src/lightspeed_evaluation/core/storage/composite_storage.py
+++ b/src/lightspeed_evaluation/core/storage/composite_storage.py
@@ -68,10 +68,10 @@ class CompositeStorageBackend(BaseStorageBackend):
         for backend in self._backends:
             backend.save_run(results)
 
-    def finalize(self) -> None:
+    def finalize(self, success: bool = True) -> None:
         """Call ``finalize`` on every child backend."""
         for backend in self._backends:
-            backend.finalize()
+            backend.finalize(success=success)
 
     def close(self) -> None:
         """Call ``close`` on every child backend."""

--- a/src/lightspeed_evaluation/core/storage/config.py
+++ b/src/lightspeed_evaluation/core/storage/config.py
@@ -157,8 +157,42 @@ class LangfuseBackendConfig(BaseModel):
     )
 
 
+class MLflowBackendConfig(BaseModel):
+    """Configuration for MLflow experiment tracking storage backend.
+
+    Exports evaluation scores, token usage, and latency to MLflow as metrics
+    and params within an experiment run.
+    Requires the ``mlflow`` optional extra: ``pip install 'lightspeed-evaluation[mlflow]'``
+
+    The tracking URI is resolved from the config field first, then from the
+    ``MLFLOW_TRACKING_URI`` environment variable as fallback (standard MLflow behavior).
+
+    Example:
+        - type: "mlflow"
+          tracking_uri: "http://localhost:5000"
+          experiment_name: "lightspeed_evaluation"
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["mlflow"] = "mlflow"
+    tracking_uri: Optional[str] = Field(
+        default=None,
+        description=(
+            "MLflow tracking server URI " "(falls back to MLFLOW_TRACKING_URI env var)"
+        ),
+    )
+    experiment_name: str = Field(
+        default="lightspeed_evaluation",
+        description="MLflow experiment name to log runs under",
+    )
+
+
 # Discriminated union for polymorphic storage configuration
 StorageBackendConfig = Annotated[
-    FileBackendConfig | DatabaseBackendConfig | LangfuseBackendConfig,
+    FileBackendConfig
+    | DatabaseBackendConfig
+    | LangfuseBackendConfig
+    | MLflowBackendConfig,
     Field(discriminator="type"),
 ]

--- a/src/lightspeed_evaluation/core/storage/factory.py
+++ b/src/lightspeed_evaluation/core/storage/factory.py
@@ -15,10 +15,12 @@ from lightspeed_evaluation.core.storage.config import (
     DatabaseBackendConfig,
     FileBackendConfig,
     LangfuseBackendConfig,
+    MLflowBackendConfig,
     StorageBackendConfig,
 )
 from lightspeed_evaluation.core.storage.file_storage import FileStorageBackend
 from lightspeed_evaluation.core.storage.langfuse_storage import LangfuseStorageBackend
+from lightspeed_evaluation.core.storage.mlflow_storage import MLflowStorageBackend
 from lightspeed_evaluation.core.storage.protocol import BaseStorageBackend
 from lightspeed_evaluation.core.storage.sql_storage import SQLStorageBackend
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
@@ -132,6 +134,9 @@ def create_pipeline_storage_backend(
         elif isinstance(config, LangfuseBackendConfig):
             logger.info("Pipeline storage: langfuse backend")
             backends.append(LangfuseStorageBackend(config))
+        elif isinstance(config, MLflowBackendConfig):
+            logger.info("Pipeline storage: mlflow backend")
+            backends.append(MLflowStorageBackend(config, system_config=system_config))
         else:
             raise ConfigurationError(
                 f"Unknown storage backend type: {type(config).__name__!r}"

--- a/src/lightspeed_evaluation/core/storage/file_storage.py
+++ b/src/lightspeed_evaluation/core/storage/file_storage.py
@@ -58,8 +58,9 @@ class FileStorageBackend(BaseStorageBackend):
         """Accumulate batch results; reports are written in :meth:`finalize`."""
         self._accumulated.extend(results)
 
-    def finalize(self) -> None:
+    def finalize(self, success: bool = True) -> None:
         """Generate reports from accumulated results."""
+        _ = success
         if not self._accumulated:
             logger.info(
                 "File storage backend: no results to persist (run_id=%s)",

--- a/src/lightspeed_evaluation/core/storage/langfuse_storage.py
+++ b/src/lightspeed_evaluation/core/storage/langfuse_storage.py
@@ -102,8 +102,9 @@ class LangfuseStorageBackend:
         """No-op — Langfuse export does not need the full evaluation dataset."""
         _ = evaluation_data
 
-    def finalize(self) -> None:
+    def finalize(self, success: bool = True) -> None:
         """Create a trace span, write all scores, and flush to Langfuse."""
+        _ = success
         if self._client is None:
             return
 

--- a/src/lightspeed_evaluation/core/storage/mlflow_storage.py
+++ b/src/lightspeed_evaluation/core/storage/mlflow_storage.py
@@ -1,0 +1,738 @@
+"""MLflow storage backend for evaluation results.
+
+Implements :class:`~lightspeed_evaluation.core.storage.protocol.BaseStorageBackend`
+so MLflow plugs into the standard pipeline storage lifecycle without any
+changes to the runner, API, or pipeline modules.
+
+Install with: ``pip install 'lightspeed-evaluation[mlflow]'``
+
+Requires **MLflow** (``mlflow>=2.14.0``) for tracing support via ``start_span()``.
+
+Credentials are resolved from :class:`MLflowBackendConfig` fields first,
+then from ``MLFLOW_TRACKING_URI`` environment variable as fallback (standard
+MLflow behavior).
+
+Lifecycle:
+    1. ``initialize(run_info)`` — sets the experiment, starts an MLflow run,
+       and logs run-level params (including model/judge/dataset context).
+    2. ``save_result(result)``  — logs metrics for a single result immediately
+       and accumulates data for per-metric aggregates and the results table.
+    3. ``save_run(results)``    — logs metrics for each result in the batch
+       immediately (called per conversation).
+    4. ``finalize(success=...)`` — registers models (``provider>model``),
+       logs per-metric aggregate metrics, a results table artifact, tags
+       ``eval_status``, and ends the run as ``FINISHED`` (complete) or
+       ``FAILED`` (aborted).
+    5. ``close()``              — ends the run as ``FAILED`` if still active
+       (finalize was skipped).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+from lightspeed_evaluation.core.models.data import EvaluationData, EvaluationResult
+from lightspeed_evaluation.core.storage.config import MLflowBackendConfig
+from lightspeed_evaluation.core.storage.protocol import RunInfo
+from lightspeed_evaluation.core.system.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from lightspeed_evaluation.core.models.system import SystemConfig
+
+logger = logging.getLogger(__name__)
+
+_HAS_MLFLOW = importlib.util.find_spec("mlflow") is not None
+
+_MLFLOW_ERRORS: tuple[type[Exception], ...] = (
+    RuntimeError,
+    ValueError,
+    OSError,
+    ConnectionError,
+)
+try:
+    _mlflow_exc = importlib.import_module("mlflow.exceptions")
+    _MLFLOW_ERRORS = (*_MLFLOW_ERRORS, _mlflow_exc.MlflowException)
+except (ImportError, ModuleNotFoundError):
+    pass
+
+
+@dataclass
+class _PerMetricAccumulator:
+    """Scores and pass/fail values for a single metric identifier."""
+
+    scores: list[float] = field(default_factory=list)
+    pass_values: list[float] = field(default_factory=list)
+
+
+@dataclass
+class _RunAccumulators:
+    """Accumulated values for computing aggregate metrics at finalize.
+
+    Attributes:
+        step: Sequential result index (used as MLflow step).
+        scores: Collected numeric scores for mean computation.
+        pass_values: 1.0/0.0 per result for pass rate.
+        latencies: Evaluation latencies for mean computation.
+        token_totals: Running totals keyed by token category name.
+        per_metric: Per-metric scores and pass values for comparison.
+        table_rows: Accumulated result dicts for ``log_table()``.
+    """
+
+    step: int = 0
+    scores: list[float] = field(default_factory=list)
+    pass_values: list[float] = field(default_factory=list)
+    latencies: list[float] = field(default_factory=list)
+    token_totals: dict[str, float] = field(default_factory=dict)
+    per_metric: dict[str, _PerMetricAccumulator] = field(default_factory=dict)
+    table_rows: list[dict[str, Any]] = field(default_factory=list)
+
+
+class MLflowStorageBackend:
+    """Storage backend that exports evaluation results to MLflow incrementally.
+
+    Creates one MLflow run per evaluation run. Each evaluation result is
+    logged immediately as it arrives (via ``save_result`` or ``save_run``),
+    using the MLflow ``step`` parameter as a sequential index. Per-metric
+    aggregate metrics and a results table artifact are logged at
+    ``finalize()``.
+
+    Complete vs failed evals are distinguished at finalize time:
+    ``success=True`` ends the MLflow run as ``FINISHED`` with tag
+    ``eval_status=complete``; ``success=False`` ends as ``FAILED`` with
+    ``eval_status=failed``. Incremental metrics remain available in both
+    cases; aggregates are still written so partial runs stay inspectable.
+
+    Judge, embedding, and agent models from system config are registered in
+    the MLflow Model Registry as ``provider>model`` (``>`` replaces ``/``
+    because MLflow disallows ``/`` and ``:`` in registered model names).
+    Each finalize creates a new model version linked to the eval run so they
+    appear under **Registered models** in the run UI.
+
+    Results with ``score=None`` (ERROR/SKIPPED) are skipped from numeric
+    scoring but their pass/fail status is still logged.
+
+    All MLflow SDK errors are caught and logged — they never fail
+    the evaluation pipeline.
+    """
+
+    def __init__(
+        self,
+        config: MLflowBackendConfig,
+        system_config: Optional[SystemConfig] = None,
+    ) -> None:
+        """Initialize the MLflow storage backend.
+
+        Args:
+            config: MLflow backend configuration with optional tracking_uri,
+                experiment_name fields.
+            system_config: Optional system configuration for logging run
+                params (model, judge panel, dataset context).
+        """
+        self._config = config
+        self._system_config = system_config
+        self._run: Any = None
+        self._client: Any = None
+        self._run_info: Optional[RunInfo] = None
+        self._acc = _RunAccumulators()
+
+    @property
+    def backend_name(self) -> str:
+        """Return the name of this storage backend."""
+        return "mlflow"
+
+    @property
+    def results_count(self) -> int:
+        """Return the number of results saved in this run."""
+        return self._acc.step
+
+    def initialize(self, run_info: RunInfo) -> None:
+        """Set the MLflow experiment and start a new run.
+
+        Args:
+            run_info: Information about the evaluation run.
+        """
+        self._run_info = run_info
+        self._acc = _RunAccumulators()
+
+        if not _HAS_MLFLOW:
+            logger.error(
+                "mlflow is not installed. "
+                "Add: pip install 'lightspeed-evaluation[mlflow]'"
+            )
+            return
+
+        mlflow_mod = importlib.import_module("mlflow")
+
+        try:
+            if self._config.tracking_uri:
+                mlflow_mod.set_tracking_uri(self._config.tracking_uri)
+
+            mlflow_mod.set_experiment(self._config.experiment_name)
+
+            run_name = run_info.name or f"eval_{run_info.run_id[:8]}"
+            self._run = mlflow_mod.start_run(run_name=run_name)
+            self._client = mlflow_mod
+
+            self._log_run_params(run_name, run_info)
+            self._client.set_tag("eval_status", "running")
+            logger.info("MLflow backend initialized (run_id=%s)", run_info.run_id)
+        except _MLFLOW_ERRORS:
+            logger.exception("mlflow: failed to initialize run")
+            self._run = None
+            self._client = None
+
+    def save_result(self, result: EvaluationResult) -> None:
+        """Log metrics and a trace for a single evaluation result immediately.
+
+        Args:
+            result: The evaluation result to log.
+        """
+        if self._client is None or self._run is None:
+            return
+
+        try:
+            self._log_result_metrics(result)
+            self._log_result_trace(result)
+        except _MLFLOW_ERRORS:
+            logger.exception("mlflow: failed to log result at step %d", self._acc.step)
+
+    def save_run(self, results: list[EvaluationResult]) -> None:
+        """Log metrics and traces for a batch of results immediately.
+
+        Args:
+            results: List of evaluation results to log.
+        """
+        if self._client is None or self._run is None:
+            return
+
+        for result in results:
+            try:
+                self._log_result_metrics(result)
+                self._log_result_trace(result)
+            except _MLFLOW_ERRORS:
+                logger.exception(
+                    "mlflow: failed to log result at step %d", self._acc.step
+                )
+
+    def set_evaluation_context(
+        self, evaluation_data: Optional[list[EvaluationData]] = None
+    ) -> None:
+        """No-op — MLflow export does not need the full evaluation dataset."""
+        _ = evaluation_data
+
+    def finalize(self, success: bool = True) -> None:
+        """Log aggregates, tag eval status, and end the MLflow run.
+
+        Args:
+            success: ``True`` for a complete eval (``FINISHED`` /
+                ``eval_status=complete``); ``False`` for an aborted eval
+                (``FAILED`` / ``eval_status=failed``). Incremental metrics
+                and final aggregates are logged in both cases.
+        """
+        if self._client is None or self._run is None:
+            return
+
+        status = "FINISHED" if success else "FAILED"
+        eval_status = "complete" if success else "failed"
+        try:
+            self._client.set_tag("eval_status", eval_status)
+            self._register_models()
+            self._log_aggregate_metrics()
+            self._log_results_table()
+        except _MLFLOW_ERRORS:
+            logger.exception("mlflow: failed to log aggregate metrics or table")
+        finally:
+            self._end_run(status=status)
+
+    def close(self) -> None:
+        """End the MLflow run as failed if finalize was not called."""
+        self._end_run(status="FAILED")
+
+    def _end_run(self, status: str = "FINISHED") -> None:
+        """Safely end the active MLflow run with the given status.
+
+        Args:
+            status: MLflow run status — typically ``FINISHED`` or ``FAILED``.
+        """
+        if self._client is not None and self._run is not None:
+            try:
+                if status == "FAILED":
+                    try:
+                        self._client.set_tag("eval_status", "failed")
+                    except _MLFLOW_ERRORS:
+                        logger.debug("mlflow: set_tag(eval_status) raised; ignoring")
+                self._client.end_run(status=status)
+            except _MLFLOW_ERRORS:
+                logger.debug("mlflow: end_run raised; ignoring")
+        self._run = None
+
+    def _log_run_params(self, run_name: str, run_info: RunInfo) -> None:
+        """Log run-level params including model and judge configuration.
+
+        Args:
+            run_name: Human-readable name for the run.
+            run_info: Run information with ID and timestamp.
+        """
+        params: dict[str, str] = {
+            "run_name": _truncate(run_name, 500),
+            "eval_run_id": run_info.run_id,
+        }
+
+        if self._system_config is not None:
+            cfg = self._system_config
+            params["judge_model"] = f"{cfg.llm.provider}/{cfg.llm.model}"
+            params["embedding_model"] = (
+                f"{cfg.embedding.provider}/{cfg.embedding.model}"
+            )
+
+            if cfg.judge_panel is not None:
+                params["judge_panel"] = ", ".join(cfg.judge_panel.judges)
+                params["judge_aggregation"] = cfg.judge_panel.aggregation_strategy
+
+            if cfg.agents is not None:
+                params["agents_enabled"] = str(cfg.agents.enabled)
+
+        self._client.log_params(params)
+
+    def _register_models(self) -> None:
+        """Register judge/embedding/agent models for the MLflow Models UI.
+
+        Logs a lightweight pyfunc artifact per unique ``provider>model`` and
+        registers a model version on this run. Failures are logged and do not
+        abort finalization.
+        """
+        models = self._collect_models_for_registry()
+        if not models:
+            return
+
+        model_ref = _build_eval_model_ref()
+        seen: set[str] = set()
+        for role, provider, model in models:
+            registry_name = _registry_model_name(provider, model)
+            if not registry_name or registry_name in seen:
+                continue
+            seen.add(registry_name)
+
+            artifact_path = (
+                f"registered_models/"
+                f"{_sanitize_artifact_segment(role)}_"
+                f"{_sanitize_artifact_segment(provider)}_"
+                f"{_sanitize_artifact_segment(model)}"
+            )
+            try:
+                self._client.pyfunc.log_model(
+                    artifact_path=artifact_path,
+                    python_model=model_ref,
+                    registered_model_name=registry_name,
+                    pip_requirements=["mlflow"],
+                    metadata={
+                        "role": role,
+                        "provider": provider,
+                        "model": model,
+                        "logical_name": f"{provider}/{model}",
+                    },
+                )
+                logger.info("mlflow: registered model %s (%s)", registry_name, role)
+            except _MLFLOW_ERRORS:
+                logger.exception(
+                    "mlflow: failed to register model %s (%s)", registry_name, role
+                )
+
+    def _collect_models_for_registry(self) -> list[tuple[str, str, str]]:
+        """Collect (role, provider, model) triples from system config."""
+        cfg = self._system_config
+        if cfg is None:
+            return []
+
+        models: list[tuple[str, str, str]] = []
+
+        try:
+            for judge_id, llm_cfg in cfg.get_judge_configs():
+                models.append((f"judge:{judge_id}", llm_cfg.provider, llm_cfg.model))
+        except ConfigurationError:
+            models.append(("judge", cfg.llm.provider, cfg.llm.model))
+
+        models.append(("embedding", cfg.embedding.provider, cfg.embedding.model))
+
+        if cfg.agents is not None:
+            for agent_name, agent_def in cfg.agents.agents.items():
+                provider = getattr(agent_def, "provider", None)
+                model = getattr(agent_def, "model", None)
+                if provider and model:
+                    models.append((f"agent:{agent_name}", str(provider), str(model)))
+
+        return models
+
+    def _log_result_metrics(self, result: EvaluationResult) -> None:
+        """Log all metrics for a single result at the current step.
+
+        Builds the metrics dict first, logs to MLflow, then commits
+        accumulator changes and the table row only on success.
+        """
+        acc = self._acc
+        step = acc.step
+        metric_id = _sanitize_metric_key(result.metric_identifier)
+        metrics: dict[str, float] = {}
+
+        score_val: Optional[float] = None
+        if result.score is not None:
+            score_val = float(result.score)
+            metrics[_metric_key("score/", metric_id)] = score_val
+
+        pass_val = 1.0 if result.result == "PASS" else 0.0
+        metrics[_metric_key("pass/", metric_id)] = pass_val
+
+        if result.evaluation_latency > 0:
+            metrics[_metric_key("latency/", metric_id)] = result.evaluation_latency
+
+        if result.execution_time > 0:
+            metrics[_metric_key("execution_time/", metric_id)] = result.execution_time
+
+        if result.agent_latency > 0:
+            metrics[_metric_key("agent_latency/", metric_id)] = result.agent_latency
+
+        pending_tokens = self._collect_token_metrics(result, metrics, metric_id)
+        self._collect_judge_and_streaming_metrics(result, metrics, metric_id)
+
+        self._client.log_metrics(metrics, step=step)
+
+        acc.step += 1
+        pm = acc.per_metric.setdefault(metric_id, _PerMetricAccumulator())
+        if score_val is not None:
+            acc.scores.append(score_val)
+            pm.scores.append(score_val)
+        acc.pass_values.append(pass_val)
+        pm.pass_values.append(pass_val)
+        if result.evaluation_latency > 0:
+            acc.latencies.append(result.evaluation_latency)
+        for tok_key, tok_val in pending_tokens.items():
+            acc.token_totals[tok_key] = acc.token_totals.get(tok_key, 0.0) + tok_val
+
+        self._accumulate_table_row(result)
+
+    def _log_result_trace(self, result: EvaluationResult) -> None:
+        """Log an evaluation result as an MLflow trace for row-level analysis.
+
+        Each result becomes a trace visible in the MLflow Traces tab with
+        all evaluation fields.
+        """
+        trace_name = f"{result.metric_identifier} | {result.conversation_group_id}"
+        if result.turn_id:
+            trace_name += f" | {result.turn_id}"
+
+        with self._client.start_span(name=trace_name) as span:
+            span.set_inputs(
+                {
+                    "conversation_group_id": result.conversation_group_id,
+                    "turn_id": result.turn_id or "",
+                    "metric_identifier": result.metric_identifier,
+                    "query": result.query or "",
+                    "response": result.response or "",
+                    "contexts": result.contexts or "",
+                    "tool_calls": result.tool_calls or "",
+                    "expected_response": _format_expected_response(
+                        result.expected_response
+                    ),
+                    "expected_intent": result.expected_intent or "",
+                    "expected_keywords": result.expected_keywords or "",
+                    "expected_tool_calls": result.expected_tool_calls or "",
+                }
+            )
+            span.set_outputs(
+                {
+                    "result": result.result,
+                    "score": result.score,
+                    "threshold": (
+                        result.threshold if result.threshold is not None else 0.0
+                    ),
+                    "reason": _truncate(result.reason, 4000) if result.reason else "",
+                    "judge_scores": _format_judge_scores(result.judge_scores),
+                }
+            )
+            span.set_attributes(
+                {
+                    "conversation_group_id": result.conversation_group_id,
+                    "turn_id": result.turn_id or "",
+                    "metric_identifier": result.metric_identifier,
+                    "metric_metadata": result.metric_metadata or "",
+                    "threshold": (
+                        result.threshold if result.threshold is not None else 0.0
+                    ),
+                    "evaluation_latency": result.evaluation_latency,
+                    "execution_time": result.execution_time,
+                    "api_input_tokens": result.api_input_tokens,
+                    "api_output_tokens": result.api_output_tokens,
+                    "judge_llm_input_tokens": result.judge_llm_input_tokens,
+                    "judge_llm_output_tokens": result.judge_llm_output_tokens,
+                }
+            )
+
+    def _accumulate_table_row(self, result: EvaluationResult) -> None:
+        """Accumulate a result dict for the results table artifact."""
+        max_col_len = 1000
+        self._acc.table_rows.append(
+            {
+                "conversation_group_id": result.conversation_group_id,
+                "turn_id": result.turn_id or "",
+                "metric": result.metric_identifier,
+                "result": result.result,
+                "score": result.score if result.score is not None else None,
+                "threshold": result.threshold if result.threshold is not None else None,
+                "reason": (
+                    _truncate(result.reason, max_col_len) if result.reason else ""
+                ),
+                "query": (_truncate(result.query, max_col_len) if result.query else ""),
+                "response": (
+                    _truncate(result.response, max_col_len) if result.response else ""
+                ),
+                "expected_response": _truncate(
+                    _format_expected_response(result.expected_response), max_col_len
+                ),
+                "execution_time": result.execution_time,
+                "evaluation_latency": result.evaluation_latency,
+                "agent_latency": result.agent_latency,
+                "time_to_first_token": result.time_to_first_token,
+                "streaming_duration": result.streaming_duration,
+                "tokens_per_second": result.tokens_per_second,
+                "api_input_tokens": result.api_input_tokens,
+                "api_output_tokens": result.api_output_tokens,
+                "judge_llm_input_tokens": result.judge_llm_input_tokens,
+                "judge_llm_output_tokens": result.judge_llm_output_tokens,
+                "embedding_tokens": result.embedding_tokens,
+                "judge_scores": _format_judge_scores(result.judge_scores),
+            }
+        )
+
+    @staticmethod
+    def _collect_token_metrics(
+        result: EvaluationResult, metrics: dict[str, float], metric_id: str
+    ) -> dict[str, float]:
+        """Build token usage metrics and return pending totals to commit later."""
+        token_fields = (
+            ("tokens/api_input", result.api_input_tokens),
+            ("tokens/api_output", result.api_output_tokens),
+            ("tokens/judge_input", result.judge_llm_input_tokens),
+            ("tokens/judge_output", result.judge_llm_output_tokens),
+            ("tokens/embedding", result.embedding_tokens),
+        )
+        pending_totals: dict[str, float] = {}
+        for key, value in token_fields:
+            if value > 0:
+                metrics[_metric_key(f"{key}/", metric_id)] = float(value)
+                pending_totals[key] = float(value)
+        return pending_totals
+
+    def _collect_judge_and_streaming_metrics(
+        self, result: EvaluationResult, metrics: dict[str, float], metric_id: str
+    ) -> None:
+        """Collect per-judge scores and streaming performance metrics."""
+        if result.judge_scores:
+            for judge_score in result.judge_scores:
+                if judge_score.score is not None:
+                    judge_key = _sanitize_metric_key(judge_score.judge_id)
+                    metrics[_metric_key(f"judge/{judge_key}/", metric_id)] = float(
+                        judge_score.score
+                    )
+
+        if result.time_to_first_token and result.time_to_first_token > 0:
+            metrics[_metric_key("time_to_first_token/", metric_id)] = (
+                result.time_to_first_token
+            )
+        if result.streaming_duration and result.streaming_duration > 0:
+            metrics[_metric_key("streaming_duration/", metric_id)] = (
+                result.streaming_duration
+            )
+        if result.tokens_per_second and result.tokens_per_second > 0:
+            metrics[_metric_key("tokens_per_second/", metric_id)] = (
+                result.tokens_per_second
+            )
+
+    def _log_aggregate_metrics(self) -> None:
+        """Compute and log aggregate metrics at the end of the run.
+
+        Logs both overall aggregates (mean_score, pass_rate) and per-metric
+        aggregates (pass_rate/<metric>, mean_score/<metric>) for cross-run
+        comparison in the MLflow UI.
+        """
+        acc = self._acc
+        if acc.step == 0:
+            logger.info("mlflow: no results to aggregate; skipping")
+            return
+
+        aggregate: dict[str, float] = {
+            "aggregate/result_count": float(acc.step),
+        }
+
+        if acc.scores:
+            aggregate["aggregate/mean_score"] = sum(acc.scores) / len(acc.scores)
+
+        if acc.pass_values:
+            aggregate["aggregate/pass_rate"] = sum(acc.pass_values) / len(
+                acc.pass_values
+            )
+
+        if acc.latencies:
+            aggregate["aggregate/mean_latency"] = sum(acc.latencies) / len(
+                acc.latencies
+            )
+
+        for metric_id, pm in acc.per_metric.items():
+            if pm.scores:
+                aggregate[_metric_key("aggregate/mean_score/", metric_id)] = sum(
+                    pm.scores
+                ) / len(pm.scores)
+            if pm.pass_values:
+                aggregate[_metric_key("aggregate/pass_rate/", metric_id)] = sum(
+                    pm.pass_values
+                ) / len(pm.pass_values)
+
+        token_aggregate_keys = {
+            "tokens/api_input": "aggregate/total_api_input_tokens",
+            "tokens/api_output": "aggregate/total_api_output_tokens",
+            "tokens/judge_input": "aggregate/total_judge_input_tokens",
+            "tokens/judge_output": "aggregate/total_judge_output_tokens",
+            "tokens/embedding": "aggregate/total_embedding_tokens",
+        }
+        for token_key, agg_key in token_aggregate_keys.items():
+            total = acc.token_totals.get(token_key, 0.0)
+            if total > 0:
+                aggregate[agg_key] = total
+
+        self._client.log_metrics(aggregate)
+        logger.info(
+            "MLflow backend finalized: %d results logged (run_id=%s)",
+            acc.step,
+            self._run_info.run_id if self._run_info else "unknown",
+        )
+
+    def _log_results_table(self) -> None:
+        """Log accumulated results as a table artifact for columnar viewing.
+
+        Converts the list of row dicts into a columnar dict (column name to
+        list of values) which is the format ``mlflow.log_table()`` expects.
+        Creates a browsable table in the MLflow Artifacts tab with one row
+        per evaluation result and separate columns for each field.
+        """
+        rows = self._acc.table_rows
+        if not rows:
+            return
+
+        columnar: dict[str, list[Any]] = {
+            key: [row.get(key) for row in rows] for key in rows[0]
+        }
+
+        try:
+            self._client.log_table(
+                data=columnar,
+                artifact_file="evaluation_results.json",
+            )
+            logger.info("mlflow: logged results table (%d rows)", len(rows))
+        except _MLFLOW_ERRORS:
+            logger.exception("mlflow: failed to log results table")
+
+
+_MAX_METRIC_KEY_LEN = 250
+
+
+def _build_eval_model_ref() -> Any:
+    """Build a minimal pyfunc model used to link registry entries to a run.
+
+    Built with ``type()`` so the base class can come from a dynamic
+    ``importlib`` load (mypy rejects variable base classes in ``class`` stmts).
+    """
+    # Typed as Any: importlib returns ModuleType, which has no PythonModel attr for mypy.
+    pyfunc_mod: Any = importlib.import_module("mlflow.pyfunc")
+    python_model_cls = pyfunc_mod.PythonModel
+
+    def predict(
+        self: Any,
+        context: Any,
+        model_input: Any,
+        params: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        """Return input unchanged — used only for registry linkage."""
+        _ = self, context, params
+        return model_input
+
+    def describe(self: Any) -> str:
+        """Return a short description of this registry stub."""
+        _ = self
+        return "lightspeed-evaluation registry stub"
+
+    eval_model_ref_cls = type(
+        "EvalModelRef",
+        (python_model_cls,),
+        {"predict": predict, "describe": describe},
+    )
+    return eval_model_ref_cls()
+
+
+def _registry_model_name(provider: str, model: str) -> str:
+    """Build an MLflow registered-model name as ``provider>model``.
+
+    MLflow rejects ``/`` and ``:`` in registered model names, so ``>`` is used
+    as the separator while preserving the provider/model identity.
+    """
+    provider = provider.strip()
+    model = model.strip()
+    if not provider or not model:
+        return ""
+    return _truncate(f"{provider}>{model}", _MAX_METRIC_KEY_LEN)
+
+
+def _sanitize_artifact_segment(name: str) -> str:
+    """Sanitize a path segment for MLflow artifact paths."""
+    sanitized = name.replace("/", "_").replace(":", "_").replace(">", "_")
+    sanitized = sanitized.replace(" ", "_")
+    return _truncate(sanitized, 80)
+
+
+def _sanitize_metric_key(name: str) -> str:
+    """Sanitize a metric name for use as an MLflow metric key.
+
+    MLflow metric keys allow alphanumerics, underscores, dashes, periods,
+    spaces, and slashes. Replace colons with underscores for compatibility.
+    """
+    sanitized = name.replace(":", "_")
+    return _truncate(sanitized, _MAX_METRIC_KEY_LEN)
+
+
+def _metric_key(prefix: str, metric_id: str) -> str:
+    """Compose and sanitize a full MLflow metric key from prefix and metric id.
+
+    Ensures the final composed key (e.g. ``aggregate/mean_score/ragas_faithfulness``)
+    does not exceed MLflow's 250-character limit.
+    """
+    return _truncate(f"{prefix}{metric_id}", _MAX_METRIC_KEY_LEN)
+
+
+def _format_expected_response(value: Optional[str | list[str]]) -> str:
+    """Format expected_response which can be a string or list of strings."""
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return "\n---\n".join(str(x) for x in value)
+    return str(value)
+
+
+def _format_judge_scores(judge_scores: Any) -> str:
+    """Format judge scores as a readable string for trace output."""
+    if not judge_scores:
+        return ""
+    parts: list[str] = []
+    for js in judge_scores:
+        score_str = f"{js.judge_id}: {js.score}"
+        if js.reason:
+            score_str += f" ({_truncate(js.reason, 200)})"
+        parts.append(score_str)
+    return " | ".join(parts)
+
+
+def _truncate(s: str, max_len: int) -> str:
+    """Truncate a string with ellipsis if it exceeds max_len."""
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 3] + "..."

--- a/src/lightspeed_evaluation/core/storage/protocol.py
+++ b/src/lightspeed_evaluation/core/storage/protocol.py
@@ -70,12 +70,20 @@ class BaseStorageBackend(Protocol):
             StorageError: If saving fails.
         """
 
-    def finalize(self) -> None:
-        """Finalize the backend after evaluation completes.
+    def finalize(self, success: bool = True) -> None:
+        """Finalize the backend after evaluation completes or fails.
+
+        Args:
+            success: ``True`` when the evaluation finished normally;
+                ``False`` when it aborted with an error. Backends that
+                support run status (e.g. MLflow) use this to distinguish
+                a complete eval from a failed one. Incremental results
+                already saved are left intact either way.
 
         Raises:
             StorageError: If finalization fails.
         """
+        _ = success
 
     def close(self) -> None:
         """Close the backend and release resources."""

--- a/src/lightspeed_evaluation/core/storage/sql_storage.py
+++ b/src/lightspeed_evaluation/core/storage/sql_storage.py
@@ -260,12 +260,16 @@ class SQLStorageBackend(BaseStorageBackend):
                 backend_name=self.backend_name,
             ) from e
 
-    def finalize(self) -> None:
+    def finalize(self, success: bool = True) -> None:
         """Finalize the storage backend.
+
+        Args:
+            success: Unused; accepted for :class:`BaseStorageBackend` compatibility.
 
         Raises:
             StorageError: If finalization fails.
         """
+        _ = success
         if self._run_info is None:
             return
 

--- a/src/lightspeed_evaluation/core/system/loader.py
+++ b/src/lightspeed_evaluation/core/system/loader.py
@@ -24,6 +24,7 @@ from lightspeed_evaluation.core.storage.config import (
     DatabaseBackendConfig,
     FileBackendConfig,
     LangfuseBackendConfig,
+    MLflowBackendConfig,
     StorageBackendConfig,
 )
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
@@ -41,6 +42,7 @@ SUPPORTED_STORAGE_TYPES: tuple[str, ...] = (
     "postgres",
     "mysql",
     "langfuse",
+    "mlflow",
 )
 DATABASE_STORAGE_TYPES: tuple[str, ...] = ("sqlite", "postgres", "mysql")
 
@@ -270,6 +272,8 @@ class ConfigLoader:  # pylint: disable=too-few-public-methods
                 backends.append(DatabaseBackendConfig(**item))
             elif backend_type == "langfuse":
                 backends.append(LangfuseBackendConfig(**item))
+            elif backend_type == "mlflow":
+                backends.append(MLflowBackendConfig(**item))
             else:
                 raise ConfigurationError(
                     f"Unknown storage backend type {backend_type!r}. "

--- a/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
@@ -189,13 +189,17 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
         run_name = original_data_path or "evaluation"
         self.storage_backend.initialize(RunInfo(name=run_name))
 
+        eval_succeeded = False
         try:
             # Process each conversation
             logger.info("Processing conversations")
             results = self._process_eval_data(evaluation_data)
+            eval_succeeded = True
         finally:
             self.storage_backend.set_evaluation_context(evaluation_data)
-            self.storage_backend.finalize()
+            # Pass success so backends (e.g. MLflow) can mark complete vs failed
+            # while still writing final aggregation / reports from incremental data.
+            self.storage_backend.finalize(success=eval_succeeded)
             self.storage_backend.close()
 
         if self.system_config.agents is not None and self.system_config.agents.enabled:

--- a/tests/unit/core/storage/test_composite_and_factory.py
+++ b/tests/unit/core/storage/test_composite_and_factory.py
@@ -95,8 +95,9 @@ class TestCompositeStorageBackend:  # pylint: disable=too-few-public-methods
                 _ = results
                 calls.append("save_run")
 
-            def finalize(self) -> None:
+            def finalize(self, success: bool = True) -> None:
                 """Record finalize."""
+                _ = success
                 calls.append("finalize")
 
             def close(self) -> None:

--- a/tests/unit/core/storage/test_mlflow_storage.py
+++ b/tests/unit/core/storage/test_mlflow_storage.py
@@ -1,0 +1,766 @@
+# pylint: disable=protected-access
+"""Tests for MLflow storage backend."""
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lightspeed_evaluation.core.models import LLMConfig, SystemConfig
+from lightspeed_evaluation.core.models.data import EvaluationResult, JudgeScore
+from lightspeed_evaluation.core.storage import create_pipeline_storage_backend
+from lightspeed_evaluation.core.storage.config import MLflowBackendConfig
+from lightspeed_evaluation.core.storage.mlflow_storage import (
+    MLflowStorageBackend,
+    _registry_model_name,
+)
+from lightspeed_evaluation.core.storage.protocol import RunInfo
+from lightspeed_evaluation.core.system.loader import ConfigLoader
+
+_RESULT_DEFAULTS: dict = {
+    "conversation_group_id": "conv_1",
+    "turn_id": "turn_1",
+    "metric_identifier": "ragas:answer_relevancy",
+    "result": "PASS",
+    "score": 0.85,
+    "reason": "Looks good",
+    "query": "What is OpenShift?",
+    "response": "OpenShift is a Kubernetes platform.",
+}
+
+
+def _make_result(**overrides: Any) -> EvaluationResult:
+    """Build a minimal EvaluationResult for testing."""
+    return EvaluationResult(**{**_RESULT_DEFAULTS, **overrides})
+
+
+def _create_initialized_backend(mocker: MockerFixture) -> MLflowStorageBackend:
+    """Create an MLflow backend with a mocked client ready for use."""
+    mock_client = mocker.MagicMock()
+    mock_client.start_run.return_value = mocker.MagicMock()
+
+    backend = MLflowStorageBackend(MLflowBackendConfig())
+    backend._client = mock_client
+    backend._run = mocker.MagicMock()
+    backend._run_info = RunInfo(name="test_run")
+    return backend
+
+
+class TestMLflowStorageBackend:
+    """Unit tests for MLflowStorageBackend."""
+
+    def test_backend_name(self) -> None:
+        """Backend name is 'mlflow'."""
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        assert backend.backend_name == "mlflow"
+
+    def test_results_count_starts_at_zero(self) -> None:
+        """results_count is 0 before any results are saved."""
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        assert backend.results_count == 0
+
+    def test_initialize_starts_mlflow_run(self, mocker: MockerFixture) -> None:
+        """initialize() sets experiment and starts an MLflow run."""
+        mock_mlflow = mocker.MagicMock()
+        mock_run = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mock_run
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        config = MLflowBackendConfig(
+            tracking_uri="http://localhost:5000",
+            experiment_name="test_experiment",
+        )
+        backend = MLflowStorageBackend(config)
+        backend.initialize(RunInfo(name="test_run"))
+
+        mock_mlflow.set_tracking_uri.assert_called_once_with("http://localhost:5000")
+        mock_mlflow.set_experiment.assert_called_once_with("test_experiment")
+        mock_mlflow.start_run.assert_called_once_with(run_name="test_run")
+        mock_mlflow.log_params.assert_called_once()
+        mock_mlflow.set_tag.assert_called_with("eval_status", "running")
+        assert backend._run is not None
+        assert backend._client is not None
+
+    def test_initialize_logs_run_params(self, mocker: MockerFixture) -> None:
+        """initialize() logs run_name and eval_run_id as params."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mocker.MagicMock()
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        run_info = RunInfo(name="my_eval")
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend.initialize(run_info)
+
+        params = mock_mlflow.log_params.call_args[0][0]
+        assert params["run_name"] == "my_eval"
+        assert params["eval_run_id"] == run_info.run_id
+
+    def test_initialize_skips_tracking_uri_when_none(
+        self, mocker: MockerFixture
+    ) -> None:
+        """initialize() does not call set_tracking_uri when URI is None."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mocker.MagicMock()
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        config = MLflowBackendConfig(tracking_uri=None)
+        backend = MLflowStorageBackend(config)
+        backend.initialize(RunInfo(name="test"))
+
+        mock_mlflow.set_tracking_uri.assert_not_called()
+
+    def test_initialize_logs_error_when_sdk_missing(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """initialize() logs error and sets client=None when mlflow not installed."""
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            False,
+        )
+
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        with caplog.at_level("ERROR"):
+            backend.initialize(RunInfo(name="test"))
+
+        assert "mlflow is not installed" in caplog.text
+        assert backend._client is None
+
+    def test_initialize_catches_client_error(self, mocker: MockerFixture) -> None:
+        """initialize() catches MLflow connection errors gracefully."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.side_effect = ConnectionError("refused")
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend.initialize(RunInfo(name="test"))
+        assert backend._run is None
+        assert backend._client is None
+
+    def test_close_ends_run_as_failed(self, mocker: MockerFixture) -> None:
+        """close() without finalize ends the run as FAILED."""
+        mock_client = mocker.MagicMock()
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend._client = mock_client
+        backend._run = mocker.MagicMock()
+
+        backend.close()
+
+        mock_client.set_tag.assert_called_with("eval_status", "failed")
+        mock_client.end_run.assert_called_once_with(status="FAILED")
+        assert backend._run is None
+
+    def test_close_noop_when_no_run(self) -> None:
+        """close() is a no-op when no run is active."""
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend._client = None
+        backend._run = None
+        backend.close()
+
+
+class TestMLflowMetricLogging:
+    """Tests for incremental metric logging behavior."""
+
+    def test_save_result_logs_metrics_immediately(self, mocker: MockerFixture) -> None:
+        """save_result() logs metrics to MLflow immediately with step."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(_make_result(score=0.9))
+
+        backend._client.log_metrics.assert_called_once()
+        call_kwargs = backend._client.log_metrics.call_args
+        metrics = call_kwargs[0][0]
+        assert metrics["score/ragas_answer_relevancy"] == pytest.approx(0.9)
+        assert metrics["pass/ragas_answer_relevancy"] == 1.0
+        assert call_kwargs[1]["step"] == 0
+        assert backend.results_count == 1
+
+    def test_save_result_increments_step(self, mocker: MockerFixture) -> None:
+        """save_result() increments step for each result."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(_make_result())
+        backend.save_result(_make_result())
+        backend.save_result(_make_result())
+
+        assert backend.results_count == 3
+        calls = backend._client.log_metrics.call_args_list
+        assert calls[0][1]["step"] == 0
+        assert calls[1][1]["step"] == 1
+        assert calls[2][1]["step"] == 2
+
+    def test_save_run_logs_each_result_immediately(self, mocker: MockerFixture) -> None:
+        """save_run() logs each result in the batch immediately."""
+        backend = _create_initialized_backend(mocker)
+
+        results = [_make_result(score=0.8), _make_result(score=0.6, result="FAIL")]
+        backend.save_run(results)
+
+        assert backend._client.log_metrics.call_count == 2
+        assert backend.results_count == 2
+
+        first_call = backend._client.log_metrics.call_args_list[0]
+        assert first_call[0][0]["score/ragas_answer_relevancy"] == pytest.approx(0.8)
+        assert first_call[0][0]["pass/ragas_answer_relevancy"] == 1.0
+        assert first_call[1]["step"] == 0
+
+        second_call = backend._client.log_metrics.call_args_list[1]
+        assert second_call[0][0]["score/ragas_answer_relevancy"] == pytest.approx(0.6)
+        assert second_call[0][0]["pass/ragas_answer_relevancy"] == 0.0
+        assert second_call[1]["step"] == 1
+
+    def test_save_result_skips_none_score(self, mocker: MockerFixture) -> None:
+        """save_result() skips score metric when score is None."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(_make_result(score=None, result="ERROR"))
+
+        metrics = backend._client.log_metrics.call_args[0][0]
+        assert "score/ragas_answer_relevancy" not in metrics
+        assert metrics["pass/ragas_answer_relevancy"] == 0.0
+
+    def test_save_result_noop_when_no_client(self) -> None:
+        """save_result() is a no-op when client failed to initialize."""
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend._client = None
+        backend._run = None
+        backend.save_result(_make_result())
+        assert backend.results_count == 0
+
+    def test_save_result_logs_token_metrics(self, mocker: MockerFixture) -> None:
+        """save_result() logs token usage as MLflow metrics with metric_id."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                api_input_tokens=100,
+                api_output_tokens=50,
+                judge_llm_input_tokens=200,
+                judge_llm_output_tokens=80,
+                embedding_tokens=30,
+            )
+        )
+
+        metrics = backend._client.log_metrics.call_args[0][0]
+        assert metrics["tokens/api_input/ragas_answer_relevancy"] == 100.0
+        assert metrics["tokens/api_output/ragas_answer_relevancy"] == 50.0
+        assert metrics["tokens/judge_input/ragas_answer_relevancy"] == 200.0
+        assert metrics["tokens/judge_output/ragas_answer_relevancy"] == 80.0
+        assert metrics["tokens/embedding/ragas_answer_relevancy"] == 30.0
+
+    def test_save_result_logs_latency_metrics(self, mocker: MockerFixture) -> None:
+        """save_result() logs latency as MLflow metrics with metric_id."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(evaluation_latency=1.5, execution_time=2.0, agent_latency=0.8)
+        )
+
+        metrics = backend._client.log_metrics.call_args[0][0]
+        assert metrics["latency/ragas_answer_relevancy"] == pytest.approx(1.5)
+        assert metrics["execution_time/ragas_answer_relevancy"] == pytest.approx(2.0)
+        assert metrics["agent_latency/ragas_answer_relevancy"] == pytest.approx(0.8)
+
+    def test_save_result_logs_judge_panel_scores(self, mocker: MockerFixture) -> None:
+        """save_result() preserves per-judge scores as MLflow metrics."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                judge_scores=[
+                    JudgeScore(judge_id="gpt-4o-mini", score=0.9, reason="good"),
+                    JudgeScore(judge_id="gpt-4.1-mini", score=0.8, reason="ok"),
+                ],
+            )
+        )
+
+        metrics = backend._client.log_metrics.call_args[0][0]
+        assert metrics["judge/gpt-4o-mini/ragas_answer_relevancy"] == pytest.approx(0.9)
+        assert metrics["judge/gpt-4.1-mini/ragas_answer_relevancy"] == pytest.approx(
+            0.8
+        )
+
+    def test_save_result_logs_streaming_metrics(self, mocker: MockerFixture) -> None:
+        """save_result() logs streaming performance metrics with metric_id."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                time_to_first_token=0.25,
+                streaming_duration=3.5,
+                tokens_per_second=42.0,
+            )
+        )
+
+        metrics = backend._client.log_metrics.call_args[0][0]
+        assert metrics["time_to_first_token/ragas_answer_relevancy"] == pytest.approx(
+            0.25
+        )
+        assert metrics["streaming_duration/ragas_answer_relevancy"] == pytest.approx(
+            3.5
+        )
+        assert metrics["tokens_per_second/ragas_answer_relevancy"] == pytest.approx(
+            42.0
+        )
+
+    def test_finalize_logs_aggregate_metrics(self, mocker: MockerFixture) -> None:
+        """finalize() computes and logs aggregate metrics."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(score=0.8, result="PASS", evaluation_latency=1.0)
+        )
+        backend.save_result(
+            _make_result(score=0.4, result="FAIL", evaluation_latency=2.0)
+        )
+
+        backend._client.log_metrics.reset_mock()
+        backend.finalize()
+
+        aggregate_call = backend._client.log_metrics.call_args[0][0]
+        assert aggregate_call["aggregate/mean_score"] == pytest.approx(0.6)
+        assert aggregate_call["aggregate/pass_rate"] == pytest.approx(0.5)
+        assert aggregate_call["aggregate/mean_latency"] == pytest.approx(1.5)
+        assert aggregate_call["aggregate/result_count"] == 2.0
+
+    def test_finalize_logs_aggregate_token_totals(self, mocker: MockerFixture) -> None:
+        """finalize() logs total token counts including embedding as aggregates."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                api_input_tokens=100, api_output_tokens=50, embedding_tokens=20
+            )
+        )
+        backend.save_result(
+            _make_result(
+                api_input_tokens=200, api_output_tokens=100, embedding_tokens=30
+            )
+        )
+
+        backend._client.log_metrics.reset_mock()
+        backend.finalize()
+
+        aggregate_call = backend._client.log_metrics.call_args[0][0]
+        assert aggregate_call["aggregate/total_api_input_tokens"] == 300.0
+        assert aggregate_call["aggregate/total_api_output_tokens"] == 150.0
+        assert aggregate_call["aggregate/total_embedding_tokens"] == 50.0
+
+    def test_finalize_ends_run_as_finished(self, mocker: MockerFixture) -> None:
+        """finalize(success=True) ends the run as FINISHED with complete tag."""
+        backend = _create_initialized_backend(mocker)
+        backend.save_result(_make_result())
+
+        backend.finalize(success=True)
+
+        backend._client.set_tag.assert_called_with("eval_status", "complete")
+        backend._client.end_run.assert_called_once_with(status="FINISHED")
+        assert backend._run is None
+
+    def test_finalize_ends_run_as_failed(self, mocker: MockerFixture) -> None:
+        """finalize(success=False) ends the run as FAILED with failed tag."""
+        backend = _create_initialized_backend(mocker)
+        backend.save_result(_make_result())
+
+        backend.finalize(success=False)
+
+        backend._client.set_tag.assert_called_with("eval_status", "failed")
+        backend._client.end_run.assert_called_once_with(status="FAILED")
+        assert backend._run is None
+
+    def test_finalize_failed_still_logs_aggregates(self, mocker: MockerFixture) -> None:
+        """finalize(success=False) still writes aggregates from incremental data."""
+        backend = _create_initialized_backend(mocker)
+        backend.save_result(_make_result(score=0.8, result="PASS"))
+        backend._client.log_metrics.reset_mock()
+
+        backend.finalize(success=False)
+
+        aggregate_call = backend._client.log_metrics.call_args[0][0]
+        assert aggregate_call["aggregate/mean_score"] == pytest.approx(0.8)
+        assert aggregate_call["aggregate/result_count"] == 1.0
+
+    def test_finalize_noop_when_no_client(self) -> None:
+        """finalize() is a no-op when client failed to initialize."""
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend._client = None
+        backend._run = None
+        backend.finalize()
+
+    def test_finalize_skips_aggregates_with_no_results(
+        self, mocker: MockerFixture
+    ) -> None:
+        """finalize() skips aggregate logging when no results were saved."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.finalize()
+
+        backend._client.end_run.assert_called_once_with(status="FINISHED")
+        backend._client.log_metrics.assert_not_called()
+
+    def test_finalize_registers_models_as_provider_gt_model(
+        self, mocker: MockerFixture
+    ) -> None:
+        """finalize() registers judge and embedding as provider>model."""
+        mock_pyfunc = mocker.MagicMock()
+        mock_pyfunc.PythonModel = type("PythonModel", (), {})
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            side_effect=lambda name: (
+                mock_pyfunc if name == "mlflow.pyfunc" else mocker.MagicMock()
+            ),
+        )
+
+        system_config = SystemConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4o-mini")
+        )
+        backend = _create_initialized_backend(mocker)
+        backend._system_config = system_config
+        backend.save_result(_make_result())
+
+        backend.finalize(success=True)
+
+        assert backend._client.pyfunc.log_model.call_count >= 2
+        registered_names = {
+            call.kwargs["registered_model_name"]
+            for call in backend._client.pyfunc.log_model.call_args_list
+        }
+        assert registered_names == {
+            "openai>gpt-4o-mini",
+            "openai>text-embedding-3-small",
+        }
+
+    def test_registry_model_name_uses_gt_separator(self) -> None:
+        """Registered model names use provider>model (MLflow forbids /)."""
+        assert _registry_model_name("openai", "gpt-4o-mini") == "openai>gpt-4o-mini"
+        assert _registry_model_name("  watsonx ", " granite ") == "watsonx>granite"
+        assert _registry_model_name("", "gpt") == ""
+
+
+class TestMLflowPerMetricAggregates:
+    """Tests for per-metric aggregate metrics logged at finalize."""
+
+    def test_per_metric_pass_rates(self, mocker: MockerFixture) -> None:
+        """finalize() logs pass_rate for each distinct metric."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                metric_identifier="ragas:faithfulness", result="PASS", score=0.9
+            )
+        )
+        backend.save_result(
+            _make_result(
+                metric_identifier="ragas:faithfulness", result="FAIL", score=0.3
+            )
+        )
+        backend.save_result(
+            _make_result(metric_identifier="custom:tool_eval", result="PASS", score=1.0)
+        )
+
+        backend._client.log_metrics.reset_mock()
+        backend.finalize()
+
+        agg = backend._client.log_metrics.call_args[0][0]
+        assert agg["aggregate/pass_rate/ragas_faithfulness"] == pytest.approx(0.5)
+        assert agg["aggregate/pass_rate/custom_tool_eval"] == pytest.approx(1.0)
+
+    def test_per_metric_mean_scores(self, mocker: MockerFixture) -> None:
+        """finalize() logs mean_score for each distinct metric."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(metric_identifier="ragas:faithfulness", score=0.8)
+        )
+        backend.save_result(
+            _make_result(metric_identifier="ragas:faithfulness", score=0.6)
+        )
+        backend.save_result(
+            _make_result(metric_identifier="custom:tool_eval", score=1.0)
+        )
+
+        backend._client.log_metrics.reset_mock()
+        backend.finalize()
+
+        agg = backend._client.log_metrics.call_args[0][0]
+        assert agg["aggregate/mean_score/ragas_faithfulness"] == pytest.approx(0.7)
+        assert agg["aggregate/mean_score/custom_tool_eval"] == pytest.approx(1.0)
+
+    def test_per_metric_none_score_excluded(self, mocker: MockerFixture) -> None:
+        """Per-metric mean_score excludes results with score=None."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                metric_identifier="ragas:faithfulness", score=0.8, result="PASS"
+            )
+        )
+        backend.save_result(
+            _make_result(
+                metric_identifier="ragas:faithfulness", score=None, result="ERROR"
+            )
+        )
+
+        backend._client.log_metrics.reset_mock()
+        backend.finalize()
+
+        agg = backend._client.log_metrics.call_args[0][0]
+        assert agg["aggregate/mean_score/ragas_faithfulness"] == pytest.approx(0.8)
+        assert agg["aggregate/pass_rate/ragas_faithfulness"] == pytest.approx(0.5)
+
+
+class TestMLflowResultsTable:
+    """Tests for log_table() results artifact."""
+
+    def test_finalize_logs_table(self, mocker: MockerFixture) -> None:
+        """finalize() calls log_table with columnar dict."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(_make_result(score=0.9, result="PASS"))
+        backend.save_result(_make_result(score=0.4, result="FAIL"))
+
+        backend.finalize()
+
+        backend._client.log_table.assert_called_once()
+        call_kwargs = backend._client.log_table.call_args
+        table_data = call_kwargs[1]["data"]
+        assert isinstance(table_data, dict)
+        assert len(table_data["result"]) == 2
+        assert call_kwargs[1]["artifact_file"] == "evaluation_results.json"
+
+    def test_table_has_expected_columns(self, mocker: MockerFixture) -> None:
+        """Table dict contains the expected column keys."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(_make_result())
+
+        backend.finalize()
+
+        table = backend._client.log_table.call_args[1]["data"]
+        expected_keys = {
+            "conversation_group_id",
+            "turn_id",
+            "metric",
+            "result",
+            "score",
+            "threshold",
+            "reason",
+            "query",
+            "response",
+            "expected_response",
+            "execution_time",
+            "evaluation_latency",
+            "agent_latency",
+            "time_to_first_token",
+            "streaming_duration",
+            "tokens_per_second",
+            "api_input_tokens",
+            "api_output_tokens",
+            "judge_llm_input_tokens",
+            "judge_llm_output_tokens",
+            "embedding_tokens",
+            "judge_scores",
+        }
+        assert expected_keys.issubset(table.keys())
+
+    def test_table_column_values(self, mocker: MockerFixture) -> None:
+        """Table column values match the evaluation result."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.save_result(
+            _make_result(
+                score=0.85,
+                result="PASS",
+                api_input_tokens=100,
+                api_output_tokens=50,
+                judge_llm_input_tokens=200,
+                judge_llm_output_tokens=80,
+                embedding_tokens=30,
+                evaluation_latency=1.5,
+                execution_time=2.0,
+                agent_latency=0.8,
+                time_to_first_token=0.25,
+                streaming_duration=3.5,
+                tokens_per_second=42.0,
+            )
+        )
+
+        backend.finalize()
+
+        table = backend._client.log_table.call_args[1]["data"]
+        assert table["conversation_group_id"][0] == "conv_1"
+        assert table["metric"][0] == "ragas:answer_relevancy"
+        assert table["result"][0] == "PASS"
+        assert table["score"][0] == pytest.approx(0.85)
+        assert table["query"][0] == "What is OpenShift?"
+        assert table["api_input_tokens"][0] == 100
+        assert table["api_output_tokens"][0] == 50
+        assert table["judge_llm_input_tokens"][0] == 200
+        assert table["judge_llm_output_tokens"][0] == 80
+        assert table["embedding_tokens"][0] == 30
+        assert table["evaluation_latency"][0] == pytest.approx(1.5)
+        assert table["execution_time"][0] == pytest.approx(2.0)
+        assert table["agent_latency"][0] == pytest.approx(0.8)
+        assert table["time_to_first_token"][0] == pytest.approx(0.25)
+        assert table["streaming_duration"][0] == pytest.approx(3.5)
+        assert table["tokens_per_second"][0] == pytest.approx(42.0)
+
+    def test_table_not_logged_with_no_results(self, mocker: MockerFixture) -> None:
+        """finalize() skips log_table when no results exist."""
+        backend = _create_initialized_backend(mocker)
+
+        backend.finalize()
+
+        backend._client.log_table.assert_not_called()
+
+
+class TestMLflowRunParams:
+    """Tests for run params logged from system_config."""
+
+    def test_params_include_system_config(self, mocker: MockerFixture) -> None:
+        """initialize() logs judge_model and embedding_model from system_config."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mocker.MagicMock()
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        mock_config = mocker.MagicMock()
+        mock_config.llm.provider = "openai"
+        mock_config.llm.model = "gpt-4o-mini"
+        mock_config.embedding.provider = "openai"
+        mock_config.embedding.model = "text-embedding-3-small"
+        mock_config.judge_panel = None
+        mock_config.agents = None
+
+        backend = MLflowStorageBackend(MLflowBackendConfig(), system_config=mock_config)
+        backend.initialize(RunInfo(name="test"))
+
+        params = mock_mlflow.log_params.call_args[0][0]
+        assert params["judge_model"] == "openai/gpt-4o-mini"
+        assert params["embedding_model"] == "openai/text-embedding-3-small"
+
+    def test_params_include_judge_panel(self, mocker: MockerFixture) -> None:
+        """initialize() logs judge_panel and aggregation_strategy."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mocker.MagicMock()
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        mock_config = mocker.MagicMock()
+        mock_config.llm.provider = "openai"
+        mock_config.llm.model = "gpt-4o-mini"
+        mock_config.embedding.provider = "openai"
+        mock_config.embedding.model = "text-embedding-3-small"
+        mock_config.judge_panel.judges = ["gpt-4.1-mini", "gpt-4o-mini"]
+        mock_config.judge_panel.aggregation_strategy = "max"
+        mock_config.agents = None
+
+        backend = MLflowStorageBackend(MLflowBackendConfig(), system_config=mock_config)
+        backend.initialize(RunInfo(name="test"))
+
+        params = mock_mlflow.log_params.call_args[0][0]
+        assert params["judge_panel"] == "gpt-4.1-mini, gpt-4o-mini"
+        assert params["judge_aggregation"] == "max"
+
+    def test_params_without_system_config(self, mocker: MockerFixture) -> None:
+        """initialize() logs basic params when system_config is None."""
+        mock_mlflow = mocker.MagicMock()
+        mock_mlflow.start_run.return_value = mocker.MagicMock()
+
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage._HAS_MLFLOW",
+            True,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.core.storage.mlflow_storage.importlib.import_module",
+            return_value=mock_mlflow,
+        )
+
+        backend = MLflowStorageBackend(MLflowBackendConfig())
+        backend.initialize(RunInfo(name="test"))
+
+        params = mock_mlflow.log_params.call_args[0][0]
+        assert "run_name" in params
+        assert "eval_run_id" in params
+        assert "judge_model" not in params
+
+
+class TestMLflowFactoryAndLoader:
+    """Integration tests for factory and config loader."""
+
+    def test_factory_creates_mlflow_backend(self) -> None:
+        """create_pipeline_storage_backend handles MLflowBackendConfig."""
+        backend = create_pipeline_storage_backend([MLflowBackendConfig()])
+        assert isinstance(backend, MLflowStorageBackend)
+        backend.close()
+
+    def test_loader_parses_mlflow_config(self) -> None:
+        """ConfigLoader._parse_storage_config handles type='mlflow'."""
+        loader = ConfigLoader()
+        configs = loader._parse_storage_config(
+            [
+                {
+                    "type": "mlflow",
+                    "tracking_uri": "http://localhost:5000",
+                    "experiment_name": "my_eval",
+                }
+            ]
+        )
+        assert len(configs) == 1
+        assert isinstance(configs[0], MLflowBackendConfig)
+        assert configs[0].tracking_uri == "http://localhost:5000"
+        assert configs[0].experiment_name == "my_eval"
+
+    def test_loader_parses_mlflow_config_defaults(self) -> None:
+        """ConfigLoader._parse_storage_config uses defaults for mlflow."""
+        loader = ConfigLoader()
+        configs = loader._parse_storage_config([{"type": "mlflow"}])
+        assert len(configs) == 1
+        assert isinstance(configs[0], MLflowBackendConfig)
+        assert configs[0].tracking_uri is None
+        assert configs[0].experiment_name == "lightspeed_evaluation"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Opus-4.6-high
- Generated by: Cursor

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LEADS-503
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLflow as a storage backend for evaluation runs and results.
  * Storage settings now accept MLflow configuration (tracking URI and experiment name).
  * MLflow now records run parameters, per-result metrics and traces, and aggregate metrics on completion.
* **Bug Fixes**
  * If MLflow is unavailable or initialization/logging fails, evaluation proceeds with MLflow logging disabled.
* **Reliability Improvements**
  * Storage finalization now reflects whether the evaluation succeeded, updating completion status accordingly.
* **Tests**
  * Added unit tests for MLflow backend lifecycle, metric/trace logging, config parsing, and backend factory wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->