### PR TITLE
feat: NxM orchestrator integration

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
@@ -131,6 +131,8 @@ def _build_run_contexts(
     eval_data_dicts = [conv.model_dump() for conv in evaluation_data]
     output_base = run_params["output_base"]
     timestamp = run_params["timestamp"]
+    run_matrix = run_params["run_matrix"]
+    is_single_run = len(run_matrix) == 1
 
     return [
         RunContext(
@@ -139,15 +141,17 @@ def _build_run_contexts(
             default_agents=run_params["default_agents"],
             agent_name=agent,
             run_index=idx,
-            run_output_dir=os.path.join(
-                output_base, f"eval_{timestamp}", agent, f"run_{idx}"
+            run_output_dir=(
+                output_base
+                if is_single_run
+                else os.path.join(output_base, f"eval_{timestamp}", agent, f"run_{idx}")
             ),
             extra={
                 "original_data_path": run_params.get("original_data_path"),
                 "dataset_metadata_dict": run_params.get("dataset_metadata_dict"),
             },
         )
-        for agent, idx in run_params["run_matrix"]
+        for agent, idx in run_matrix
     ]
 
 
@@ -166,6 +170,7 @@ def _clone_config_for_run(
     config_dict: dict[str, Any],
     agent_name: str,
     disable_cache: bool,
+    run_output_dir: str,
 ) -> dict[str, Any]:
     """Clone config dict and set the target agent as the sole default."""
     cloned = copy.deepcopy(config_dict)
@@ -176,6 +181,14 @@ def _clone_config_for_run(
         agent_def = agent_defs[agent_name]
         if isinstance(agent_def, dict):
             agent_def["cache_enabled"] = False
+
+    storage = cloned.get("storage", [])
+    has_file_backend = any(
+        isinstance(s, dict) and s.get("type") == "file" for s in storage
+    )
+    if not has_file_backend:
+        storage.append({"type": "file", "output_dir": run_output_dir})
+        cloned["storage"] = storage
 
     return cloned
 
@@ -263,7 +276,10 @@ def _run_single(ctx: RunContext) -> RunResult:
 
     try:
         cloned_dict = _clone_config_for_run(
-            ctx.config_dict, ctx.agent_name, disable_cache=ctx.run_index > 1
+            ctx.config_dict,
+            ctx.agent_name,
+            disable_cache=ctx.run_index > 1,
+            run_output_dir=ctx.run_output_dir,
         )
         config = SystemConfig.model_validate(cloned_dict)
 
@@ -328,20 +344,51 @@ def _run_single(ctx: RunContext) -> RunResult:
         )
 
 
-def _make_summary(results: list) -> dict[str, int]:
-    """Build summary dict from evaluation results."""
+def _make_summary(results: list) -> dict[str, Any]:
+    """Build summary dict from evaluation results.
+
+    Judge/embedding tokens are summed per result (each metric has its own).
+    API tokens are deduplicated per turn to avoid overcounting when a turn
+    has multiple metrics.
+    """
+    seen_turns: set[tuple[str, str]] = set()
+    api_in = 0
+    api_out = 0
+    for r in results:
+        turn_key = (r.conversation_group_id, r.turn_id or "")
+        if turn_key not in seen_turns:
+            seen_turns.add(turn_key)
+            api_in += r.api_input_tokens
+            api_out += r.api_output_tokens
+
     return {
         "TOTAL": len(results),
         "PASS": sum(1 for r in results if r.result == "PASS"),
         "FAIL": sum(1 for r in results if r.result == "FAIL"),
         "ERROR": sum(1 for r in results if r.result == "ERROR"),
         "SKIPPED": sum(1 for r in results if r.result == "SKIPPED"),
+        "judge_llm_input_tokens": sum(r.judge_llm_input_tokens for r in results),
+        "judge_llm_output_tokens": sum(r.judge_llm_output_tokens for r in results),
+        "embedding_tokens": sum(r.embedding_tokens for r in results),
+        "api_input_tokens": api_in,
+        "api_output_tokens": api_out,
     }
 
 
-def _empty_summary() -> dict[str, int]:
+def _empty_summary() -> dict[str, Any]:
     """Return empty summary for runs with no matching conversations."""
-    return {"TOTAL": 0, "PASS": 0, "FAIL": 0, "ERROR": 0, "SKIPPED": 0}
+    return {
+        "TOTAL": 0,
+        "PASS": 0,
+        "FAIL": 0,
+        "ERROR": 0,
+        "SKIPPED": 0,
+        "judge_llm_input_tokens": 0,
+        "judge_llm_output_tokens": 0,
+        "embedding_tokens": 0,
+        "api_input_tokens": 0,
+        "api_output_tokens": 0,
+    }
 
 
 def _warn_resource_usage(num_runs: int, config: SystemConfig) -> None:

--- a/src/lightspeed_evaluation/runner/evaluation.py
+++ b/src/lightspeed_evaluation/runner/evaluation.py
@@ -1,6 +1,7 @@
 """Lightspeed Evaluation Framework - Main Evaluation Runner."""
 
 import argparse
+import os
 import shutil
 import sys
 import traceback
@@ -8,14 +9,12 @@ from pathlib import Path
 from typing import Optional
 
 from lightspeed_evaluation.core.models import (
-    AgentTokenUsage,
     LLMPoolConfig,
-    OverallStats,
     SystemConfig,
 )
 
 # Import only lightweight modules at top level
-from lightspeed_evaluation.core.storage import FileBackendConfig, get_file_config
+from lightspeed_evaluation.core.storage import get_file_config
 from lightspeed_evaluation.core.system import ConfigLoader
 from lightspeed_evaluation.core.system.exceptions import (
     ConfigurationError,
@@ -70,43 +69,52 @@ def _clear_caches(system_config: SystemConfig) -> None:
         path.mkdir(parents=True, exist_ok=True)
 
 
-def _print_summary(
-    summary: OverallStats,
-    api_tokens: Optional[AgentTokenUsage] = None,
+def _print_run_summary(
+    totals: dict[str, int],
+    run_results: list,
 ) -> None:
-    """Print evaluation summary and token usage."""
+    """Print evaluation summary and token usage from orchestrator results."""
+    print(f"📊 {totals['TOTAL']} evaluations completed")
+    if len(run_results) > 1:
+        succeeded = sum(1 for r in run_results if r.success)
+        print(
+            f"📊 {len(run_results)} runs "
+            f"({succeeded} succeeded, {len(run_results) - succeeded} failed)"
+        )
+    output_dirs = {Path(rr.output_dir).resolve() for rr in run_results if rr.output_dir}
+    if len(run_results) > 1 and output_dirs:
+        common = Path(os.path.commonpath(output_dirs))
+        print(f"📁 Reports generated in: {common}")
+    else:
+        for d in output_dirs:
+            print(f"📁 Reports generated in: {d}")
     print(
-        f"✅ Pass: {summary.passed}, ❌ Fail: {summary.failed}, "
-        f"⚠️ Error: {summary.error}, ⏭️ Skipped: {summary.skipped}"
+        f"✅ Pass: {totals['PASS']}, ❌ Fail: {totals['FAIL']}, "
+        f"⚠️ Error: {totals['ERROR']}, ⏭️ Skipped: {totals['SKIPPED']}"
     )
-    if summary.error > 0:
-        print(f"⚠️ {summary.error} evaluations had errors - check detailed report")
+    if totals.get("ERROR", 0) > 0:
+        print(f"⚠️ {totals['ERROR']} evaluations had errors - check detailed report")
+
+    judge_in = totals.get("judge_llm_input_tokens", 0)
+    judge_out = totals.get("judge_llm_output_tokens", 0)
+    embed = totals.get("embedding_tokens", 0)
+    api_in = totals.get("api_input_tokens", 0)
+    api_out = totals.get("api_output_tokens", 0)
 
     print("\n📊 Token Usage Summary:")
     print(
-        f"Judge LLM: {summary.total_judge_llm_tokens:,} tokens "
-        f"(Input: {summary.total_judge_llm_input_tokens:,}, "
-        f"Output: {summary.total_judge_llm_output_tokens:,})"
+        f"Judge LLM: {judge_in + judge_out:,} tokens "
+        f"(Input: {judge_in:,}, Output: {judge_out:,})"
     )
-
-    print(f"Embeddings: {summary.total_embedding_tokens:,} tokens")
-
-    if api_tokens:
+    print(f"Embeddings: {embed:,} tokens")
+    if api_in + api_out > 0:
         print(
-            f"API Calls: {api_tokens.total_api_tokens:,} tokens "
-            f"(Input: {api_tokens.total_api_input_tokens:,}, "
-            f"Output: {api_tokens.total_api_output_tokens:,})"
+            f"API Calls: {api_in + api_out:,} tokens "
+            f"(Input: {api_in:,}, Output: {api_out:,})"
         )
-        total = (
-            summary.total_judge_llm_tokens
-            + summary.total_embedding_tokens
-            + api_tokens.total_api_tokens
-        )
-        print(f"Total: {total:,} tokens")
-    else:
-        total = summary.total_judge_llm_tokens + summary.total_embedding_tokens
-        if total > 0:
-            print(f"Total: {total:,} tokens")
+    total_tokens = judge_in + judge_out + embed + api_in + api_out
+    if total_tokens > 0:
+        print(f"Total: {total_tokens:,} tokens")
 
 
 def run_evaluation(  # pylint: disable=too-many-locals
@@ -138,11 +146,12 @@ def run_evaluation(  # pylint: disable=too-many-locals
         # pylint: disable=import-outside-toplevel
         from lightspeed_evaluation.api import evaluate
         from lightspeed_evaluation.core.output import OutputHandler
-        from lightspeed_evaluation.core.output.statistics import (
-            compute_agent_token_usage,
-            compute_overall_stats,
-        )
+        from lightspeed_evaluation.core.output.statistics import compute_overall_stats
+        from lightspeed_evaluation.core.storage import FileBackendConfig
         from lightspeed_evaluation.core.system import DataValidator
+        from lightspeed_evaluation.pipeline.behavioral.orchestrator import (
+            run as orchestrator_run,
+        )
 
         # pylint: enable=import-outside-toplevel
         print("✅ Configuration loaded & Setup is done !")
@@ -172,61 +181,88 @@ def run_evaluation(  # pylint: disable=too-many-locals
             print("   Nothing to evaluate - returning empty results")
             return {"TOTAL": 0, "PASS": 0, "FAIL": 0, "ERROR": 0, "SKIPPED": 0}
 
-        # Run evaluation pipeline
-        print("\n⚙️ Initializing Evaluation Pipeline...")
-
+        # Run evaluation
         print("\n🔄 Running Evaluation...")
-        results = evaluate(
-            system_config,
-            evaluation_data,
-            output_dir=eval_args.output_dir,
-            original_data_path=eval_args.eval_data,
-            dataset_metadata=dataset_metadata,
+        has_agents = (
+            system_config.agents is not None and system_config.agents.default.agent
         )
 
-        file_entries = [
-            c for c in system_config.storage if isinstance(c, FileBackendConfig)
-        ]
-        if not file_entries:
-            # No file storage in config: use legacy default file settings (same as get_file_config).
-            print("\n📊 Generating Reports...")
-            file_config = get_file_config(system_config.storage)
-            output_handler = OutputHandler(
-                output_dir=eval_args.output_dir or file_config.output_dir,
-                base_filename=file_config.base_filename,
-                system_config=system_config,
-                file_config=file_config,
+        if not has_agents:
+            # Offline mode: run pipeline directly (no agents to orchestrate)
+            results = evaluate(
+                system_config,
+                evaluation_data,
+                output_dir=eval_args.output_dir,
+                original_data_path=eval_args.eval_data,
+                dataset_metadata=dataset_metadata,
             )
-            output_handler.generate_reports(results, evaluation_data)
-
-        print("\n🎉 Evaluation Complete!")
-        print(f"📊 {len(results)} evaluations completed")
-        for fc in file_entries:
-            report_dir = Path(eval_args.output_dir or fc.output_dir).resolve()
-            print(f"📁 Reports generated in: {report_dir}")
-        if not file_entries:
-            out_dir = Path(
+            file_entries = [
+                c for c in system_config.storage if isinstance(c, FileBackendConfig)
+            ]
+            if not file_entries:
+                file_config = get_file_config(system_config.storage)
+                handler = OutputHandler(
+                    output_dir=eval_args.output_dir or file_config.output_dir,
+                    base_filename=file_config.base_filename,
+                    system_config=system_config,
+                    file_config=file_config,
+                )
+                handler.generate_reports(results, evaluation_data)
+            summary = compute_overall_stats(results)
+            out_dir = (
                 eval_args.output_dir
                 or get_file_config(system_config.storage).output_dir
-            ).resolve()
-            print(f"📁 Reports generated in: {out_dir}")
+            )
+            print(f"\n🎉 Evaluation Complete!\n📊 {len(results)} evaluations completed")
+            print(f"📁 Reports generated in: {Path(out_dir).resolve()}")
+            print(
+                f"✅ Pass: {summary.passed}, ❌ Fail: {summary.failed}, "
+                f"⚠️ Error: {summary.error}, ⏭️ Skipped: {summary.skipped}"
+            )
+            print(
+                f"\n📊 Token Usage Summary:\n"
+                f"Judge LLM: {summary.total_judge_llm_tokens:,} tokens "
+                f"(Input: {summary.total_judge_llm_input_tokens:,}, "
+                f"Output: {summary.total_judge_llm_output_tokens:,})\n"
+                f"Embeddings: {summary.total_embedding_tokens:,} tokens"
+            )
+            return {
+                "TOTAL": summary.total,
+                "PASS": summary.passed,
+                "FAIL": summary.failed,
+                "ERROR": summary.error,
+                "SKIPPED": summary.skipped,
+            }
 
-        # Final Summary
-        summary = compute_overall_stats(results)
-        api_tokens = (
-            compute_agent_token_usage(evaluation_data)
-            if system_config.agents is not None and system_config.agents.enabled
-            else None
+        # Agent mode: run via orchestrator
+        output_dir = (
+            eval_args.output_dir or get_file_config(system_config.storage).output_dir
         )
-        _print_summary(summary, api_tokens)
-
-        return {
-            "TOTAL": summary.total,
-            "PASS": summary.passed,
-            "FAIL": summary.failed,
-            "ERROR": summary.error,
-            "SKIPPED": summary.skipped,
+        run_results = orchestrator_run(
+            system_config,
+            evaluation_data,
+            output_dir,
+            original_data_path=eval_args.eval_data,
+            dataset_metadata_dict=(
+                dataset_metadata.model_dump() if dataset_metadata else None
+            ),
+        )
+        totals: dict[str, int] = {
+            "TOTAL": 0,
+            "PASS": 0,
+            "FAIL": 0,
+            "ERROR": 0,
+            "SKIPPED": 0,
         }
+        for rr in run_results:
+            if rr.summary:
+                for key, val in rr.summary.items():
+                    totals[key] = totals.get(key, 0) + val
+
+        print("\n🎉 Evaluation Complete!")
+        _print_run_summary(totals, run_results)
+
+        return totals
 
     except (
         FileNotFoundError,

--- a/tests/unit/pipeline/behavioral/test_orchestrator.py
+++ b/tests/unit/pipeline/behavioral/test_orchestrator.py
@@ -15,6 +15,7 @@ from lightspeed_evaluation.pipeline.behavioral.orchestrator import (
     _build_agent_set,
     _clone_config_for_run,
     _filter_conversations,
+    _make_summary,
     _pin_conversations_to_agent,
     run,
 )
@@ -187,25 +188,118 @@ class TestCloneConfigForRun:
 
     def test_sets_single_agent(self) -> None:
         """Cloned config has only the target agent in default."""
-        cloned = _clone_config_for_run(self._base_config(), "model_a", False)
+        cloned = _clone_config_for_run(
+            self._base_config(), "model_a", False, "/tmp/out"
+        )
         assert cloned["agents"]["default"]["agent"] == ["model_a"]
 
     def test_does_not_mutate_original(self) -> None:
         """Original config is not modified."""
         original = self._base_config()
-        _clone_config_for_run(original, "model_a", False)
+        _clone_config_for_run(original, "model_a", False, "/tmp/out")
         assert original["agents"]["default"]["agent"] == ["model_a", "model_b"]
 
     def test_disables_cache(self) -> None:
         """Cache disabled when requested."""
-        cloned = _clone_config_for_run(self._base_config(), "model_a", True)
+        cloned = _clone_config_for_run(self._base_config(), "model_a", True, "/tmp/out")
         assert cloned["agents"]["agents"]["model_a"]["cache_enabled"] is False
         assert cloned["agents"]["agents"]["model_b"]["cache_enabled"] is True
 
     def test_cache_not_disabled_when_not_requested(self) -> None:
         """Cache stays enabled when not disabled."""
-        cloned = _clone_config_for_run(self._base_config(), "model_a", False)
+        cloned = _clone_config_for_run(
+            self._base_config(), "model_a", False, "/tmp/out"
+        )
         assert cloned["agents"]["agents"]["model_a"]["cache_enabled"] is True
+
+    def test_injects_file_backend_when_missing(self) -> None:
+        """File backend injected when no storage configured."""
+        config = self._base_config()
+        config["storage"] = []
+        cloned = _clone_config_for_run(config, "model_a", False, "/tmp/run_out")
+        file_entries = [
+            s
+            for s in cloned["storage"]
+            if isinstance(s, dict) and s.get("type") == "file"
+        ]
+        assert len(file_entries) == 1
+        assert file_entries[0]["output_dir"] == "/tmp/run_out"
+
+    def test_does_not_inject_file_backend_when_present(self) -> None:
+        """File backend not injected when already configured."""
+        config = self._base_config()
+        config["storage"] = [{"type": "file", "output_dir": "/existing"}]
+        cloned = _clone_config_for_run(config, "model_a", False, "/tmp/run_out")
+        file_entries = [
+            s
+            for s in cloned["storage"]
+            if isinstance(s, dict) and s.get("type") == "file"
+        ]
+        assert len(file_entries) == 1
+        assert file_entries[0]["output_dir"] == "/existing"
+
+
+class TestMakeSummary:
+    """Tests for _make_summary token deduplication."""
+
+    def test_api_tokens_deduplicated_per_turn(self) -> None:
+        """API tokens counted once per turn even with multiple metrics."""
+        results = [
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="ragas:faithfulness",
+                result="PASS",
+                score=0.9,
+                api_input_tokens=100,
+                api_output_tokens=50,
+                judge_llm_input_tokens=200,
+                judge_llm_output_tokens=80,
+                embedding_tokens=10,
+            ),
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="ragas:relevancy",
+                result="PASS",
+                score=0.8,
+                api_input_tokens=100,
+                api_output_tokens=50,
+                judge_llm_input_tokens=150,
+                judge_llm_output_tokens=60,
+                embedding_tokens=5,
+            ),
+        ]
+        summary = _make_summary(results)
+        assert summary["api_input_tokens"] == 100
+        assert summary["api_output_tokens"] == 50
+        assert summary["judge_llm_input_tokens"] == 350
+        assert summary["judge_llm_output_tokens"] == 140
+        assert summary["embedding_tokens"] == 15
+
+    def test_different_turns_counted_separately(self) -> None:
+        """API tokens from different turns are summed."""
+        results = [
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="ragas:faithfulness",
+                result="PASS",
+                api_input_tokens=100,
+                api_output_tokens=50,
+            ),
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t2",
+                metric_identifier="ragas:faithfulness",
+                result="PASS",
+                api_input_tokens=200,
+                api_output_tokens=80,
+            ),
+        ]
+        summary = _make_summary(results)
+        assert summary["api_input_tokens"] == 300
+        assert summary["api_output_tokens"] == 130
 
 
 class TestRunOrchestrator:
@@ -307,6 +401,7 @@ class TestRunOrchestrator:
         assert len(results) == 1
         assert results[0].agent_name == "model_a"
         assert results[0].run_index == 1
+        assert results[0].output_dir == str(tmp_path)
 
     def test_failed_run_does_not_stop_others(
         self, mocker: MockerFixture, tmp_path: Path

--- a/tests/unit/runner/test_evaluation.py
+++ b/tests/unit/runner/test_evaluation.py
@@ -16,7 +16,6 @@ from lightspeed_evaluation.core.models.llm import (
     LLMPoolConfig,
     LLMProviderConfig,
 )
-from lightspeed_evaluation.core.models.statistics import OverallStats
 from lightspeed_evaluation.core.models.system import (
     APIConfig,
     SystemConfig,
@@ -25,6 +24,7 @@ from lightspeed_evaluation.core.system.exceptions import (
     DataValidationError,
     StorageError,
 )
+from lightspeed_evaluation.pipeline.behavioral.models import RunResult
 from lightspeed_evaluation.runner.evaluation import _clear_caches, main, run_evaluation
 
 _MAIN_STATS: dict[str, int] = {
@@ -65,6 +65,53 @@ def _make_eval_args(**kwargs: Any) -> argparse.Namespace:
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
+
+
+def _setup_runner_mocks(
+    mocker: MockerFixture,
+    *,
+    orchestrator_results: list[RunResult] | None = None,
+    orchestrator_side_effect: Any = None,
+) -> tuple[Any, Any, Any]:
+    """Set up common mocks for runner tests.
+
+    Returns (mock_config, mock_validator, mock_orchestrator).
+    """
+    mock_loader = mocker.Mock()
+    mock_config = mocker.Mock()
+    mock_config.llm.provider = "openai"
+    mock_config.llm.model = "gpt-4"
+    mock_config.agents.default.agent = ["mock_agent"]
+    mock_config.storage = []
+    mock_loader.system_config = mock_config
+    mock_loader.load_system_config.return_value = mock_config
+
+    mocker.patch(
+        "lightspeed_evaluation.runner.evaluation.ConfigLoader"
+    ).return_value = mock_loader
+
+    mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
+    mock_validator.return_value.load_evaluation_data.return_value = [mocker.Mock()]
+    mock_validator.return_value.dataset_metadata = None
+
+    if orchestrator_results is None:
+        orchestrator_results = [
+            RunResult(
+                agent_name="model_a",
+                run_index=1,
+                output_dir="/tmp/out",
+                success=True,
+                summary={"TOTAL": 1, "PASS": 1, "FAIL": 0, "ERROR": 0, "SKIPPED": 0},
+            )
+        ]
+
+    mock_orchestrator = mocker.patch(
+        "lightspeed_evaluation.pipeline.behavioral.orchestrator.run",
+        return_value=orchestrator_results,
+        side_effect=orchestrator_side_effect,
+    )
+
+    return mock_config, mock_validator, mock_orchestrator
 
 
 def _system_config_all_caches_under_tmp(tmp_path: Path) -> SystemConfig:
@@ -112,57 +159,41 @@ class TestRunEvaluation:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """Test successful evaluation run."""
-        # Mock ConfigLoader
         mock_loader = mocker.Mock()
         mock_config = mocker.Mock()
         mock_config.llm.provider = "openai"
         mock_config.llm.model = "gpt-4"
-        mock_config.agents = None
+        mock_config.agents.default.agent = ["mock_agent"]
         mock_config.storage = []
         mock_loader.system_config = mock_config
         mock_loader.load_system_config.return_value = mock_config
 
-        mock_config_loader_class = mocker.patch(
+        mocker.patch(
             "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
+        ).return_value = mock_loader
 
-        # Mock evaluation data
         mock_eval_data = [mocker.Mock()]
-
-        # Mock DataValidator (imported inside function)
         mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
         mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
+        mock_validator.return_value.dataset_metadata = None
 
-        # Mock evaluate() API function (imported inside function)
-        mock_result = mocker.Mock()
-        mock_result.result = "PASS"
-        mock_evaluate = mocker.patch(
-            "lightspeed_evaluation.api.evaluate", return_value=[mock_result]
-        )
-
-        # Mock OutputHandler (imported inside function)
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/tmp/output"
-        mock_output_class = mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler"
-        )
-        mock_output_class.return_value = mock_output_handler
-
-        # Mock compute_overall_stats (imported inside function)
-        mock_stats = mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats"
-        )
-        mock_stats.return_value = OverallStats(
-            total=1,
-            passed=1,
-            failed=0,
-            error=0,
-            skipped=0,
-            total_judge_llm_input_tokens=100,
-            total_judge_llm_output_tokens=50,
-            total_judge_llm_tokens=150,
-            total_embedding_tokens=10,
+        mock_orchestrator = mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.run",
+            return_value=[
+                RunResult(
+                    agent_name="model_a",
+                    run_index=1,
+                    output_dir="/tmp/out",
+                    success=True,
+                    summary={
+                        "TOTAL": 1,
+                        "PASS": 1,
+                        "FAIL": 0,
+                        "ERROR": 0,
+                        "SKIPPED": 0,
+                    },
+                )
+            ],
         )
 
         result = run_evaluation(_make_eval_args())
@@ -170,22 +201,13 @@ class TestRunEvaluation:
         assert result is not None
         assert result["TOTAL"] == 1
         assert result["PASS"] == 1
-        mock_evaluate.assert_called_once()
-        call_args = mock_evaluate.call_args
-        assert call_args[0] == (mock_config, mock_eval_data)
-        assert call_args[1]["output_dir"] is None
-        assert call_args[1]["original_data_path"] == "config/evaluation_data.yaml"
-        assert (
-            call_args[1]["dataset_metadata"]
-            is mock_validator.return_value.dataset_metadata
-        )
+        mock_orchestrator.assert_called_once()
 
-    def test_run_evaluation_with_output_dir_override(
+    def test_run_evaluation_offline_does_not_call_orchestrator(
         self,
         mocker: MockerFixture,
-        capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test evaluation with custom output directory."""
+        """Offline mode (no agents) does not call the orchestrator."""
         mock_loader = mocker.Mock()
         mock_config = mocker.Mock()
         mock_config.llm.provider = "openai"
@@ -195,42 +217,34 @@ class TestRunEvaluation:
         mock_loader.system_config = mock_config
         mock_loader.load_system_config.return_value = mock_config
 
-        mock_config_loader_class = mocker.patch(
+        mocker.patch(
             "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
+        ).return_value = mock_loader
 
-        mock_eval_data = [mocker.Mock()]
         mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
+        mock_validator.return_value.load_evaluation_data.return_value = []
 
-        mock_evaluate = mocker.patch(
-            "lightspeed_evaluation.api.evaluate", return_value=[]
+        mock_orchestrator = mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.run",
         )
 
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/custom/output"
-        mock_output_class = mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler"
-        )
-        mock_output_class.return_value = mock_output_handler
+        run_evaluation(_make_eval_args())
 
-        mock_stats = mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats"
-        )
-        mock_stats.return_value = OverallStats()
+        mock_orchestrator.assert_not_called()
+
+    def test_run_evaluation_with_output_dir_override(
+        self,
+        mocker: MockerFixture,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Test evaluation with custom output directory."""
+        _, _, mock_orchestrator = _setup_runner_mocks(mocker)
 
         run_evaluation(_make_eval_args(output_dir="/custom/output"))
 
-        mock_evaluate.assert_called_once()
-        call_args = mock_evaluate.call_args
-        assert call_args[0] == (mock_config, mock_eval_data)
-        assert call_args[1]["output_dir"] == "/custom/output"
-        assert call_args[1]["original_data_path"] == "config/evaluation_data.yaml"
-        assert (
-            call_args[1]["dataset_metadata"]
-            is mock_validator.return_value.dataset_metadata
-        )
+        mock_orchestrator.assert_called_once()
+        call_args = mock_orchestrator.call_args
+        assert call_args[0][2] == "/custom/output"
 
     def test_run_evaluation_file_not_found(
         self, mocker: MockerFixture, capsys: pytest.CaptureFixture
@@ -281,46 +295,23 @@ class TestRunEvaluation:
         self, mocker: MockerFixture, capsys: pytest.CaptureFixture
     ) -> None:
         """Test evaluation reports errors in results."""
-        mock_loader = mocker.Mock()
-        mock_config = mocker.Mock()
-        mock_config.llm.provider = "openai"
-        mock_config.llm.model = "gpt-4"
-        mock_config.agents = None
-        mock_config.storage = []
-        mock_loader.system_config = mock_config
-        mock_loader.load_system_config.return_value = mock_config
-
-        mock_config_loader_class = mocker.patch(
-            "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
-
-        mock_eval_data = [mocker.Mock()]
-        mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
-
-        mocker.patch("lightspeed_evaluation.api.evaluate", return_value=[])
-
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/tmp/output"
-        mock_output_class = mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler"
-        )
-        mock_output_class.return_value = mock_output_handler
-
-        mock_stats = mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats"
-        )
-        mock_stats.return_value = OverallStats(
-            total=10,
-            passed=5,
-            failed=2,
-            error=3,
-            skipped=0,
-            total_judge_llm_input_tokens=500,
-            total_judge_llm_output_tokens=250,
-            total_judge_llm_tokens=750,
-            total_embedding_tokens=10,
+        _setup_runner_mocks(
+            mocker,
+            orchestrator_results=[
+                RunResult(
+                    agent_name="model_a",
+                    run_index=1,
+                    output_dir="/tmp/out",
+                    success=True,
+                    summary={
+                        "TOTAL": 10,
+                        "PASS": 5,
+                        "FAIL": 2,
+                        "ERROR": 3,
+                        "SKIPPED": 0,
+                    },
+                )
+            ],
         )
 
         result = run_evaluation(_make_eval_args())
@@ -335,28 +326,10 @@ class TestRunEvaluation:
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test that RuntimeError from evaluate() is caught by the CLI handler."""
-        mock_loader = mocker.Mock()
-        mock_config = mocker.Mock()
-        mock_config.llm.provider = "openai"
-        mock_config.llm.model = "gpt-4"
-        mock_config.agents = None
-        mock_config.storage = []
-        mock_loader.system_config = mock_config
-        mock_loader.load_system_config.return_value = mock_config
-
-        mock_config_loader_class = mocker.patch(
-            "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
-
-        mock_eval_data = [mocker.Mock()]
-        mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
-
-        mocker.patch(
-            "lightspeed_evaluation.api.evaluate",
-            side_effect=RuntimeError("Processing error"),
+        """Test that RuntimeError from orchestrator is caught by the CLI handler."""
+        _setup_runner_mocks(
+            mocker,
+            orchestrator_side_effect=RuntimeError("Processing error"),
         )
 
         result = run_evaluation(_make_eval_args())
@@ -400,47 +373,7 @@ class TestRunEvaluation:
 
     def test_run_evaluation_with_filter_parameters(self, mocker: MockerFixture) -> None:
         """Test that filter parameters are correctly passed to DataValidator."""
-        mock_loader = mocker.Mock()
-        mock_config = mocker.Mock()
-        mock_config.llm.provider = "openai"
-        mock_config.llm.model = "gpt-4"
-        mock_config.agents = None
-        mock_config.storage = []
-        mock_loader.system_config = mock_config
-        mock_loader.load_system_config.return_value = mock_config
-
-        mocker.patch(
-            "lightspeed_evaluation.runner.evaluation.ConfigLoader",
-            return_value=mock_loader,
-        )
-
-        mock_eval_data = mocker.Mock()
-        mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = [mock_eval_data]
-
-        mocker.patch("lightspeed_evaluation.api.evaluate", return_value=[])
-
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/tmp/output"
-        mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler",
-            return_value=mock_output_handler,
-        )
-
-        mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats",
-            return_value=OverallStats(
-                total=1,
-                passed=1,
-                failed=0,
-                error=0,
-                skipped=0,
-                total_judge_llm_input_tokens=100,
-                total_judge_llm_output_tokens=50,
-                total_judge_llm_tokens=150,
-                total_embedding_tokens=10,
-            ),
-        )
+        _, mock_validator, _ = _setup_runner_mocks(mocker)
 
         run_evaluation(_make_eval_args(tags=["basic"], conv_ids=["conv_1"]))
 
@@ -456,28 +389,10 @@ class TestRunEvaluation:
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """StorageError from the pipeline ends the run with a clear message."""
-        mock_loader = mocker.Mock()
-        mock_config = mocker.Mock()
-        mock_config.llm.provider = "openai"
-        mock_config.llm.model = "gpt-4"
-        mock_config.agents = None
-        mock_config.storage = []
-        mock_loader.system_config = mock_config
-        mock_loader.load_system_config.return_value = mock_config
-
-        mock_config_loader_class = mocker.patch(
-            "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
-
-        mock_eval_data = [mocker.Mock()]
-        mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
-
-        mocker.patch(
-            "lightspeed_evaluation.api.evaluate",
-            side_effect=StorageError(
+        """StorageError from the orchestrator ends the run with a clear message."""
+        _setup_runner_mocks(
+            mocker,
+            orchestrator_side_effect=StorageError(
                 "Database schema mismatch: the existing table 'evaluation_results' "
                 "is missing required column(s): score.",
                 backend_name="sqlite",
@@ -737,7 +652,7 @@ class TestRunEvaluationCacheWarmup:
         mock_config.llm.model = "gpt-4"
         mock_config.llm.cache_enabled = True
         mock_config.llm.cache_dir = str(llm_cache)
-        mock_config.agents = None
+        mock_config.agents.default.agent = ["mock_agent"]
         mock_config.api.cache_enabled = False
         mock_config.embedding.cache_enabled = False
         mock_config.storage = []
@@ -752,34 +667,26 @@ class TestRunEvaluationCacheWarmup:
         # Mock evaluation data
         mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
         mock_validator.return_value.load_evaluation_data.return_value = [mocker.Mock()]
+        mock_validator.return_value.dataset_metadata = None
 
-        # Mock evaluate() API function
-        mock_result = mocker.Mock()
-        mock_result.result = "PASS"
-        mocker.patch("lightspeed_evaluation.api.evaluate", return_value=[mock_result])
-
-        # Mock output handler
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/tmp/output"
-        mock_output_class = mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler"
-        )
-        mock_output_class.return_value = mock_output_handler
-
-        # Mock stats
-        mock_stats = mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats"
-        )
-        mock_stats.return_value = OverallStats(
-            total=1,
-            passed=1,
-            failed=0,
-            error=0,
-            skipped=0,
-            total_judge_llm_input_tokens=100,
-            total_judge_llm_output_tokens=50,
-            total_judge_llm_tokens=150,
-            total_embedding_tokens=10,
+        # Mock orchestrator
+        mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.run",
+            return_value=[
+                RunResult(
+                    agent_name="model_a",
+                    run_index=1,
+                    output_dir="/tmp/out",
+                    success=True,
+                    summary={
+                        "TOTAL": 1,
+                        "PASS": 1,
+                        "FAIL": 0,
+                        "ERROR": 0,
+                        "SKIPPED": 0,
+                    },
+                )
+            ],
         )
 
         # Run evaluation with cache warmup flag
@@ -802,58 +709,21 @@ class TestRunEvaluationCacheWarmup:
         self, tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture
     ) -> None:
         """Test that caches are NOT cleared when warmup flag is false."""
-        # Setup cache directory with existing file
         llm_cache = tmp_path / "llm_cache"
         llm_cache.mkdir()
         (llm_cache / "existing_cache.db").write_text("existing data")
 
-        # Mock ConfigLoader
-        mock_loader = mocker.Mock()
-        mock_config = mocker.Mock()
-        mock_config.llm.provider = "openai"
-        mock_config.llm.model = "gpt-4"
+        mock_config, _, _ = _setup_runner_mocks(mocker)
         mock_config.llm.cache_enabled = True
         mock_config.llm.cache_dir = str(llm_cache)
-        mock_config.agents = None
         mock_config.api.cache_enabled = False
         mock_config.embedding.cache_enabled = False
-        mock_config.storage = []
-        mock_loader.system_config = mock_config
-        mock_loader.load_system_config.return_value = mock_config
 
-        mock_config_loader_class = mocker.patch(
-            "lightspeed_evaluation.runner.evaluation.ConfigLoader"
-        )
-        mock_config_loader_class.return_value = mock_loader
-
-        mock_eval_data = [mocker.Mock()]
-        mock_validator = mocker.patch("lightspeed_evaluation.core.system.DataValidator")
-        mock_validator.return_value.load_evaluation_data.return_value = mock_eval_data
-
-        mocker.patch("lightspeed_evaluation.api.evaluate", return_value=[])
-
-        mock_output_handler = mocker.Mock()
-        mock_output_handler.output_dir = "/tmp/output"
-        mock_output_class = mocker.patch(
-            "lightspeed_evaluation.core.output.OutputHandler"
-        )
-        mock_output_class.return_value = mock_output_handler
-
-        mock_stats = mocker.patch(
-            "lightspeed_evaluation.core.output.statistics.compute_overall_stats"
-        )
-        mock_stats.return_value = OverallStats()
-
-        # Run evaluation WITHOUT cache warmup flag
         run_evaluation(_make_eval_args(cache_warmup=False))
 
-        # Verify cache was NOT cleared
         assert (llm_cache / "existing_cache.db").exists()
-
-        # Verify no warmup message in output
         captured = capsys.readouterr()
         assert "Cache warmup mode" not in captured.out
-        assert "Cleared LLM Judge cache" not in captured.out
 
 
 class TestMain:


### PR DESCRIPTION
## Description

  - Runner delegates to orchestrator when agents are configured
  - Offline mode (no agents) uses existing evaluate() path — unchanged behavior
  - 1x1 produces flat output (backward compat), NxM produces nested eval_<ts>/agent/run_N/
  - All artifacts preserved: CSV, JSON, TXT, quality report, graphs, amended data
  - Token summary and pass/fail/error in console output
  - Parallel execution works via ProcessPoolExecutor
  - Cache disabled for repeated runs, judge cache preserved

Next: Statistical modules & final reporting

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Expanded evaluation summaries to report additional token totals, including deduplicated API input/output tokens per conversation turn.

- **Bug Fixes**
  - Corrected output directory selection: single-run writes to the provided output base; multi-run uses per-run subfolders.
  - Ensured per-run storage configuration is applied consistently during cloned runs.

- **Refactor**
  - Updated runner reporting flow to separate offline vs agent-based execution and to aggregate totals across runs.

- **Tests**
  - Added/updated unit and integration tests covering token aggregation, run output directories, and storage injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->