### PR TITLE
save both old and new file structure for 1x1

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
@@ -132,7 +132,6 @@ def _build_run_contexts(
     output_base = run_params["output_base"]
     timestamp = run_params["timestamp"]
     run_matrix = run_params["run_matrix"]
-    is_single_run = len(run_matrix) == 1
 
     return [
         RunContext(
@@ -141,10 +140,8 @@ def _build_run_contexts(
             default_agents=run_params["default_agents"],
             agent_name=agent,
             run_index=idx,
-            run_output_dir=(
-                output_base
-                if is_single_run
-                else os.path.join(output_base, f"eval_{timestamp}", agent, f"run_{idx}")
+            run_output_dir=os.path.join(
+                output_base, f"eval_{timestamp}", agent, f"run_{idx}"
             ),
             extra={
                 "original_data_path": run_params.get("original_data_path"),

--- a/src/lightspeed_evaluation/runner/evaluation.py
+++ b/src/lightspeed_evaluation/runner/evaluation.py
@@ -1,6 +1,7 @@
 """Lightspeed Evaluation Framework - Main Evaluation Runner."""
 
 import argparse
+import logging
 import os
 import shutil
 import sys
@@ -21,6 +22,8 @@ from lightspeed_evaluation.core.system.exceptions import (
     DataValidationError,
     StorageError,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _clear_caches(system_config: SystemConfig) -> None:
@@ -71,23 +74,36 @@ def _clear_caches(system_config: SystemConfig) -> None:
 
 def _print_run_summary(
     totals: dict[str, int],
-    run_results: list,
+    run_results: Optional[list] = None,
+    output_dir: Optional[str] = None,
 ) -> None:
-    """Print evaluation summary and token usage from orchestrator results."""
+    """Print evaluation summary and token usage.
+
+    Args:
+        totals: Aggregated summary dict with TOTAL/PASS/FAIL/ERROR/SKIPPED
+            and token fields.
+        run_results: Run results from orchestrator (agent mode).
+        output_dir: Explicit output directory (offline mode).
+    """
     print(f"📊 {totals['TOTAL']} evaluations completed")
-    if len(run_results) > 1:
+    if run_results and len(run_results) > 1:
         succeeded = sum(1 for r in run_results if r.success)
         print(
             f"📊 {len(run_results)} runs "
             f"({succeeded} succeeded, {len(run_results) - succeeded} failed)"
         )
-    output_dirs = {Path(rr.output_dir).resolve() for rr in run_results if rr.output_dir}
-    if len(run_results) > 1 and output_dirs:
-        common = Path(os.path.commonpath(output_dirs))
-        print(f"📁 Reports generated in: {common}")
-    else:
-        for d in output_dirs:
-            print(f"📁 Reports generated in: {d}")
+    if run_results:
+        output_dirs = {
+            Path(rr.output_dir).resolve() for rr in run_results if rr.output_dir
+        }
+        if len(run_results) > 1 and output_dirs:
+            common = Path(os.path.commonpath(output_dirs))
+            print(f"📁 Reports generated in: {common}")
+        else:
+            for d in output_dirs:
+                print(f"📁 Reports generated in: {d}")
+    elif output_dir:
+        print(f"📁 Reports generated in: {Path(output_dir).resolve()}")
     print(
         f"✅ Pass: {totals['PASS']}, ❌ Fail: {totals['FAIL']}, "
         f"⚠️ Error: {totals['ERROR']}, ⏭️ Skipped: {totals['SKIPPED']}"
@@ -117,6 +133,46 @@ def _print_run_summary(
         print(f"Total: {total_tokens:,} tokens")
 
 
+def _aggregate_totals(run_results: list) -> dict[str, int]:
+    """Aggregate summary totals from multiple run results."""
+    totals: dict[str, int] = {
+        "TOTAL": 0,
+        "PASS": 0,
+        "FAIL": 0,
+        "ERROR": 0,
+        "SKIPPED": 0,
+        "judge_llm_input_tokens": 0,
+        "judge_llm_output_tokens": 0,
+        "embedding_tokens": 0,
+        "api_input_tokens": 0,
+        "api_output_tokens": 0,
+    }
+    for rr in run_results:
+        if rr.summary:
+            for key, val in rr.summary.items():
+                totals[key] = totals.get(key, 0) + val
+    return totals
+
+
+def _copy_flat_output(run_results: list, output_dir: str) -> None:
+    """Copy nested output to flat dir for 1x1 backward compatibility.
+
+    Temporary bridge: will be removed once all consumers migrate to
+    the nested eval_<timestamp>/agent/run_N/ structure.
+    """
+    if len(run_results) != 1 or run_results[0].output_dir == output_dir:
+        return
+    nested = Path(run_results[0].output_dir)
+    if not nested.is_dir():
+        return
+    try:
+        flat = Path(output_dir)
+        flat.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(nested, flat, dirs_exist_ok=True)
+    except OSError:
+        logger.warning("Failed to copy flat output from %s to %s", nested, output_dir)
+
+
 def run_evaluation(  # pylint: disable=too-many-locals
     eval_args: argparse.Namespace,
 ) -> Optional[dict[str, int]]:
@@ -127,6 +183,7 @@ def run_evaluation(  # pylint: disable=too-many-locals
 
     Returns:
         dict: Summary statistics with keys TOTAL, PASS, FAIL, ERROR, SKIPPED
+            and token usage fields (judge_llm, embedding, api).
     """
     print("🚀 Lightspeed Evaluation Framework")
     print("=" * 50)
@@ -179,12 +236,25 @@ def run_evaluation(  # pylint: disable=too-many-locals
         if len(evaluation_data) == 0:
             print("\n⚠️ No conversation groups matched the filter criteria")
             print("   Nothing to evaluate - returning empty results")
-            return {"TOTAL": 0, "PASS": 0, "FAIL": 0, "ERROR": 0, "SKIPPED": 0}
+            return {
+                "TOTAL": 0,
+                "PASS": 0,
+                "FAIL": 0,
+                "ERROR": 0,
+                "SKIPPED": 0,
+                "judge_llm_input_tokens": 0,
+                "judge_llm_output_tokens": 0,
+                "embedding_tokens": 0,
+                "api_input_tokens": 0,
+                "api_output_tokens": 0,
+            }
 
         # Run evaluation
         print("\n🔄 Running Evaluation...")
         has_agents = (
-            system_config.agents is not None and system_config.agents.default.agent
+            system_config.agents is not None
+            and system_config.agents.enabled
+            and system_config.agents.default.agent
         )
 
         if not has_agents:
@@ -213,26 +283,21 @@ def run_evaluation(  # pylint: disable=too-many-locals
                 eval_args.output_dir
                 or get_file_config(system_config.storage).output_dir
             )
-            print(f"\n🎉 Evaluation Complete!\n📊 {len(results)} evaluations completed")
-            print(f"📁 Reports generated in: {Path(out_dir).resolve()}")
-            print(
-                f"✅ Pass: {summary.passed}, ❌ Fail: {summary.failed}, "
-                f"⚠️ Error: {summary.error}, ⏭️ Skipped: {summary.skipped}"
-            )
-            print(
-                f"\n📊 Token Usage Summary:\n"
-                f"Judge LLM: {summary.total_judge_llm_tokens:,} tokens "
-                f"(Input: {summary.total_judge_llm_input_tokens:,}, "
-                f"Output: {summary.total_judge_llm_output_tokens:,})\n"
-                f"Embeddings: {summary.total_embedding_tokens:,} tokens"
-            )
-            return {
+            totals: dict[str, int] = {
                 "TOTAL": summary.total,
                 "PASS": summary.passed,
                 "FAIL": summary.failed,
                 "ERROR": summary.error,
                 "SKIPPED": summary.skipped,
+                "judge_llm_input_tokens": summary.total_judge_llm_input_tokens,
+                "judge_llm_output_tokens": summary.total_judge_llm_output_tokens,
+                "embedding_tokens": summary.total_embedding_tokens,
+                "api_input_tokens": 0,
+                "api_output_tokens": 0,
             }
+            print("\n🎉 Evaluation Complete!")
+            _print_run_summary(totals, output_dir=out_dir)
+            return totals
 
         # Agent mode: run via orchestrator
         output_dir = (
@@ -247,20 +312,11 @@ def run_evaluation(  # pylint: disable=too-many-locals
                 dataset_metadata.model_dump() if dataset_metadata else None
             ),
         )
-        totals: dict[str, int] = {
-            "TOTAL": 0,
-            "PASS": 0,
-            "FAIL": 0,
-            "ERROR": 0,
-            "SKIPPED": 0,
-        }
-        for rr in run_results:
-            if rr.summary:
-                for key, val in rr.summary.items():
-                    totals[key] = totals.get(key, 0) + val
+        totals = _aggregate_totals(run_results)
+        _copy_flat_output(run_results, output_dir)
 
         print("\n🎉 Evaluation Complete!")
-        _print_run_summary(totals, run_results)
+        _print_run_summary(totals, run_results=run_results)
 
         return totals
 

--- a/tests/unit/pipeline/behavioral/test_orchestrator.py
+++ b/tests/unit/pipeline/behavioral/test_orchestrator.py
@@ -375,7 +375,7 @@ class TestRunOrchestrator:
     def test_1x1_produces_one_result(
         self, mocker: MockerFixture, tmp_path: Path
     ) -> None:
-        """1x1 produces one run result."""
+        """1x1 produces one run result with nested output path."""
         mock_pipeline = self._mock_pipeline(mocker)
         mock_pipeline.run_evaluation.return_value = []
 
@@ -401,7 +401,10 @@ class TestRunOrchestrator:
         assert len(results) == 1
         assert results[0].agent_name == "model_a"
         assert results[0].run_index == 1
-        assert results[0].output_dir == str(tmp_path)
+        output_path = Path(results[0].output_dir)
+        assert output_path.name == "run_1"
+        assert output_path.parent.name == "model_a"
+        assert output_path.parent.parent.name.startswith("eval_")
 
     def test_failed_run_does_not_stop_others(
         self, mocker: MockerFixture, tmp_path: Path
@@ -470,6 +473,8 @@ class TestRunOrchestrator:
 
         assert len(results) == 2
         for r in results:
-            assert f"model_a/run_{r.run_index}" in r.output_dir
-            assert "eval_" in r.output_dir
-            assert Path(r.output_dir).is_dir()
+            output_path = Path(r.output_dir)
+            assert output_path.name == f"run_{r.run_index}"
+            assert output_path.parent.name == "model_a"
+            assert output_path.parent.parent.name.startswith("eval_")
+            assert output_path.is_dir()

--- a/tests/unit/runner/test_evaluation.py
+++ b/tests/unit/runner/test_evaluation.py
@@ -25,7 +25,13 @@ from lightspeed_evaluation.core.system.exceptions import (
     StorageError,
 )
 from lightspeed_evaluation.pipeline.behavioral.models import RunResult
-from lightspeed_evaluation.runner.evaluation import _clear_caches, main, run_evaluation
+from lightspeed_evaluation.runner.evaluation import (
+    _aggregate_totals,
+    _clear_caches,
+    _copy_flat_output,
+    main,
+    run_evaluation,
+)
 
 _MAIN_STATS: dict[str, int] = {
     "TOTAL": 1,
@@ -830,3 +836,171 @@ class TestMain:
         assert ev.cache_warmup is expected["cache_warmup"]
         assert ev.tags == expected["tags"]
         assert ev.conv_ids == expected["conv_ids"]
+
+
+class TestAggregateTotals:
+    """Tests for _aggregate_totals helper."""
+
+    def test_aggregates_all_fields(self) -> None:
+        """All token and status fields are summed across runs."""
+        results = [
+            RunResult(
+                agent_name="a",
+                run_index=1,
+                output_dir="/out",
+                success=True,
+                summary={
+                    "TOTAL": 3,
+                    "PASS": 2,
+                    "FAIL": 1,
+                    "ERROR": 0,
+                    "SKIPPED": 0,
+                    "judge_llm_input_tokens": 100,
+                    "judge_llm_output_tokens": 50,
+                    "embedding_tokens": 10,
+                    "api_input_tokens": 200,
+                    "api_output_tokens": 80,
+                },
+            ),
+            RunResult(
+                agent_name="b",
+                run_index=1,
+                output_dir="/out2",
+                success=True,
+                summary={
+                    "TOTAL": 2,
+                    "PASS": 1,
+                    "FAIL": 0,
+                    "ERROR": 1,
+                    "SKIPPED": 0,
+                    "judge_llm_input_tokens": 50,
+                    "judge_llm_output_tokens": 20,
+                    "embedding_tokens": 5,
+                    "api_input_tokens": 100,
+                    "api_output_tokens": 40,
+                },
+            ),
+        ]
+        totals = _aggregate_totals(results)
+        assert totals["TOTAL"] == 5
+        assert totals["PASS"] == 3
+        assert totals["FAIL"] == 1
+        assert totals["ERROR"] == 1
+        assert totals["judge_llm_input_tokens"] == 150
+        assert totals["api_input_tokens"] == 300
+        assert totals["embedding_tokens"] == 15
+
+    def test_skips_none_summary(self) -> None:
+        """Runs with no summary are skipped."""
+        results = [
+            RunResult(
+                agent_name="a",
+                run_index=1,
+                output_dir="/out",
+                success=False,
+                summary=None,
+            ),
+        ]
+        totals = _aggregate_totals(results)
+        assert totals["TOTAL"] == 0
+        assert totals["judge_llm_input_tokens"] == 0
+
+    def test_empty_results(self) -> None:
+        """Empty results list returns zeroed totals."""
+        totals = _aggregate_totals([])
+        assert totals["TOTAL"] == 0
+        assert all(v == 0 for v in totals.values())
+
+
+class TestCopyFlatOutput:
+    """Tests for _copy_flat_output helper."""
+
+    def test_copies_files_for_1x1(self, tmp_path: Path) -> None:
+        """1x1 run copies nested files to flat dir."""
+        nested = tmp_path / "eval_20260729" / "agent" / "run_1"
+        nested.mkdir(parents=True)
+        (nested / "results.csv").write_text("data")
+        (nested / "summary.json").write_text("{}")
+
+        flat = tmp_path / "flat_out"
+        results = [
+            RunResult(
+                agent_name="agent",
+                run_index=1,
+                output_dir=str(nested),
+                success=True,
+            ),
+        ]
+        _copy_flat_output(results, str(flat))
+        assert (flat / "results.csv").exists()
+        assert (flat / "summary.json").exists()
+
+    def test_copies_subdirs_for_1x1(self, tmp_path: Path) -> None:
+        """1x1 run copies subdirectories (e.g. graphs/) to flat dir."""
+        nested = tmp_path / "eval_20260729" / "agent" / "run_1"
+        graphs = nested / "graphs"
+        graphs.mkdir(parents=True)
+        (graphs / "chart.png").write_text("img")
+
+        flat = tmp_path / "flat_out"
+        results = [
+            RunResult(
+                agent_name="agent",
+                run_index=1,
+                output_dir=str(nested),
+                success=True,
+            ),
+        ]
+        _copy_flat_output(results, str(flat))
+        assert (flat / "graphs" / "chart.png").exists()
+
+    def test_no_copy_for_multi_run(self, tmp_path: Path) -> None:
+        """Multi-run results do not trigger flat copy."""
+        nested1 = tmp_path / "run_1"
+        nested1.mkdir()
+        (nested1 / "results.csv").write_text("data")
+        nested2 = tmp_path / "run_2"
+        nested2.mkdir()
+
+        flat = tmp_path / "flat_out"
+        results = [
+            RunResult(
+                agent_name="a",
+                run_index=1,
+                output_dir=str(nested1),
+                success=True,
+            ),
+            RunResult(
+                agent_name="a",
+                run_index=2,
+                output_dir=str(nested2),
+                success=True,
+            ),
+        ]
+        _copy_flat_output(results, str(flat))
+        assert not flat.exists()
+
+    def test_no_copy_when_same_dir(self, tmp_path: Path) -> None:
+        """No copy when nested dir equals flat dir."""
+        (tmp_path / "results.csv").write_text("data")
+        results = [
+            RunResult(
+                agent_name="a",
+                run_index=1,
+                output_dir=str(tmp_path),
+                success=True,
+            ),
+        ]
+        _copy_flat_output(results, str(tmp_path))
+
+    def test_tolerates_missing_nested_dir(self, tmp_path: Path) -> None:
+        """No error when nested dir doesn't exist."""
+        results = [
+            RunResult(
+                agent_name="a",
+                run_index=1,
+                output_dir=str(tmp_path / "nonexistent"),
+                success=True,
+            ),
+        ]
+        _copy_flat_output(results, str(tmp_path / "flat"))


### PR DESCRIPTION
## Description

save both old and new file structure for 1x1
Add additional metadata

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Evaluation outputs now use a consistent nested directory structure across single- and multi-run evaluations.
  * Evaluation summaries provide clearer reporting for offline and agent-based runs, including token usage totals and report locations.
  * Multi-agent results can also be copied to a flat output location for easier access.
* **Bug Fixes**
  * Evaluations with no matching conversation groups now return complete totals, including token usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->