### PR TITLE
feat: add new repeat and parallel config for NxM

### DIFF
--- a/src/lightspeed_evaluation/core/models/agents.py
+++ b/src/lightspeed_evaluation/core/models/agents.py
@@ -220,6 +220,16 @@ class AgentDefaultConfig(BaseModel):
         description="Shared default agent config overrides applied to all agents",
     )
 
+    repeat: int = Field(
+        default=1,
+        gt=0,
+        description="Number of times to run each agent evaluation",
+    )
+    parallel: bool = Field(
+        default=False,
+        description="Run agent evaluations in parallel",
+    )
+
 
 class AgentsConfig(BaseModel):
     """Top-level agents configuration container.

--- a/tests/unit/core/models/test_agents.py
+++ b/tests/unit/core/models/test_agents.py
@@ -120,10 +120,28 @@ class TestAgentDefaultConfig:
     """Tests for AgentDefaultConfig model."""
 
     def test_defaults(self) -> None:
-        """Test all fields default to None."""
+        """Test all fields default to expected values."""
         config = AgentDefaultConfig()
         assert config.agent is None
+        assert config.repeat == 1
+        assert config.parallel is False
         assert config.agent_config is None
+
+    def test_repeat_and_parallel(self) -> None:
+        """Test setting repeat and parallel."""
+        config = AgentDefaultConfig(agent=["ols_api"], repeat=3, parallel=True)
+        assert config.repeat == 3
+        assert config.parallel is True
+
+    def test_repeat_zero_rejected(self) -> None:
+        """Test repeat must be positive."""
+        with pytest.raises(ValidationError):
+            AgentDefaultConfig(repeat=0)
+
+    def test_repeat_negative_rejected(self) -> None:
+        """Test negative repeat is rejected."""
+        with pytest.raises(ValidationError):
+            AgentDefaultConfig(repeat=-1)
 
     def test_with_agent_config(self) -> None:
         """Test setting agent list and agent_config."""


### PR DESCRIPTION
## Description

add new repeat and parallel config for NxM (Just the config change)

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added evaluation control options to agent configuration.
  * Evaluations can now be repeated a specified number of times.
  * Added an option to run repeated evaluations in parallel.
  * Repeat counts must be greater than zero (default is 1); parallel execution is disabled by default.  
* **Tests**
  * Updated model unit tests to cover new default values and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->