### PR TITLE
nxm independent orchestrator

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/__init__.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/__init__.py
@@ -1,0 +1,1 @@
+"""Behavioral evaluation pipeline for NxM multi-agent evaluation."""

--- a/src/lightspeed_evaluation/pipeline/behavioral/models.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/models.py
@@ -1,0 +1,29 @@
+"""Models for NxM behavioral evaluation orchestration."""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class RunContext:
+    """Serializable context for a single evaluation run."""
+
+    config_dict: dict[str, Any]
+    eval_data_dicts: list[dict[str, Any]]
+    default_agents: list[str]
+    agent_name: str
+    run_index: int
+    run_output_dir: str
+    extra: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class RunResult:
+    """Result metadata from a single evaluation run."""
+
+    agent_name: str
+    run_index: int
+    output_dir: str
+    success: bool = False
+    error: Optional[str] = None
+    summary: Optional[dict[str, Any]] = field(default_factory=dict)

--- a/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
@@ -1,0 +1,362 @@
+"""NxM evaluation orchestrator.
+
+Runs M agent configurations x N repeats, saving results independently
+per run. Each run calls the pipeline directly with a cloned config
+targeting one agent.
+"""
+
+import copy
+import logging
+import multiprocessing
+import os
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from lightspeed_evaluation.core.models import EvaluationData, SystemConfig
+from lightspeed_evaluation.core.models.data import DatasetMetadata
+from lightspeed_evaluation.core.system import ConfigLoader
+from lightspeed_evaluation.core.system.exceptions import (
+    ConfigurationError,
+    DataValidationError,
+)
+from lightspeed_evaluation.pipeline.behavioral.models import RunContext, RunResult
+from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
+
+logger = logging.getLogger(__name__)
+
+
+def run(
+    system_config: SystemConfig,
+    evaluation_data: list[EvaluationData],
+    output_base: str,
+    *,
+    original_data_path: Optional[str] = None,
+    dataset_metadata_dict: Optional[dict[str, Any]] = None,
+) -> list[RunResult]:
+    """Run NxM evaluation matrix.
+
+    Args:
+        system_config: System configuration with agents, repeat, parallel.
+        evaluation_data: Conversation groups to evaluate.
+        output_base: Base output directory.
+        original_data_path: Path to original eval data file.
+        dataset_metadata_dict: Serialized dataset metadata to pass through.
+
+    Returns:
+        List of RunResult with metadata per run.
+    """
+    agents_config = system_config.agents
+    if agents_config is None or not agents_config.default.agent:
+        logger.warning("No agents configured, nothing to orchestrate")
+        return []
+
+    default_agents = agents_config.default.agent
+    repeat = agents_config.default.repeat
+    parallel = agents_config.default.parallel
+    all_agents = _build_agent_set(default_agents, evaluation_data)
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+
+    run_matrix = [(agent, i) for agent in all_agents for i in range(1, repeat + 1)]
+    if not run_matrix:
+        logger.warning("No runs to execute")
+        return []
+
+    logger.info(
+        "Starting NxM evaluation: %d agents x %d repeats = %d runs",
+        len(all_agents),
+        repeat,
+        len(run_matrix),
+    )
+
+    contexts = _build_run_contexts(
+        system_config,
+        evaluation_data,
+        {
+            "default_agents": default_agents,
+            "run_matrix": run_matrix,
+            "output_base": output_base,
+            "timestamp": timestamp,
+            "original_data_path": original_data_path,
+            "dataset_metadata_dict": dataset_metadata_dict,
+        },
+    )
+
+    if parallel and len(contexts) > 1:
+        _warn_resource_usage(len(contexts), system_config)
+        results = _run_parallel(contexts)
+    else:
+        results = _run_sequential(contexts)
+
+    succeeded = sum(1 for r in results if r.success)
+    logger.info(
+        "NxM evaluation complete: %d/%d succeeded, %d failed",
+        succeeded,
+        len(results),
+        len(results) - succeeded,
+    )
+    return results
+
+
+def _build_agent_set(
+    default_agents: list[str],
+    evaluation_data: list[EvaluationData],
+) -> list[str]:
+    """Build deduplicated agent set from config defaults + eval data overrides."""
+    agents: dict[str, None] = {}
+    for agent in default_agents:
+        agents[agent] = None
+    for conv in evaluation_data:
+        if conv.agent:
+            for agent in conv.agent:
+                agents[agent] = None
+    return list(agents.keys())
+
+
+def _build_run_contexts(
+    system_config: SystemConfig,
+    evaluation_data: list[EvaluationData],
+    run_params: dict[str, Any],
+) -> list[RunContext]:
+    """Build serializable RunContext for each run in the matrix.
+
+    Args:
+        system_config: System configuration to serialize.
+        evaluation_data: Conversation groups to serialize.
+        run_params: Dict with keys: default_agents, run_matrix,
+            output_base, timestamp, original_data_path.
+    """
+    config_dict = system_config.model_dump()
+    eval_data_dicts = [conv.model_dump() for conv in evaluation_data]
+    output_base = run_params["output_base"]
+    timestamp = run_params["timestamp"]
+
+    return [
+        RunContext(
+            config_dict=config_dict,
+            eval_data_dicts=eval_data_dicts,
+            default_agents=run_params["default_agents"],
+            agent_name=agent,
+            run_index=idx,
+            run_output_dir=os.path.join(
+                output_base, f"eval_{timestamp}", agent, f"run_{idx}"
+            ),
+            extra={
+                "original_data_path": run_params.get("original_data_path"),
+                "dataset_metadata_dict": run_params.get("dataset_metadata_dict"),
+            },
+        )
+        for agent, idx in run_params["run_matrix"]
+    ]
+
+
+def _filter_conversations(
+    evaluation_data: list[EvaluationData],
+    agent_name: str,
+    default_agents: list[str],
+) -> list[EvaluationData]:
+    """Filter conversations that should participate in this agent's run."""
+    return [
+        conv for conv in evaluation_data if agent_name in (conv.agent or default_agents)
+    ]
+
+
+def _clone_config_for_run(
+    config_dict: dict[str, Any],
+    agent_name: str,
+    disable_cache: bool,
+) -> dict[str, Any]:
+    """Clone config dict and set the target agent as the sole default."""
+    cloned = copy.deepcopy(config_dict)
+    cloned["agents"]["default"]["agent"] = [agent_name]
+
+    agent_defs = cloned.get("agents", {}).get("agents", {})
+    if disable_cache and agent_name in agent_defs:
+        agent_def = agent_defs[agent_name]
+        if isinstance(agent_def, dict):
+            agent_def["cache_enabled"] = False
+
+    return cloned
+
+
+def _run_sequential(contexts: list[RunContext]) -> list[RunResult]:
+    """Execute runs sequentially."""
+    results: list[RunResult] = []
+    total = len(contexts)
+
+    for idx, ctx in enumerate(contexts, 1):
+        result = _run_single(ctx)
+        results.append(result)
+        status = "OK" if result.success else "FAILED"
+        logger.info(
+            "[%d/%d] %s/run_%d %s", idx, total, ctx.agent_name, ctx.run_index, status
+        )
+
+    return results
+
+
+def _run_parallel(contexts: list[RunContext]) -> list[RunResult]:
+    """Execute runs in parallel using ProcessPoolExecutor."""
+    max_workers = max(1, multiprocessing.cpu_count() - 1)
+    results: list[RunResult] = []
+    completed = 0
+    total = len(contexts)
+
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        future_to_ctx = {executor.submit(_run_single, ctx): ctx for ctx in contexts}
+
+        for future in as_completed(future_to_ctx):
+            ctx = future_to_ctx[future]
+            completed += 1
+            try:
+                result = future.result()
+                results.append(result)
+                status = "OK" if result.success else "FAILED"
+            except (ConfigurationError, DataValidationError):
+                raise
+            except Exception:  # pylint: disable=broad-exception-caught
+                results.append(
+                    RunResult(
+                        agent_name=ctx.agent_name,
+                        run_index=ctx.run_index,
+                        output_dir="",
+                        success=False,
+                        error=traceback.format_exc(),
+                    )
+                )
+                status = "ERROR"
+
+            logger.info(
+                "[%d/%d] %s/run_%d %s",
+                completed,
+                total,
+                ctx.agent_name,
+                ctx.run_index,
+                status,
+            )
+
+    return results
+
+
+def _pin_conversations_to_agent(
+    conversations: list[EvaluationData],
+    agent_name: str,
+) -> list[EvaluationData]:
+    """Pin each conversation's agent list to the current run's agent.
+
+    Conversations with multi-agent lists (e.g. agent: [model_a, model_c])
+    are narrowed to just the current agent so the pipeline resolves the
+    correct driver.
+    """
+    pinned: list[EvaluationData] = []
+    for conv in conversations:
+        if conv.agent and len(conv.agent) > 1:
+            conv = conv.model_copy(update={"agent": [agent_name]})
+        pinned.append(conv)
+    return pinned
+
+
+def _run_single(ctx: RunContext) -> RunResult:
+    """Execute one evaluation run. Module-level for ProcessPoolExecutor pickling."""
+    os.makedirs(ctx.run_output_dir, exist_ok=True)
+
+    try:
+        cloned_dict = _clone_config_for_run(
+            ctx.config_dict, ctx.agent_name, disable_cache=ctx.run_index > 1
+        )
+        config = SystemConfig.model_validate(cloned_dict)
+
+        all_conversations = [
+            EvaluationData.model_validate(d) for d in ctx.eval_data_dicts
+        ]
+        filtered = _filter_conversations(
+            all_conversations, ctx.agent_name, ctx.default_agents
+        )
+
+        if not filtered:
+            return RunResult(
+                agent_name=ctx.agent_name,
+                run_index=ctx.run_index,
+                output_dir=ctx.run_output_dir,
+                success=True,
+                summary=_empty_summary(),
+            )
+
+        pinned = _pin_conversations_to_agent(filtered, ctx.agent_name)
+
+        extra = ctx.extra or {}
+        dataset_metadata = None
+        metadata_dict = extra.get("dataset_metadata_dict")
+        if metadata_dict:
+            dataset_metadata = DatasetMetadata.model_validate(metadata_dict)
+
+        loader = ConfigLoader.from_config(config)
+        pipeline = EvaluationPipeline(loader, ctx.run_output_dir)
+        try:
+            eval_results = pipeline.run_evaluation(
+                pinned,
+                original_data_path=extra.get("original_data_path"),
+                dataset_metadata=dataset_metadata,
+            )
+        finally:
+            pipeline.close()
+
+        return RunResult(
+            agent_name=ctx.agent_name,
+            run_index=ctx.run_index,
+            output_dir=ctx.run_output_dir,
+            success=True,
+            summary=_make_summary(eval_results),
+        )
+
+    except (ConfigurationError, DataValidationError):
+        raise
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.error(
+            "Run %s/run_%d failed: %s",
+            ctx.agent_name,
+            ctx.run_index,
+            traceback.format_exc(),
+        )
+        return RunResult(
+            agent_name=ctx.agent_name,
+            run_index=ctx.run_index,
+            output_dir=ctx.run_output_dir,
+            success=False,
+            error=traceback.format_exc(),
+        )
+
+
+def _make_summary(results: list) -> dict[str, int]:
+    """Build summary dict from evaluation results."""
+    return {
+        "TOTAL": len(results),
+        "PASS": sum(1 for r in results if r.result == "PASS"),
+        "FAIL": sum(1 for r in results if r.result == "FAIL"),
+        "ERROR": sum(1 for r in results if r.result == "ERROR"),
+        "SKIPPED": sum(1 for r in results if r.result == "SKIPPED"),
+    }
+
+
+def _empty_summary() -> dict[str, int]:
+    """Return empty summary for runs with no matching conversations."""
+    return {"TOTAL": 0, "PASS": 0, "FAIL": 0, "ERROR": 0, "SKIPPED": 0}
+
+
+def _warn_resource_usage(num_runs: int, config: SystemConfig) -> None:
+    """Log warning if parallel runs may overwhelm the system."""
+    max_threads = config.core.max_threads or 1
+    cpu_count = multiprocessing.cpu_count()
+    total_threads = num_runs * max_threads
+
+    if total_threads > cpu_count * 2:
+        logger.warning(
+            "High resource usage: %d parallel runs x %d threads = "
+            "%d total threads on %d CPUs. Consider reducing "
+            "core.max_threads or the number of agents/repeats.",
+            num_runs,
+            max_threads,
+            total_threads,
+            cpu_count,
+        )

