### PR TITLE
feat: multi-agent config override from eval data

### DIFF
--- a/src/lightspeed_evaluation/core/models/agents.py
+++ b/src/lightspeed_evaluation/core/models/agents.py
@@ -2,9 +2,16 @@
 
 import logging
 import os
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from lightspeed_evaluation.core.constants import (
     DEFAULT_API_BASE,
@@ -15,6 +22,7 @@ from lightspeed_evaluation.core.constants import (
     SUPPORTED_AGENT_TYPES,
     SUPPORTED_ENDPOINT_TYPES,
 )
+from lightspeed_evaluation.core.models.utils import normalize_string_list
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
 
 logger = logging.getLogger(__name__)
@@ -196,28 +204,16 @@ class AgentDefaultConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    agent: Optional[list[str]] = Field(
+    agent: Optional[
+        Annotated[
+            list[str],
+            BeforeValidator(lambda v: normalize_string_list(v, "Agent names")),
+        ]
+    ] = Field(
         default=None,
         min_length=1,
-        description="List of agent names to evaluate against",
+        description="Agent name(s) to evaluate against",
     )
-
-    @field_validator("agent", mode="before")
-    @classmethod
-    def normalize_and_validate_agent(cls, v: Any) -> Any:
-        """Normalize string to list and validate each agent name."""
-        if isinstance(v, str):
-            v = [v]
-        if isinstance(v, list):
-            stripped = []
-            for name in v:
-                if not isinstance(name, str) or not name.strip():
-                    raise ValueError(
-                        f"Agent names must be non-empty strings, got: {name!r}"
-                    )
-                stripped.append(name.strip())
-            return stripped
-        return v
 
     agent_config: Optional[dict[str, Any]] = Field(
         default=None,
@@ -304,7 +300,7 @@ class AgentsConfig(BaseModel):
         Raises:
             ConfigurationError: If no agent can be resolved or agent not found.
         """
-        default_agents: list[str] = self.default.agent or []
+        default_agents = self.default.agent or []
         if agent_name:
             name = agent_name
         elif default_agents:

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -2,12 +2,20 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from lightspeed_evaluation.core.constants import SUPPORTED_RESULT_STATUSES
 from lightspeed_evaluation.core.models.mixins import StreamingMetricsMixin
+from lightspeed_evaluation.core.models.utils import normalize_string_list
 
 logger = logging.getLogger(__name__)
 
@@ -580,14 +588,20 @@ class EvaluationData(BaseModel):
     )
 
     # Agent selection and config override
-    agent: Optional[str] = Field(
+    agent: Optional[
+        Annotated[
+            list[str],
+            BeforeValidator(lambda v: normalize_string_list(v, "Agent names")),
+        ]
+    ] = Field(
         default=None,
         min_length=1,
-        description="Agent name for this conversation group (overrides agents.default.agent)",
+        description="Agent name(s) for this conversation group (overrides agents.default.agent)",
     )
+
     agent_config: Optional[dict[str, Any]] = Field(
         default=None,
-        description="Per-conversation agent config overrides (highest priority)",
+        description="Agent config overrides — flat dict (applies to all) or keyed by agent name",
     )
 
     # Set of conversation metrics that don't pass the validation to ignore them later

--- a/src/lightspeed_evaluation/core/models/utils.py
+++ b/src/lightspeed_evaluation/core/models/utils.py
@@ -1,0 +1,27 @@
+"""Shared validation utilities for model fields."""
+
+from typing import Any
+
+
+def normalize_string_list(v: Any, field_name: str = "value") -> Any:
+    """Normalize str to list, validate non-empty, strip whitespace, deduplicate."""
+    if isinstance(v, str):
+        v = [v]
+    if isinstance(v, list):
+        seen: set[str] = set()
+        result: list[str] = []
+        for item in v:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError(
+                    f"{field_name} must be non-empty strings, got: {item!r}"
+                )
+            clean = item.strip()
+            if clean not in seen:
+                result.append(clean)
+                seen.add(clean)
+        return result
+    if v is not None:
+        raise ValueError(
+            f"{field_name} must be a string or list of strings, got: {type(v).__name__}"
+        )
+    return v

--- a/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/pipeline.py
@@ -44,6 +44,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_eval_data_agent_config(
+    agent_config: Optional[dict[str, Any]],
+    agent_name: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Extract agent-specific config from flat or keyed format.
+
+    Flat format (applies to all agents): {"timeout": 1200}
+    Keyed format (per-agent): {"model_a": {"timeout": 300}}
+
+    Detection: if any value is a dict, the format is keyed.
+    """
+    if not agent_config:
+        return None
+    is_keyed = any(isinstance(v, dict) for v in agent_config.values())
+    if is_keyed:
+        if agent_name and agent_name in agent_config:
+            return agent_config[agent_name]  # type: ignore[return-value]
+        return None
+    return agent_config
+
+
 class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
     """Evaluation pipeline - orchestrates the evaluation process through different stages.
 
@@ -155,9 +176,14 @@ class EvaluationPipeline:  # pylint: disable=too-many-instance-attributes
         if not self.system_config.agents.enabled:
             return self._default_driver, False
 
+        agent_name = conv_data.agent[0] if conv_data.agent else None
+        agent_config_override = _resolve_eval_data_agent_config(
+            conv_data.agent_config, agent_name
+        )
+
         _name, agent_config = self.system_config.agents.resolve_agent_config(
-            agent_name=conv_data.agent,
-            agent_config_override=conv_data.agent_config,
+            agent_name=agent_name,
+            agent_config_override=agent_config_override,
         )
         return (
             self._registry.create_driver(

--- a/tests/unit/core/models/test_agents.py
+++ b/tests/unit/core/models/test_agents.py
@@ -139,6 +139,11 @@ class TestAgentDefaultConfig:
         config = AgentDefaultConfig(agent=["agent_a", "agent_b"])
         assert config.agent == ["agent_a", "agent_b"]
 
+    def test_duplicate_agents_deduplicated(self) -> None:
+        """Test duplicate agent names are silently removed."""
+        config = AgentDefaultConfig(agent=["model_a", "model_b", "model_a"])
+        assert config.agent == ["model_a", "model_b"]
+
     def test_string_agent_normalized_to_list(self) -> None:
         """Test string agent is auto-converted to single-element list."""
         config = AgentDefaultConfig.model_validate({"agent": "ols_api"})
@@ -168,6 +173,11 @@ class TestAgentDefaultConfig:
         """Test list containing empty string is rejected."""
         with pytest.raises(ValidationError):
             AgentDefaultConfig(agent=["ols_api", ""])
+
+    def test_invalid_type_rejected(self) -> None:
+        """Test non-str/non-list type is rejected."""
+        with pytest.raises(ValidationError):
+            AgentDefaultConfig.model_validate({"agent": 42})
 
 
 class TestAgentsConfig:

--- a/tests/unit/core/models/test_data.py
+++ b/tests/unit/core/models/test_data.py
@@ -762,33 +762,94 @@ class TestEvaluationDataAgentFields:
         assert data.agent is None
         assert data.agent_config is None
 
-    def test_agent_field_accepted(self) -> None:
-        """Agent name is accepted."""
+    def test_agent_list_accepted(self) -> None:
+        """Agent list is accepted."""
         data = EvaluationData(
             conversation_group_id="cg1",
-            agent="openshift_agentic_lightspeed",
+            agent=["openshift_agentic_lightspeed"],
             turns=[TurnData(turn_id="t1", query="Q")],
         )
-        assert data.agent == "openshift_agentic_lightspeed"
+        assert data.agent == ["openshift_agentic_lightspeed"]
 
-    def test_agent_config_accepted(self) -> None:
-        """Agent config dict is accepted."""
+    def test_agent_string_normalized_to_list(self) -> None:
+        """String agent is auto-converted to single-element list."""
+        data = EvaluationData.model_validate(
+            {
+                "conversation_group_id": "cg1",
+                "agent": "ols_api",
+                "turns": [{"turn_id": "t1", "query": "Q"}],
+            }
+        )
+        assert data.agent == ["ols_api"]
+
+    def test_duplicate_agents_deduplicated(self) -> None:
+        """Duplicate agent names are silently removed."""
         data = EvaluationData(
             conversation_group_id="cg1",
-            agent="ols_api",
+            agent=["model_a", "model_b", "model_a"],
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        assert data.agent == ["model_a", "model_b"]
+
+    def test_agent_multi_list_accepted(self) -> None:
+        """Multiple agents in list accepted."""
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            agent=["model_a", "model_b"],
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        assert data.agent == ["model_a", "model_b"]
+
+    def test_agent_config_keyed_by_agent(self) -> None:
+        """Agent config keyed by agent name is accepted."""
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            agent=["model_a"],
+            agent_config={"model_a": {"timeout": 1200}},
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        assert data.agent_config == {"model_a": {"timeout": 1200}}
+
+    def test_agent_config_flat_accepted(self) -> None:
+        """Flat agent config (applies to all agents) is accepted."""
+        data = EvaluationData(
+            conversation_group_id="cg1",
+            agent=["model_a"],
             agent_config={"timeout": 1200, "namespace": "custom"},
             turns=[TurnData(turn_id="t1", query="Q")],
         )
         assert data.agent_config == {"timeout": 1200, "namespace": "custom"}
 
-    def test_empty_agent_name_rejected(self) -> None:
-        """Empty string agent name is rejected."""
+    def test_empty_agent_list_rejected(self) -> None:
+        """Empty agent list is rejected."""
         with pytest.raises(ValidationError):
             EvaluationData(
                 conversation_group_id="cg1",
-                agent="",
+                agent=[],
                 turns=[TurnData(turn_id="t1", query="Q")],
             )
+
+    def test_empty_string_agent_rejected(self) -> None:
+        """Empty string agent is rejected."""
+        with pytest.raises(ValidationError):
+            EvaluationData.model_validate(
+                {
+                    "conversation_group_id": "cg1",
+                    "agent": "",
+                    "turns": [{"turn_id": "t1", "query": "Q"}],
+                }
+            )
+
+    def test_padded_agent_name_stripped(self) -> None:
+        """Whitespace-padded agent name is stripped."""
+        data = EvaluationData.model_validate(
+            {
+                "conversation_group_id": "cg1",
+                "agent": " ols_api ",
+                "turns": [{"turn_id": "t1", "query": "Q"}],
+            }
+        )
+        assert data.agent == ["ols_api"]
 
 
 class TestConversationMetadata:

--- a/tests/unit/pipeline/evaluation/test_agent_config_resolve.py
+++ b/tests/unit/pipeline/evaluation/test_agent_config_resolve.py
@@ -1,0 +1,55 @@
+"""Tests for _resolve_eval_data_agent_config helper."""
+
+from lightspeed_evaluation.pipeline.evaluation.pipeline import (
+    _resolve_eval_data_agent_config,
+)
+
+
+class TestResolveEvalDataAgentConfig:
+    """Tests for flat vs keyed agent_config resolution."""
+
+    def test_none_config_returns_none(self) -> None:
+        """No config returns None."""
+        assert _resolve_eval_data_agent_config(None, "model_a") is None
+
+    def test_empty_config_returns_none(self) -> None:
+        """Empty dict returns None."""
+        assert _resolve_eval_data_agent_config({}, "model_a") is None
+
+    def test_flat_config_returned_as_is(self) -> None:
+        """Flat config applies to all agents."""
+        config = {"timeout": 1200, "num_retries": 5}
+        result = _resolve_eval_data_agent_config(config, "model_a")
+        assert result == {"timeout": 1200, "num_retries": 5}
+
+    def test_flat_config_with_no_agent_name(self) -> None:
+        """Flat config with no agent name still returned."""
+        config = {"timeout": 1200}
+        result = _resolve_eval_data_agent_config(config, None)
+        assert result == {"timeout": 1200}
+
+    def test_keyed_config_matching_agent(self) -> None:
+        """Keyed config returns matching agent's config."""
+        config = {
+            "model_a": {"timeout": 300},
+            "model_b": {"timeout": 600},
+        }
+        result = _resolve_eval_data_agent_config(config, "model_a")
+        assert result == {"timeout": 300}
+
+    def test_keyed_config_no_match_returns_none(self) -> None:
+        """Keyed config with unmatched agent returns None."""
+        config = {
+            "model_a": {"timeout": 300},
+            "model_b": {"timeout": 600},
+        }
+        result = _resolve_eval_data_agent_config(config, "model_c")
+        assert result is None
+
+    def test_keyed_config_no_agent_name_returns_none(self) -> None:
+        """Keyed config with no agent name returns None."""
+        config = {
+            "model_a": {"timeout": 300},
+        }
+        result = _resolve_eval_data_agent_config(config, None)
+        assert result is None


### PR DESCRIPTION
## Description

  - Conversation groups can specify one or more agents, overriding the system config default
  - Agent config override can target specific agents by name or apply to all
  - Both str and list[str] are supported in system config and eval data

Currently internally it will treat as 1x1 till full implementation is done.
Also a scope for de-duplicating some existing/new logic - follow up PR.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent configuration inputs can now be provided as a single agent name or a list of agent names.
  * Agent configuration overrides support both shared (flat) and per-agent (keyed) formats.
* **Bug Fixes**
  * Agent name values are normalized (trimmed, deduplicated, and empty entries rejected).
  * Conversation-level agent configuration override selection is now applied correctly for multi-agent inputs.
* **Tests**
  * Added and expanded unit coverage for agent normalization and per-agent override resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->