### PR TITLE
[LEADS-563] LLMManager requires OpenAI credentials when only llm_pool/ judge_panel (non-OpenAI) is configured

### DIFF
--- a/src/lightspeed_evaluation/core/llm/manager.py
+++ b/src/lightspeed_evaluation/core/llm/manager.py
@@ -26,7 +26,8 @@ class LLMManager:
         config: LLMConfig,
         system_config: Optional[SystemConfig] = None,
         judge_id: Optional[str] = None,
-    ):
+        judge_configs: Optional[list[tuple[str, LLMConfig]]] = None,
+    ) -> None:
         """Initialize with validated environment and constructed model name.
 
         Args:
@@ -34,27 +35,24 @@ class LLMManager:
             system_config: Optional full system config for judge panel support
             judge_id: Optional identifier for this judge (pool key). If not provided,
                 defaults to "primary" for single LLM or the pool key for panel judges.
+            judge_configs: Optional pre-resolved ``(pool_key, LLMConfig)`` pairs for
+                the judge panel. When provided (typically by ``from_system_config``),
+                managers are built from these configs without resolving again.
         """
         self.config = config
         self.system_config = system_config
         self.model_name = self._construct_model_name_and_validate(config)
         self.judge_id = judge_id or "primary"
 
-        # Initialize judge panel if available
+        # Initialize judge panel from pre-resolved configs when available
         self.judge_managers: list["LLMManager"] = []
-        if system_config and system_config.judge_panel and system_config.llm_pool:
-            panel = system_config.judge_panel
-            logger.info("Judge panel configured with %d judges", len(panel.judges))
-            # Create LLM managers for each judge using resolved configs from llms pool
-            try:
-                judge_configs = system_config.get_judge_configs()
-                for pool_key, resolved_config in judge_configs:
-                    # Create child manager without system_config to avoid recursion
-                    judge_manager = LLMManager(resolved_config, judge_id=pool_key)
-                    self.judge_managers.append(judge_manager)
-            except ConfigurationError as e:
-                logger.error("Failed to resolve judge panel: %s", e)
-                raise
+        if judge_configs:
+            logger.info("Judge panel configured with %d judges", len(judge_configs))
+            for pool_key, resolved_config in judge_configs:
+                # Create child manager without system_config to avoid recursion
+                self.judge_managers.append(
+                    LLMManager(resolved_config, judge_id=pool_key)
+                )
         else:
             # No judge panel - log single LLM info
             logger.info(
@@ -231,12 +229,30 @@ class LLMManager:
     def from_system_config(cls, system_config: SystemConfig) -> "LLMManager":
         """Create LLM Manager from system configuration.
 
+        When ``judge_panel`` is configured, the first judge's resolved config is
+        used as the primary/fallback LLM. ``get_judge_configs()`` raises
+        ``ConfigurationError`` if ``llm_pool`` is missing, so invalid panel
+        configs do not silently fall back to the legacy top-level ``llm``
+        (which defaults to OpenAI when ``llm:`` is omitted from YAML).
+
         Args:
             system_config: System configuration with LLM and optional judge panel
 
         Returns:
             LLMManager with judge panel support if configured
         """
+        if system_config.judge_panel:
+            try:
+                judge_configs = system_config.get_judge_configs()
+            except ConfigurationError as e:
+                logger.error("Failed to resolve judge panel: %s", e)
+                raise
+            _, primary_config = judge_configs[0]
+            return cls(
+                primary_config,
+                system_config=system_config,
+                judge_configs=judge_configs,
+            )
         return cls(system_config.llm, system_config=system_config)
 
     @classmethod

--- a/tests/unit/core/llm/test_llm_manager.py
+++ b/tests/unit/core/llm/test_llm_manager.py
@@ -17,6 +17,7 @@ from lightspeed_evaluation.core.models.llm import (
     LLMParametersConfig,
     LLMProviderConfig,
 )
+from lightspeed_evaluation.core.system.exceptions import ConfigurationError
 
 
 class TestLLMManager:
@@ -387,6 +388,60 @@ class TestLLMManagerJudgePanel:
             "Judge panel" in record.message and "2 judges" in record.message
             for record in caplog.records
         )
+
+    def test_judge_panel_skips_legacy_llm_provider_validation(
+        self, mocker: MockerFixture
+    ) -> None:
+        """llm_pool + judge_panel must not validate unused legacy llm defaults.
+
+        When top-level llm: is omitted, SystemConfig defaults provider to openai.
+        Startup should only require credentials for configured judges.
+        """
+        validate_mock = mocker.patch(
+            "lightspeed_evaluation.core.llm.manager.validate_provider_env"
+        )
+
+        pool, panel = _create_llm_pool_with_judges([("gemini", "gemini-2.5-pro")])
+        # Intentionally leave default llm (openai/gpt-4o-mini) unused
+        system_config = SystemConfig(llm_pool=pool, judge_panel=panel)
+
+        manager = LLMManager.from_system_config(system_config)
+
+        validated_providers = [call.args[0] for call in validate_mock.call_args_list]
+        assert "openai" not in validated_providers
+        assert "gemini" in validated_providers
+        assert manager.has_judge_panel()
+        assert manager.config.provider == "gemini"
+        assert manager.get_primary_judge().config.provider == "gemini"
+        assert manager.get_primary_judge().config.model == "gemini-2.5-pro"
+
+    def test_judge_panel_without_llm_pool_raises(self, mocker: MockerFixture) -> None:
+        """judge_panel without llm_pool must raise, not fall back to legacy llm."""
+        mocker.patch("lightspeed_evaluation.core.llm.manager.validate_provider_env")
+
+        panel = JudgePanelConfig(judges=["gemini-2.5-pro"])
+        system_config = SystemConfig(judge_panel=panel)
+
+        with pytest.raises(ConfigurationError, match="llm_pool"):
+            LLMManager.from_system_config(system_config)
+
+    def test_from_system_config_resolves_judge_configs_once(
+        self, mocker: MockerFixture
+    ) -> None:
+        """get_judge_configs should be called once when building a panel manager."""
+        mocker.patch("lightspeed_evaluation.core.llm.manager.validate_provider_env")
+
+        pool, panel = _create_llm_pool_with_judges(
+            [("openai", "gpt-4o-mini"), ("gemini", "gemini-2.5-pro")]
+        )
+        system_config = SystemConfig(llm_pool=pool, judge_panel=panel)
+        resolve_spy = mocker.spy(SystemConfig, "get_judge_configs")
+
+        manager = LLMManager.from_system_config(system_config)
+
+        assert resolve_spy.call_count == 1
+        assert len(manager.judge_managers) == 2
+        assert manager.get_primary_judge().config.model == "gpt-4o-mini"
 
 
 class TestLLMManagerBackwardCompatibility:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Grok-4.5-high
- Generated by: Cursor

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LEADS-563
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying pre-resolved judge configurations when initializing the LLM manager.

* **Bug Fixes**
  * Improved precedence of judge panel settings over legacy LLM pool/provider configuration.
  * Avoided unnecessary legacy provider validation when judge-specific settings are present.
  * Uses the resolved judge configuration as the primary/fallback; invalid judge panel setups now raise `ConfigurationError`.

* **Tests**
  * Added unit tests covering precedence, skipped legacy validation, error handling, and ensuring judge configs are resolved once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->