--- a/tests/unit/pipeline/behavioral/__init__.py
+++ b/tests/unit/pipeline/behavioral/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for behavioral evaluation pipeline."""

--- a/tests/unit/pipeline/behavioral/test_orchestrator.py
+++ b/tests/unit/pipeline/behavioral/test_orchestrator.py
@@ -1,0 +1,380 @@
+"""Tests for NxM behavioral evaluation orchestrator."""
+
+from pathlib import Path
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from lightspeed_evaluation.core.models.agents import AgentsConfig
+from lightspeed_evaluation.core.models.data import (
+    EvaluationData,
+    EvaluationResult,
+    TurnData,
+)
+from lightspeed_evaluation.pipeline.behavioral.orchestrator import (
+    _build_agent_set,
+    _clone_config_for_run,
+    _filter_conversations,
+    _pin_conversations_to_agent,
+    run,
+)
+
+
+class TestBuildAgentSet:
+    """Tests for agent set building from config + eval data."""
+
+    def test_default_agents_only(self) -> None:
+        """Default agents with no eval data overrides."""
+        data = [
+            EvaluationData(
+                conversation_group_id="c1",
+                turns=[TurnData(turn_id="t1", query="Q")],
+            ),
+        ]
+        result = _build_agent_set(["model_a", "model_b"], data)
+        assert result == ["model_a", "model_b"]
+
+    def test_eval_data_adds_agents(self) -> None:
+        """Eval data agent overrides add to the set."""
+        data = [
+            EvaluationData(
+                conversation_group_id="c1",
+                agent=["model_c"],
+                turns=[TurnData(turn_id="t1", query="Q")],
+            ),
+        ]
+        result = _build_agent_set(["model_a"], data)
+        assert result == ["model_a", "model_c"]
+
+    def test_duplicates_removed(self) -> None:
+        """Duplicate agents across default and eval data are deduplicated."""
+        data = [
+            EvaluationData(
+                conversation_group_id="c1",
+                agent=["model_a", "model_b"],
+                turns=[TurnData(turn_id="t1", query="Q")],
+            ),
+        ]
+        result = _build_agent_set(["model_a"], data)
+        assert result == ["model_a", "model_b"]
+
+    def test_empty_eval_data(self) -> None:
+        """No eval data returns just default agents."""
+        result = _build_agent_set(["model_a"], [])
+        assert result == ["model_a"]
+
+
+class TestFilterConversations:
+    """Tests for conversation filtering per agent."""
+
+    def _make_conv(
+        self, conv_id: str, agent: list[str] | None = None
+    ) -> EvaluationData:
+        return EvaluationData(
+            conversation_group_id=conv_id,
+            agent=agent,
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+
+    def test_no_agent_uses_default(self) -> None:
+        """Conversation without agent uses default agents."""
+        convs = [self._make_conv("c1")]
+        result = _filter_conversations(convs, "model_a", ["model_a", "model_b"])
+        assert len(result) == 1
+
+    def test_no_agent_excluded_if_not_in_default(self) -> None:
+        """Conversation without agent excluded if agent not in defaults."""
+        convs = [self._make_conv("c1")]
+        result = _filter_conversations(convs, "model_c", ["model_a"])
+        assert len(result) == 0
+
+    def test_pinned_conversation_included(self) -> None:
+        """Conversation pinned to agent is included."""
+        convs = [self._make_conv("c1", agent=["model_a"])]
+        result = _filter_conversations(convs, "model_a", ["model_b"])
+        assert len(result) == 1
+
+    def test_pinned_conversation_excluded(self) -> None:
+        """Conversation pinned to different agent is excluded."""
+        convs = [self._make_conv("c1", agent=["model_b"])]
+        result = _filter_conversations(convs, "model_a", ["model_a"])
+        assert len(result) == 0
+
+    def test_mixed_conversations(self) -> None:
+        """Mix of pinned and default conversations filtered correctly."""
+        convs = [
+            self._make_conv("c1"),
+            self._make_conv("c2", agent=["model_a"]),
+            self._make_conv("c3", agent=["model_b"]),
+        ]
+        result = _filter_conversations(convs, "model_a", ["model_a"])
+        assert len(result) == 2
+        assert {c.conversation_group_id for c in result} == {"c1", "c2"}
+
+
+class TestPinConversationsToAgent:
+    """Tests for pinning multi-agent conversations to current run agent."""
+
+    def test_single_agent_unchanged(self) -> None:
+        """Single-agent conversation left unchanged."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            agent=["model_a"],
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        result = _pin_conversations_to_agent([conv], "model_a")
+        assert result[0].agent == ["model_a"]
+
+    def test_multi_agent_pinned(self) -> None:
+        """Multi-agent conversation pinned to current run agent."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            agent=["model_a", "model_c"],
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        result = _pin_conversations_to_agent([conv], "model_c")
+        assert result[0].agent == ["model_c"]
+
+    def test_no_agent_unchanged(self) -> None:
+        """Conversation with no agent left unchanged."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        result = _pin_conversations_to_agent([conv], "model_a")
+        assert result[0].agent is None
+
+    def test_original_not_mutated(self) -> None:
+        """Original conversation not mutated."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            agent=["model_a", "model_c"],
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        _pin_conversations_to_agent([conv], "model_c")
+        assert conv.agent == ["model_a", "model_c"]
+
+    def test_agent_config_preserved(self) -> None:
+        """Agent config is preserved through pinning."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            agent=["model_a", "model_c"],
+            agent_config={"model_a": {"timeout": 300}, "model_c": {"timeout": 600}},
+            turns=[TurnData(turn_id="t1", query="Q")],
+        )
+        result = _pin_conversations_to_agent([conv], "model_c")
+        assert result[0].agent == ["model_c"]
+        assert result[0].agent_config == {
+            "model_a": {"timeout": 300},
+            "model_c": {"timeout": 600},
+        }
+
+
+class TestCloneConfigForRun:
+    """Tests for config cloning."""
+
+    def _base_config(self) -> dict:
+        return {
+            "agents": {
+                "enabled": True,
+                "default": {"agent": ["model_a", "model_b"]},
+                "agents": {
+                    "model_a": {"type": "http_api", "cache_enabled": True},
+                    "model_b": {"type": "http_api", "cache_enabled": True},
+                },
+            },
+        }
+
+    def test_sets_single_agent(self) -> None:
+        """Cloned config has only the target agent in default."""
+        cloned = _clone_config_for_run(self._base_config(), "model_a", False)
+        assert cloned["agents"]["default"]["agent"] == ["model_a"]
+
+    def test_does_not_mutate_original(self) -> None:
+        """Original config is not modified."""
+        original = self._base_config()
+        _clone_config_for_run(original, "model_a", False)
+        assert original["agents"]["default"]["agent"] == ["model_a", "model_b"]
+
+    def test_disables_cache(self) -> None:
+        """Cache disabled when requested."""
+        cloned = _clone_config_for_run(self._base_config(), "model_a", True)
+        assert cloned["agents"]["agents"]["model_a"]["cache_enabled"] is False
+        assert cloned["agents"]["agents"]["model_b"]["cache_enabled"] is True
+
+    def test_cache_not_disabled_when_not_requested(self) -> None:
+        """Cache stays enabled when not disabled."""
+        cloned = _clone_config_for_run(self._base_config(), "model_a", False)
+        assert cloned["agents"]["agents"]["model_a"]["cache_enabled"] is True
+
+
+class TestRunOrchestrator:
+    """Integration tests for the orchestrator run function."""
+
+    def _make_config_mock(
+        self, mocker: MockerFixture, agents_dict: dict[str, Any]
+    ) -> Any:
+        """Create a mock SystemConfig with agents."""
+        agents_config = AgentsConfig.model_validate(agents_dict)
+        config = mocker.MagicMock(spec=["agents", "core", "model_dump"])
+        config.agents = agents_config
+        config.core.max_threads = 1
+
+        full_dict = {"agents": {**agents_dict, "enabled": True}}
+        for k, v in agents_dict.items():
+            if k != "default" and isinstance(v, dict) and "type" in v:
+                full_dict["agents"][k] = v
+        config.model_dump.return_value = full_dict
+        return config
+
+    def _mock_pipeline(self, mocker: MockerFixture) -> Any:
+        """Mock EvaluationPipeline and ConfigLoader to return test results."""
+        mock_pipeline = mocker.MagicMock()
+        mock_pipeline.run_evaluation.return_value = [
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="ragas:faithfulness",
+                result="PASS",
+                score=0.9,
+            ),
+        ]
+        mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.EvaluationPipeline",
+            return_value=mock_pipeline,
+        )
+        mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.ConfigLoader"
+        )
+        return mock_pipeline
+
+    def test_2x2_calls_pipeline_4_times(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Orchestrator calls pipeline per agent x repeat."""
+        mock_pipeline = self._mock_pipeline(mocker)
+
+        config = self._make_config_mock(
+            mocker,
+            {
+                "default": {"agent": ["model_a", "model_b"], "repeat": 2},
+                "model_a": {"type": "http_api"},
+                "model_b": {"type": "http_api"},
+            },
+        )
+
+        results = run(
+            config,
+            [
+                EvaluationData(
+                    conversation_group_id="c1",
+                    turns=[TurnData(turn_id="t1", query="Q")],
+                )
+            ],
+            str(tmp_path),
+        )
+
+        assert len(results) == 4
+        assert all(r.success for r in results)
+        assert mock_pipeline.run_evaluation.call_count == 4
+
+    def test_1x1_produces_one_result(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """1x1 produces one run result."""
+        mock_pipeline = self._mock_pipeline(mocker)
+        mock_pipeline.run_evaluation.return_value = []
+
+        config = self._make_config_mock(
+            mocker,
+            {
+                "default": {"agent": ["model_a"]},
+                "model_a": {"type": "http_api"},
+            },
+        )
+
+        results = run(
+            config,
+            [
+                EvaluationData(
+                    conversation_group_id="c1",
+                    turns=[TurnData(turn_id="t1", query="Q")],
+                )
+            ],
+            str(tmp_path),
+        )
+
+        assert len(results) == 1
+        assert results[0].agent_name == "model_a"
+        assert results[0].run_index == 1
+
+    def test_failed_run_does_not_stop_others(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """One failing run doesn't prevent others from completing."""
+        call_count = 0
+
+        def side_effect(*_args: Any, **_kwargs: Any) -> list:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Simulated failure")
+            return []
+
+        mock_pipeline = self._mock_pipeline(mocker)
+        mock_pipeline.run_evaluation.side_effect = side_effect
+
+        config = self._make_config_mock(
+            mocker,
+            {
+                "default": {"agent": ["model_a"], "repeat": 3},
+                "model_a": {"type": "http_api"},
+            },
+        )
+
+        results = run(
+            config,
+            [
+                EvaluationData(
+                    conversation_group_id="c1",
+                    turns=[TurnData(turn_id="t1", query="Q")],
+                )
+            ],
+            str(tmp_path),
+        )
+
+        assert len(results) == 3
+        assert sum(1 for r in results if not r.success) == 1
+        assert sum(1 for r in results if r.success) == 2
+
+    def test_output_directory_structure(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Verify output directory follows eval_<timestamp>/agent/run_N structure."""
+        mock_pipeline = self._mock_pipeline(mocker)
+        mock_pipeline.run_evaluation.return_value = []
+
+        config = self._make_config_mock(
+            mocker,
+            {
+                "default": {"agent": ["model_a"], "repeat": 2},
+                "model_a": {"type": "http_api"},
+            },
+        )
+
+        results = run(
+            config,
+            [
+                EvaluationData(
+                    conversation_group_id="c1",
+                    turns=[TurnData(turn_id="t1", query="Q")],
+                )
+            ],
+            str(tmp_path),
+        )
+
+        assert len(results) == 2
+        for r in results:
+            assert f"model_a/run_{r.run_index}" in r.output_dir
+            assert "eval_" in r.output_dir
+            assert Path(r.output_dir).is_dir()


### PR DESCRIPTION
## Description

NxM orchestrator — runs M agents × N repeats, each as an independent pipeline run
Next: Wire into CLI runner

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added behavioral evaluation orchestration across multiple agents and repeated runs.
  * Supports sequential or parallel execution, per-run output directories, result summaries, and continued processing when individual runs fail.
  * Automatically handles agent selection, conversation filtering, and multi-agent evaluation scenarios.

* **Tests**
  * Added comprehensive coverage for agent selection, filtering, repeated runs, failure handling, configuration isolation, and output organization.

* **Documentation**
  * Added module descriptions for the behavioral evaluation pipeline and its tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->