### PR TITLE
feat: add opt-in verbose_logs to surface GEval judge criteria, steps,…

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -217,6 +217,7 @@ metrics_metadata:
       #     expected_outcome: "Technically correct and follows best practices."
       threshold: 0.7
       description: "General technical accuracy of provided commands, code, or technical information"
+      # verbose: true  # optional: include verbose logs (criteria, evaluation steps, rubric) in output
 
   # Conversation-level metrics metadata
   conversation_level:

--- a/src/lightspeed_evaluation/core/constants.py
+++ b/src/lightspeed_evaluation/core/constants.py
@@ -109,6 +109,8 @@ SUPPORTED_CSV_COLUMNS = [
     "embedding_tokens",
     # Per-judge scores (JSON array with one entry for single judge)
     "judge_scores",
+    # GEval verbose logs (opt-in via verbose: true in metric config)
+    "verbose_logs",
     # Streaming performance metrics
     "time_to_first_token",
     "streaming_duration",

--- a/src/lightspeed_evaluation/core/metrics/deepeval.py
+++ b/src/lightspeed_evaluation/core/metrics/deepeval.py
@@ -69,6 +69,8 @@ class DeepEvalMetrics:  # pylint: disable=too-few-public-methods
             metric_manager=metric_manager,
         )
 
+        self.last_verbose_logs: str | None = None
+
         # Standard DeepEval metrics routing
         self.supported_metrics = {
             "conversation_completeness": self._evaluate_conversation_completeness,
@@ -137,6 +139,8 @@ class DeepEvalMetrics:  # pylint: disable=too-few-public-methods
             tuple[float | None, str]: Tuple of (score, reason).
                 Score is in [0, 1] or None if evaluation failed.
         """
+        self.last_verbose_logs = None
+
         # Route to standard DeepEval metrics
         if metric_name in self.supported_metrics:
             try:
@@ -152,13 +156,15 @@ class DeepEvalMetrics:  # pylint: disable=too-few-public-methods
             if metric_name.startswith("geval:")
             else metric_name
         )
-        return self.geval_handler.evaluate(
+        result = self.geval_handler.evaluate(
             metric_name=normalized_metric_name,
             conv_data=conv_data,
             _turn_idx=scope.turn_idx,
             turn_data=scope.turn_data,
             is_conversation=scope.is_conversation,
         )
+        self.last_verbose_logs = self.geval_handler.last_verbose_logs
+        return result
 
     def _evaluate_conversation_completeness(
         self,

--- a/src/lightspeed_evaluation/core/metrics/geval.py
+++ b/src/lightspeed_evaluation/core/metrics/geval.py
@@ -55,6 +55,7 @@ class GEvalHandler:  # pylint: disable=R0903
         """
         self.deepeval_llm_manager = deepeval_llm_manager
         self.metric_manager = metric_manager
+        self.last_verbose_logs: str | None = None
 
     def evaluate(  # pylint: disable=R0913,R0917
         self,
@@ -99,6 +100,8 @@ class GEvalHandler:  # pylint: disable=R0903
         4. Delegate to `_evaluate_conversation()` or `_evaluate_turn()` depending
            on the `is_conversation` flag.
         """
+        self.last_verbose_logs = None
+
         # Extract GEval configuration from metadata (runtime or system registry)
         raw_config = self._get_geval_config(
             metric_name, conv_data, turn_data, is_conversation
@@ -131,6 +134,7 @@ class GEvalHandler:  # pylint: disable=R0903
                 config.evaluation_steps,
                 config.threshold,
                 rubrics,
+                config.verbose,
             )
         return self._evaluate_turn(
             turn_data,
@@ -139,6 +143,7 @@ class GEvalHandler:  # pylint: disable=R0903
             config.evaluation_steps,
             config.threshold,
             rubrics,
+            config.verbose,
         )
 
     def _convert_evaluation_params(
@@ -201,7 +206,7 @@ class GEvalHandler:  # pylint: disable=R0903
         # Return the successfully converted list, or None if it ended up empty
         return converted if converted else None
 
-    def _evaluate_turn(  # pylint: disable=R0913,R0917
+    def _evaluate_turn(  # pylint: disable=R0913,R0914,R0917
         self,
         turn_data: Any,
         criteria: str,
@@ -209,6 +214,7 @@ class GEvalHandler:  # pylint: disable=R0903
         evaluation_steps: list[str] | None,
         threshold: float,
         rubrics: list[Rubric] | None = None,
+        verbose: bool = False,
     ) -> tuple[float | None, str]:
         """Evaluate a single turn using GEval.
 
@@ -305,6 +311,9 @@ class GEvalHandler:  # pylint: disable=R0903
                 else "No reason provided"
             )
 
+            if verbose and hasattr(metric, "verbose_logs"):
+                self.last_verbose_logs = metric.verbose_logs
+
             # CRITICAL: Warn if score is None (indicates evaluation failure)
             # None scores indicate evaluation failures that need investigation:
             # - Rate limiting (429 errors after all retries exhausted)
@@ -347,6 +356,7 @@ class GEvalHandler:  # pylint: disable=R0903
         evaluation_steps: list[str] | None,
         threshold: float,
         rubrics: list[Rubric] | None = None,
+        verbose: bool = False,
     ) -> tuple[float | None, str]:
         """Evaluate a conversation using GEval.
 
@@ -434,6 +444,9 @@ class GEvalHandler:  # pylint: disable=R0903
                 if hasattr(metric, "reason") and metric.reason
                 else "No reason provided"
             )
+
+            if verbose and hasattr(metric, "verbose_logs"):
+                self.last_verbose_logs = metric.verbose_logs
 
             # CRITICAL: Warn if score is None (indicates evaluation failure)
             # See turn-level evaluation for detailed explanation of why this matters

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -676,6 +676,10 @@ class MetricResult(BaseModel):
         default=None,
         description="Per-judge scores when using judge panel (for transparency)",
     )
+    verbose_logs: Optional[str] = Field(
+        default=None,
+        description="GEval verbose logs when verbose mode is enabled",
+    )
 
     @field_validator("result")
     @classmethod

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -649,6 +649,10 @@ class JudgeScore(BaseModel):
     judge_input_tokens: int = Field(default=0, ge=0, description="Input tokens used")
     judge_output_tokens: int = Field(default=0, ge=0, description="Output tokens used")
     embedding_tokens: int = Field(default=0, ge=0, description="Embedding tokens used")
+    verbose_logs: Optional[str] = Field(
+        default=None,
+        description="Verbose logs from DeepEval/GEval judge when enabled",
+    )
 
 
 class MetricResult(BaseModel):

--- a/src/lightspeed_evaluation/core/models/llm.py
+++ b/src/lightspeed_evaluation/core/models/llm.py
@@ -550,6 +550,10 @@ class GEvalConfig(BaseModel):
         le=1.0,
         description="Minimum score threshold for pass/fail",
     )
+    verbose: bool = Field(
+        default=False,
+        description="Include verbose logs (criteria, evaluation steps, rubric) in output",
+    )
 
     @model_validator(mode="after")
     def validate_rubrics_non_overlapping(self) -> "GEvalConfig":
@@ -599,6 +603,7 @@ class GEvalConfig(BaseModel):
             "evaluation_params": raw.get("evaluation_params") or [],
             "evaluation_steps": raw.get("evaluation_steps"),
             "threshold": raw.get("threshold", 0.5),
+            "verbose": raw.get("verbose", False),
         }
         raw_rubrics = raw.get("rubrics")
         if raw_rubrics and isinstance(raw_rubrics, list):

--- a/src/lightspeed_evaluation/core/output/serializers.py
+++ b/src/lightspeed_evaluation/core/output/serializers.py
@@ -44,9 +44,8 @@ def result_to_json_dict(r: EvaluationResult) -> dict[str, Any]:
         "streaming_duration": r.streaming_duration,
         "agent_latency": r.agent_latency,
         "tokens_per_second": r.tokens_per_second,
+        "verbose_logs": r.verbose_logs,
     }
-    if r.verbose_logs is not None:
-        d["verbose_logs"] = r.verbose_logs
     return d
 
 

--- a/src/lightspeed_evaluation/core/output/serializers.py
+++ b/src/lightspeed_evaluation/core/output/serializers.py
@@ -25,7 +25,7 @@ def result_to_json_dict(r: EvaluationResult) -> dict[str, Any]:
     Returns:
         Dictionary matching the existing JSON summary result format.
     """
-    return {
+    d = {
         "conversation_group_id": r.conversation_group_id,
         "tag": sorted(r.tag),
         "turn_id": r.turn_id,
@@ -45,6 +45,9 @@ def result_to_json_dict(r: EvaluationResult) -> dict[str, Any]:
         "agent_latency": r.agent_latency,
         "tokens_per_second": r.tokens_per_second,
     }
+    if r.verbose_logs is not None:
+        d["verbose_logs"] = r.verbose_logs
+    return d
 
 
 def overall_to_basic_stats_dict(

--- a/src/lightspeed_evaluation/core/storage/sql_storage.py
+++ b/src/lightspeed_evaluation/core/storage/sql_storage.py
@@ -176,9 +176,30 @@ class SQLStorageBackend(BaseStorageBackend):
         Databases created before new columns were added would fail strict
         validation.  This method applies safe additive migrations (nullable
         columns only) so that older databases keep working.
+
+        Before mutating the schema, a preflight check ensures all required
+        non-nullable ORM columns already exist.  If any are missing, the
+        table is structurally incompatible and must not be altered.
         """
         reflected = {col["name"] for col in db_inspector.get_columns(table_name)}
         orm_columns = EvaluationResultDB.__table__.columns
+
+        missing_required = sorted(
+            col.name
+            for col in orm_columns
+            if col.name not in reflected and not col.nullable
+        )
+        if missing_required:
+            missing_list = ", ".join(missing_required)
+            raise StorageError(
+                "Database schema mismatch: the existing table "
+                f"{table_name!r} is missing required non-nullable column(s): "
+                f"{missing_list}. This database was likely created by an "
+                "incompatible version or is not an evaluation results database. "
+                "Use a different database path or remove this database.",
+                backend_name=self.backend_name,
+            )
+
         for col in orm_columns:
             if col.name not in reflected and col.nullable:
                 col_type = col.type.compile(dialect=self._engine.dialect)

--- a/src/lightspeed_evaluation/core/storage/sql_storage.py
+++ b/src/lightspeed_evaluation/core/storage/sql_storage.py
@@ -75,6 +75,7 @@ class EvaluationResultDB(Base):  # pylint: disable=too-few-public-methods
     expected_intent = Column(Text, nullable=True)
     expected_keywords = Column(Text, nullable=True)
     expected_tool_calls = Column(Text, nullable=True)
+    verbose_logs = Column(Text, nullable=True)
 
 
 class SQLStorageBackend(BaseStorageBackend):
@@ -343,6 +344,7 @@ class SQLStorageBackend(BaseStorageBackend):
             expected_intent=result.expected_intent,
             expected_keywords=result.expected_keywords,
             expected_tool_calls=result.expected_tool_calls,
+            verbose_logs=result.verbose_logs,
         )
 
     @staticmethod

--- a/src/lightspeed_evaluation/core/storage/sql_storage.py
+++ b/src/lightspeed_evaluation/core/storage/sql_storage.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Text,
     create_engine,
     inspect,
+    text,
 )
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
@@ -148,6 +149,8 @@ class SQLStorageBackend(BaseStorageBackend):
             table_name = EvaluationResultDB.__tablename__
             db_inspector = inspect(self._engine)
             if db_inspector.has_table(table_name):
+                self._migrate_missing_columns(db_inspector, table_name)
+                db_inspector = inspect(self._engine)
                 self._validate_evaluation_results_schema(db_inspector, table_name)
             Base.metadata.create_all(self._engine)
             self._session_factory = sessionmaker(bind=self._engine)
@@ -166,6 +169,28 @@ class SQLStorageBackend(BaseStorageBackend):
                 f"Failed to initialize database: {e}",
                 backend_name=self.backend_name,
             ) from e
+
+    def _migrate_missing_columns(self, db_inspector: Any, table_name: str) -> None:
+        """Add missing nullable columns to an existing table.
+
+        Databases created before new columns were added would fail strict
+        validation.  This method applies safe additive migrations (nullable
+        columns only) so that older databases keep working.
+        """
+        reflected = {col["name"] for col in db_inspector.get_columns(table_name)}
+        orm_columns = EvaluationResultDB.__table__.columns
+        for col in orm_columns:
+            if col.name not in reflected and col.nullable:
+                col_type = col.type.compile(dialect=self._engine.dialect)
+                with self._engine.connect() as conn:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table_name} "
+                            f"ADD COLUMN {col.name} {col_type}"
+                        )
+                    )
+                    conn.commit()
+                logger.info("Migrated: added column '%s' to %s", col.name, table_name)
 
     def _validate_evaluation_results_schema(
         self, db_inspector: Any, table_name: str

--- a/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
@@ -227,14 +227,6 @@ class MetricsEvaluator:
             # Evaluate metric
             metric_result = self._evaluate_wrapper(request, evaluation_scope, threshold)
 
-            # Capture verbose_logs from GEval handler if enabled
-            if framework in ("geval", "deepeval"):
-                handler = self.handlers.get(framework)
-                if handler is not None:
-                    verbose_logs = getattr(handler, "last_verbose_logs", None)
-                    if isinstance(verbose_logs, str):
-                        metric_result.verbose_logs = verbose_logs
-
             evaluation_latency = _measure_latency(start_time)
 
             turn_data = request.turn_data

--- a/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
@@ -227,6 +227,14 @@ class MetricsEvaluator:
             # Evaluate metric
             metric_result = self._evaluate_wrapper(request, evaluation_scope, threshold)
 
+            # Capture verbose_logs from GEval handler if enabled
+            if framework in ("geval", "deepeval"):
+                handler = self.handlers.get(framework)
+                if handler is not None:
+                    verbose_logs = getattr(handler, "last_verbose_logs", None)
+                    if isinstance(verbose_logs, str):
+                        metric_result.verbose_logs = verbose_logs
+
             evaluation_latency = _measure_latency(start_time)
 
             turn_data = request.turn_data

--- a/src/lightspeed_evaluation/pipeline/evaluation/judges.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/judges.py
@@ -122,6 +122,10 @@ class JudgeOrchestrator:
             judge_llm_output_tokens=token_totals["judge_output_tokens"],
             embedding_tokens=token_totals["embedding_tokens"],
             judge_scores=judge_scores,
+            verbose_logs="\n---\n".join(
+                js.verbose_logs for js in judge_scores if js.verbose_logs
+            )
+            or None,
         )
 
     def _evaluate_all_judges(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -206,42 +210,30 @@ class JudgeOrchestrator:
             score, reason = handler.evaluate(
                 metric_name, request.conv_data, evaluation_scope
             )
-            judge_input_tokens, judge_output_tokens = token_tracker.get_judge_counts()
-            embedding_tokens = token_tracker.get_embedding_counts()
-
-            logger.debug(
-                "Judge %s: score=%s, tokens=%d/%d, embeddings=%d",
-                judge_id,
-                score,
-                judge_input_tokens,
-                judge_output_tokens,
-                embedding_tokens,
-            )
-
-            return JudgeScore(
-                judge_id=judge_id,
-                score=score,
-                reason=reason,
-                judge_input_tokens=judge_input_tokens,
-                judge_output_tokens=judge_output_tokens,
-                embedding_tokens=embedding_tokens,
-            )
-
+            handler_logs = getattr(handler, "last_verbose_logs", None)
         except EvaluationError as e:
-            # Catch expected evaluation errors (LLM errors, metric errors, etc.)
-            # Let unexpected exceptions (ConfigurationError, bugs) propagate
             logger.error("Judge %s failed: %s", judge_id, e)
-            judge_input_tokens, judge_output_tokens = token_tracker.get_judge_counts()
-            embedding_tokens = token_tracker.get_embedding_counts()
+            score, reason, handler_logs = None, f"Evaluation error: {e}", None
 
-            return JudgeScore(
-                judge_id=judge_id,
-                score=None,
-                reason=f"Evaluation error: {e}",
-                judge_input_tokens=judge_input_tokens,
-                judge_output_tokens=judge_output_tokens,
-                embedding_tokens=embedding_tokens,
-            )
+        judge_tokens = token_tracker.get_judge_counts()
+        emb_tokens = token_tracker.get_embedding_counts()
+        logger.debug(
+            "Judge %s: score=%s, tokens=%d/%d, embeddings=%d",
+            judge_id,
+            score,
+            judge_tokens[0],
+            judge_tokens[1],
+            emb_tokens,
+        )
+        return JudgeScore(
+            judge_id=judge_id,
+            score=score,
+            reason=reason,
+            judge_input_tokens=judge_tokens[0],
+            judge_output_tokens=judge_tokens[1],
+            embedding_tokens=emb_tokens,
+            verbose_logs=handler_logs if isinstance(handler_logs, str) else None,
+        )
 
     def _get_handler_for_judge(self, framework: str, judge_manager: LLMManager) -> Any:
         """Get or create a metric handler for a specific judge.

--- a/tests/unit/core/metrics/test_geval.py
+++ b/tests/unit/core/metrics/test_geval.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-public-methods,protected-access
+# pylint: disable=too-many-public-methods,protected-access,too-many-lines
 
 """Tests for GEval metrics handler."""
 
@@ -875,3 +875,171 @@ class TestGEvalHandler:
             is_conversation=False,
         )
         assert score == 0.85
+
+    def test_verbose_logs_captured_when_enabled(
+        self,
+        handler: GEvalHandler,
+        mock_metric_manager: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that verbose_logs are captured when verbose is True."""
+        mock_geval_class = mocker.patch(
+            "lightspeed_evaluation.core.metrics.geval.GEval"
+        )
+        mock_metric = mocker.MagicMock()
+        mock_metric.score = 0.9
+        mock_metric.reason = "Good"
+        mock_metric.verbose_logs = "Criteria:\nTest\nEvaluation Steps:\n1. Step"
+        mock_geval_class.return_value = mock_metric
+
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "criteria": "Test criteria",
+            "threshold": 0.5,
+            "verbose": True,
+        }
+        turn_data = mocker.MagicMock()
+        turn_data.query = "Q"
+        turn_data.response = "R"
+        turn_data.expected_response = None
+        turn_data.contexts = None
+        conv_data = mocker.MagicMock()
+
+        score, reason = handler.evaluate(
+            metric_name="test_metric",
+            conv_data=conv_data,
+            _turn_idx=0,
+            turn_data=turn_data,
+            is_conversation=False,
+        )
+        assert score == 0.9
+        assert reason == "Good"
+        assert (
+            handler.last_verbose_logs == "Criteria:\nTest\nEvaluation Steps:\n1. Step"
+        )
+
+    def test_verbose_logs_not_captured_when_disabled(
+        self,
+        handler: GEvalHandler,
+        mock_metric_manager: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that verbose_logs are NOT captured when verbose is False (default)."""
+        mock_geval_class = mocker.patch(
+            "lightspeed_evaluation.core.metrics.geval.GEval"
+        )
+        mock_metric = mocker.MagicMock()
+        mock_metric.score = 0.9
+        mock_metric.reason = "Good"
+        mock_metric.verbose_logs = "Should not be captured"
+        mock_geval_class.return_value = mock_metric
+
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "criteria": "Test criteria",
+            "threshold": 0.5,
+        }
+        turn_data = mocker.MagicMock()
+        turn_data.query = "Q"
+        turn_data.response = "R"
+        turn_data.expected_response = None
+        turn_data.contexts = None
+        conv_data = mocker.MagicMock()
+
+        handler.evaluate(
+            metric_name="test_metric",
+            conv_data=conv_data,
+            _turn_idx=0,
+            turn_data=turn_data,
+            is_conversation=False,
+        )
+        assert handler.last_verbose_logs is None
+
+    def test_verbose_logs_captured_conversation_level(
+        self,
+        handler: GEvalHandler,
+        mock_metric_manager: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that verbose_logs are captured at conversation level."""
+        mock_geval_class = mocker.patch(
+            "lightspeed_evaluation.core.metrics.geval.GEval"
+        )
+        mock_metric = mocker.MagicMock()
+        mock_metric.score = 0.8
+        mock_metric.reason = "Coherent"
+        mock_metric.verbose_logs = "Conversation verbose logs"
+        mock_geval_class.return_value = mock_metric
+
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "criteria": "Evaluate coherence",
+            "evaluation_params": ["query", "response"],
+            "threshold": 0.6,
+            "verbose": True,
+        }
+
+        turn1 = mocker.MagicMock()
+        turn1.query = "Hello"
+        turn1.response = "Hi there"
+        conv_data = mocker.MagicMock()
+        conv_data.turns = [turn1]
+
+        score, _reason = handler.evaluate(
+            metric_name="test_metric",
+            conv_data=conv_data,
+            _turn_idx=None,
+            turn_data=None,
+            is_conversation=True,
+        )
+        assert score == 0.8
+        assert handler.last_verbose_logs == "Conversation verbose logs"
+
+    def test_verbose_logs_reset_between_evaluations(
+        self,
+        handler: GEvalHandler,
+        mock_metric_manager: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test that verbose_logs are reset at the start of each evaluate() call."""
+        mock_geval_class = mocker.patch(
+            "lightspeed_evaluation.core.metrics.geval.GEval"
+        )
+        mock_metric = mocker.MagicMock()
+        mock_metric.score = 0.9
+        mock_metric.reason = "OK"
+        mock_metric.verbose_logs = "Logs from first eval"
+        mock_geval_class.return_value = mock_metric
+
+        turn_data = mocker.MagicMock()
+        turn_data.query = "Q"
+        turn_data.response = "R"
+        turn_data.expected_response = None
+        turn_data.contexts = None
+        conv_data = mocker.MagicMock()
+
+        # First eval with verbose=True
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "criteria": "Test",
+            "threshold": 0.5,
+            "verbose": True,
+        }
+        handler.evaluate(
+            metric_name="m",
+            conv_data=conv_data,
+            _turn_idx=0,
+            turn_data=turn_data,
+            is_conversation=False,
+        )
+        assert handler.last_verbose_logs == "Logs from first eval"
+
+        # Second eval with verbose=False — logs should be reset
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "criteria": "Test",
+            "threshold": 0.5,
+        }
+        handler.evaluate(
+            metric_name="m",
+            conv_data=conv_data,
+            _turn_idx=0,
+            turn_data=turn_data,
+            is_conversation=False,
+        )
+        assert handler.last_verbose_logs is None

--- a/tests/unit/core/models/test_data.py
+++ b/tests/unit/core/models/test_data.py
@@ -750,6 +750,44 @@ class TestMetricResultJudgeScores:
         assert len(result.judge_scores) == 2
 
 
+class TestMetricResultVerboseLogs:
+    """Tests for MetricResult.verbose_logs field."""
+
+    def test_metric_result_with_verbose_logs(self) -> None:
+        """Test MetricResult with verbose_logs populated."""
+        result = MetricResult(
+            result="PASS",
+            score=0.9,
+            threshold=0.7,
+            reason="Good",
+            verbose_logs="Criteria:\nTest\nEvaluation Steps:\n1. Step",
+        )
+        assert result.verbose_logs == "Criteria:\nTest\nEvaluation Steps:\n1. Step"
+
+    def test_metric_result_verbose_logs_defaults_none(self) -> None:
+        """Test MetricResult verbose_logs defaults to None."""
+        result = MetricResult(
+            result="PASS",
+            score=0.9,
+            threshold=0.7,
+            reason="Good",
+        )
+        assert result.verbose_logs is None
+
+    def test_evaluation_result_inherits_verbose_logs(self) -> None:
+        """Test that EvaluationResult inherits verbose_logs from MetricResult."""
+        result = EvaluationResult(
+            conversation_group_id="conv1",
+            turn_id="turn1",
+            metric_identifier="geval:accuracy",
+            result="PASS",
+            score=0.9,
+            threshold=0.7,
+            verbose_logs="Verbose log content",
+        )
+        assert result.verbose_logs == "Verbose log content"
+
+
 class TestEvaluationDataAgentFields:
     """Tests for agent-related fields on EvaluationData."""
 

--- a/tests/unit/core/models/test_system.py
+++ b/tests/unit/core/models/test_system.py
@@ -786,6 +786,18 @@ class TestGEvalRubricValidation:
         assert config.rubrics[0].score_range == (0, 3)
         assert config.rubrics[1].score_range == (4, 7)
 
+    def test_geval_config_verbose_enabled(self) -> None:
+        """Verbose field accepted and parsed from metadata."""
+        config = GEvalConfig.from_metadata(
+            {"criteria": "Check correctness.", "verbose": True}
+        )
+        assert config.verbose is True
+
+    def test_geval_config_verbose_defaults_false(self) -> None:
+        """Verbose defaults to False when not specified."""
+        config = GEvalConfig.from_metadata({"criteria": "Check correctness."})
+        assert config.verbose is False
+
     def test_geval_config_rubrics_overlapping_fails(self) -> None:
         """Overlapping rubric ranges fail validation."""
         with pytest.raises(ConfigurationError, match="overlap"):

--- a/tests/unit/core/output/test_final_coverage.py
+++ b/tests/unit/core/output/test_final_coverage.py
@@ -2,10 +2,13 @@
 
 """Additional tests to boost coverage towards 75%."""
 
+import csv
+import io
 from pathlib import Path
 
 from pytest_mock import MockerFixture
 
+from lightspeed_evaluation.core.constants import SUPPORTED_CSV_COLUMNS
 from lightspeed_evaluation.core.models import (
     EvaluationData,
     EvaluationResult,
@@ -186,6 +189,40 @@ class TestSystemLoaderEdgeCases:
         assert any("unknown:metric1" in err for err in validator.validation_errors)
         assert any("unknown:metric2" in err for err in validator.validation_errors)
         assert any("unknown:conv_metric" in err for err in validator.validation_errors)
+
+
+class TestCsvExportVerboseLogs:
+    """Tests for verbose_logs in CSV export path."""
+
+    def test_csv_includes_verbose_logs_column(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Test verbose_logs column appears in CSV output."""
+        file_config = FileBackendConfig(csv_columns=list(SUPPORTED_CSV_COLUMNS))
+        config = mocker.Mock()
+        config.storage = [file_config]
+        config.visualization.enabled_graphs = []
+
+        handler = OutputHandler(output_dir=str(tmp_path), system_config=config)
+        results = [
+            EvaluationResult(
+                conversation_group_id="conv1",
+                metric_identifier="geval:accuracy",
+                result="PASS",
+                verbose_logs="Criteria:\nAccuracy\nSteps:\n1. Verify",
+            ),
+            EvaluationResult(
+                conversation_group_id="conv2",
+                metric_identifier="ragas:faithfulness",
+                result="PASS",
+            ),
+        ]
+
+        csv_file = handler._generate_csv_report(results, "test_verbose")
+        rows = list(csv.reader(io.StringIO(csv_file.read_text())))
+        verbose_idx = rows[0].index("verbose_logs")
+        assert rows[1][verbose_idx] == "Criteria:\nAccuracy\nSteps:\n1. Verify"
+        assert rows[2][verbose_idx] == ""
 
 
 class TestResultToJsonDictVerboseLogs:

--- a/tests/unit/core/output/test_final_coverage.py
+++ b/tests/unit/core/output/test_final_coverage.py
@@ -14,6 +14,7 @@ from lightspeed_evaluation.core.models import (
 )
 from lightspeed_evaluation.core.models.summary import EvaluationSummary
 from lightspeed_evaluation.core.output.generator import OutputHandler
+from lightspeed_evaluation.core.output.serializers import result_to_json_dict
 from lightspeed_evaluation.core.output.statistics import (
     compute_detailed_stats,
     compute_overall_stats,
@@ -185,3 +186,35 @@ class TestSystemLoaderEdgeCases:
         assert any("unknown:metric1" in err for err in validator.validation_errors)
         assert any("unknown:metric2" in err for err in validator.validation_errors)
         assert any("unknown:conv_metric" in err for err in validator.validation_errors)
+
+
+class TestResultToJsonDictVerboseLogs:
+    """Tests for verbose_logs in result_to_json_dict serializer."""
+
+    def test_verbose_logs_included_when_set(self) -> None:
+        """Test verbose_logs appears in JSON dict when populated."""
+        result = EvaluationResult(
+            conversation_group_id="conv1",
+            turn_id="t1",
+            metric_identifier="geval:accuracy",
+            result="PASS",
+            score=0.9,
+            threshold=0.7,
+            verbose_logs="Criteria:\nAccuracy\nSteps:\n1. Verify",
+        )
+        d = result_to_json_dict(result)
+        assert "verbose_logs" in d
+        assert d["verbose_logs"] == "Criteria:\nAccuracy\nSteps:\n1. Verify"
+
+    def test_verbose_logs_omitted_when_none(self) -> None:
+        """Test verbose_logs is NOT in JSON dict when None."""
+        result = EvaluationResult(
+            conversation_group_id="conv1",
+            turn_id="t1",
+            metric_identifier="ragas:faithfulness",
+            result="PASS",
+            score=0.85,
+            threshold=0.7,
+        )
+        d = result_to_json_dict(result)
+        assert "verbose_logs" not in d

--- a/tests/unit/core/output/test_final_coverage.py
+++ b/tests/unit/core/output/test_final_coverage.py
@@ -206,8 +206,8 @@ class TestResultToJsonDictVerboseLogs:
         assert "verbose_logs" in d
         assert d["verbose_logs"] == "Criteria:\nAccuracy\nSteps:\n1. Verify"
 
-    def test_verbose_logs_omitted_when_none(self) -> None:
-        """Test verbose_logs is NOT in JSON dict when None."""
+    def test_verbose_logs_null_when_none(self) -> None:
+        """Test verbose_logs is None in JSON dict when not set."""
         result = EvaluationResult(
             conversation_group_id="conv1",
             turn_id="t1",
@@ -217,4 +217,5 @@ class TestResultToJsonDictVerboseLogs:
             threshold=0.7,
         )
         d = result_to_json_dict(result)
-        assert "verbose_logs" not in d
+        assert "verbose_logs" in d
+        assert d["verbose_logs"] is None

--- a/tests/unit/core/storage/test_sql_storage.py
+++ b/tests/unit/core/storage/test_sql_storage.py
@@ -390,6 +390,86 @@ class TestSQLStorageBackendMultipleRuns:  # pylint: disable=too-few-public-metho
         assert run_info2.run_id in run_ids
 
 
+class TestSQLStorageBackendMigration:
+    """Tests for schema migration in initialize()."""
+
+    def test_migrate_adds_missing_nullable_column(self, temp_db_url: str) -> None:
+        """Test legacy DB without verbose_logs is migrated transparently."""
+        engine = create_engine(temp_db_url)
+        orm_cols = EvaluationResultDB.__table__.columns
+        col_defs = ", ".join(
+            f"{c.name} {c.type.compile(dialect=engine.dialect)}"
+            f"{'' if c.nullable else ' NOT NULL'}"
+            for c in orm_cols
+            if c.name != "verbose_logs"
+        )
+        with engine.begin() as conn:
+            conn.execute(text(f"CREATE TABLE evaluation_results ({col_defs})"))
+        engine.dispose()
+
+        backend = SQLStorageBackend(temp_db_url)
+        backend.initialize(RunInfo())
+
+        check_engine = create_engine(temp_db_url)
+        with check_engine.connect() as conn:
+            cols = {
+                row[1]
+                for row in conn.execute(
+                    text("PRAGMA table_info(evaluation_results)")
+                ).fetchall()
+            }
+        assert "verbose_logs" in cols
+        backend.close()
+        check_engine.dispose()
+
+    def test_migrate_rejects_incompatible_table(self, temp_db_url: str) -> None:
+        """Test that a table missing required non-nullable columns is rejected."""
+        engine = create_engine(temp_db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE evaluation_results ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "run_id VARCHAR(36) NOT NULL"
+                    ")"
+                )
+            )
+        engine.dispose()
+
+        backend = SQLStorageBackend(temp_db_url)
+        with pytest.raises(StorageError, match="non-nullable"):
+            backend.initialize(RunInfo())
+
+    def test_migrate_does_not_alter_incompatible_table(self, temp_db_url: str) -> None:
+        """Test that incompatible tables are not mutated before rejection."""
+        engine = create_engine(temp_db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE evaluation_results ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "run_id VARCHAR(36) NOT NULL"
+                    ")"
+                )
+            )
+        engine.dispose()
+
+        backend = SQLStorageBackend(temp_db_url)
+        with pytest.raises(StorageError, match="non-nullable"):
+            backend.initialize(RunInfo())
+
+        check_engine = create_engine(temp_db_url)
+        with check_engine.connect() as conn:
+            cols = {
+                row[1]
+                for row in conn.execute(
+                    text("PRAGMA table_info(evaluation_results)")
+                ).fetchall()
+            }
+        assert "verbose_logs" not in cols
+        check_engine.dispose()
+
+
 class TestEvaluationResultDB:
     """Tests for EvaluationResultDB SQLAlchemy model."""
 

--- a/tests/unit/core/storage/test_sql_storage.py
+++ b/tests/unit/core/storage/test_sql_storage.py
@@ -433,5 +433,6 @@ class TestEvaluationResultDB:
             "expected_intent",
             "expected_keywords",
             "expected_tool_calls",
+            "verbose_logs",
         }
         assert required_columns == columns

--- a/tests/unit/pipeline/evaluation/test_evaluator.py
+++ b/tests/unit/pipeline/evaluation/test_evaluator.py
@@ -603,3 +603,41 @@ class TestMetricsEvaluator:
         assert result.evaluation_latency > 0.0
         assert result.execution_time == result.evaluation_latency + result.agent_latency
         assert result.execution_time >= 4.0
+
+    def test_verbose_logs_propagated_from_geval_handler(
+        self, evaluator: MetricsEvaluator
+    ) -> None:
+        """Test verbose_logs from GEval handler are propagated to EvaluationResult."""
+        mock_geval = evaluator.handlers["geval"]
+        mock_geval.evaluate.return_value = (0.9, "Accurate")
+        mock_geval.last_verbose_logs = "Criteria:\nAccuracy\nSteps:\n1. Check"
+
+        turn_data = TurnData(turn_id="1", query="Q", response="R")
+        conv_data = EvaluationData(conversation_group_id="conv1", turns=[turn_data])
+        request = EvaluationRequest.for_turn(conv_data, "geval:accuracy", 0, turn_data)
+
+        result = evaluator.evaluate_metric(request)
+
+        assert result is not None
+        assert result.verbose_logs == "Criteria:\nAccuracy\nSteps:\n1. Check"
+
+    def test_verbose_logs_none_when_not_set(self, evaluator: MetricsEvaluator) -> None:
+        """Test verbose_logs is None when handler doesn't set it."""
+        mock_ragas = evaluator.handlers["ragas"]
+        mock_ragas.evaluate.return_value = (0.85, "Good faithfulness")
+
+        turn_data = TurnData(
+            turn_id="1",
+            query="Q",
+            response="R",
+            contexts=["Context"],
+        )
+        conv_data = EvaluationData(conversation_group_id="conv1", turns=[turn_data])
+        request = EvaluationRequest.for_turn(
+            conv_data, "ragas:faithfulness", 0, turn_data
+        )
+
+        result = evaluator.evaluate_metric(request)
+
+        assert result is not None
+        assert result.verbose_logs is None

--- a/tests/unit/pipeline/evaluation/test_judges.py
+++ b/tests/unit/pipeline/evaluation/test_judges.py
@@ -214,6 +214,192 @@ class TestAggregationStrategies:
         assert score == pytest.approx(0.65)
 
 
+class TestVerboseLogsPropagation:
+    """Tests for verbose_logs capture and aggregation across judges."""
+
+    def test_single_judge_verbose_logs_propagated(self, mocker: MockerFixture) -> None:
+        """Verbose logs from a single judge appear in MetricResult."""
+        mock_manager = mocker.MagicMock()
+        mock_manager.system_config = None
+        mock_manager.judge_id = "primary"
+
+        handler = mocker.MagicMock()
+        handler.evaluate.return_value = (0.9, "Good")
+        handler.last_verbose_logs = "Criteria:\nAccuracy\nSteps:\n1. Check"
+
+        token_tracker = mocker.MagicMock()
+        token_tracker.get_judge_counts.return_value = (10, 20)
+        token_tracker.get_embedding_counts.return_value = 0
+
+        orch = JudgeOrchestrator(
+            llm_manager=mock_manager,
+            primary_handlers={"deepeval": handler},
+            handler_factory=mocker.MagicMock(),
+            status_determiner=lambda s, _: "PASS" if s >= 0.5 else "FAIL",
+        )
+        mock_manager_list = [mock_manager]
+        mock_manager.get_judges_for_metric.return_value = mock_manager_list
+
+        request = mocker.MagicMock()
+        request.metric_identifier = "deepeval:g_eval"
+        scope = mocker.MagicMock()
+
+        result = orch.evaluate_with_judges(request, scope, token_tracker, 0.7)
+
+        assert result.verbose_logs == "Criteria:\nAccuracy\nSteps:\n1. Check"
+
+    def test_multi_judge_verbose_logs_aggregated(self, mocker: MockerFixture) -> None:
+        """Verbose logs from multiple judges are joined with separator."""
+        mock_manager = mocker.MagicMock()
+        mock_manager.system_config.judge_panel.aggregation_strategy = "max"
+        mock_manager.judge_id = "primary"
+
+        handler_a = mocker.MagicMock()
+        handler_a.evaluate.return_value = (0.9, "Good")
+        handler_a.last_verbose_logs = "Judge A logs"
+
+        handler_b = mocker.MagicMock()
+        handler_b.evaluate.return_value = (0.8, "OK")
+        handler_b.last_verbose_logs = "Judge B logs"
+
+        judge_a = mocker.MagicMock()
+        judge_a.judge_id = "judge-a"
+        judge_b = mocker.MagicMock()
+        judge_b.judge_id = "judge-b"
+
+        token_tracker = mocker.MagicMock()
+        token_tracker.get_judge_counts.return_value = (10, 20)
+        token_tracker.get_embedding_counts.return_value = 0
+
+        factory = mocker.MagicMock(side_effect=[handler_a, handler_b])
+        orch = JudgeOrchestrator(
+            llm_manager=mock_manager,
+            primary_handlers={},
+            handler_factory=factory,
+            status_determiner=lambda s, _: "PASS" if s >= 0.5 else "FAIL",
+        )
+        mock_manager.get_judges_for_metric.return_value = [judge_a, judge_b]
+
+        request = mocker.MagicMock()
+        request.metric_identifier = "deepeval:g_eval"
+        scope = mocker.MagicMock()
+
+        result = orch.evaluate_with_judges(request, scope, token_tracker, 0.7)
+
+        assert result.verbose_logs == "Judge A logs\n---\nJudge B logs"
+
+    def test_multi_judge_only_one_has_verbose_logs(self, mocker: MockerFixture) -> None:
+        """When only one judge produces verbose_logs, no separator is added."""
+        mock_manager = mocker.MagicMock()
+        mock_manager.system_config.judge_panel.aggregation_strategy = "max"
+        mock_manager.judge_id = "primary"
+
+        handler_a = mocker.MagicMock()
+        handler_a.evaluate.return_value = (0.9, "Good")
+        handler_a.last_verbose_logs = "Only judge A logs"
+
+        handler_b = mocker.MagicMock()
+        handler_b.evaluate.return_value = (0.8, "OK")
+        handler_b.last_verbose_logs = None
+
+        judge_a = mocker.MagicMock()
+        judge_a.judge_id = "judge-a"
+        judge_b = mocker.MagicMock()
+        judge_b.judge_id = "judge-b"
+
+        token_tracker = mocker.MagicMock()
+        token_tracker.get_judge_counts.return_value = (10, 20)
+        token_tracker.get_embedding_counts.return_value = 0
+
+        factory = mocker.MagicMock(side_effect=[handler_a, handler_b])
+        orch = JudgeOrchestrator(
+            llm_manager=mock_manager,
+            primary_handlers={},
+            handler_factory=factory,
+            status_determiner=lambda s, _: "PASS" if s >= 0.5 else "FAIL",
+        )
+        mock_manager.get_judges_for_metric.return_value = [judge_a, judge_b]
+
+        request = mocker.MagicMock()
+        request.metric_identifier = "deepeval:g_eval"
+        scope = mocker.MagicMock()
+
+        result = orch.evaluate_with_judges(request, scope, token_tracker, 0.7)
+
+        assert result.verbose_logs == "Only judge A logs"
+
+    def test_no_judges_have_verbose_logs(self, mocker: MockerFixture) -> None:
+        """When no judge produces verbose_logs, result is None."""
+        mock_manager = mocker.MagicMock()
+        mock_manager.system_config.judge_panel.aggregation_strategy = "max"
+        mock_manager.judge_id = "primary"
+
+        handler_a = mocker.MagicMock()
+        handler_a.evaluate.return_value = (0.9, "Good")
+        handler_a.last_verbose_logs = None
+
+        handler_b = mocker.MagicMock()
+        handler_b.evaluate.return_value = (0.8, "OK")
+        handler_b.last_verbose_logs = None
+
+        judge_a = mocker.MagicMock()
+        judge_a.judge_id = "judge-a"
+        judge_b = mocker.MagicMock()
+        judge_b.judge_id = "judge-b"
+
+        token_tracker = mocker.MagicMock()
+        token_tracker.get_judge_counts.return_value = (10, 20)
+        token_tracker.get_embedding_counts.return_value = 0
+
+        factory = mocker.MagicMock(side_effect=[handler_a, handler_b])
+        orch = JudgeOrchestrator(
+            llm_manager=mock_manager,
+            primary_handlers={},
+            handler_factory=factory,
+            status_determiner=lambda s, _: "PASS" if s >= 0.5 else "FAIL",
+        )
+        mock_manager.get_judges_for_metric.return_value = [judge_a, judge_b]
+
+        request = mocker.MagicMock()
+        request.metric_identifier = "deepeval:g_eval"
+        scope = mocker.MagicMock()
+
+        result = orch.evaluate_with_judges(request, scope, token_tracker, 0.7)
+
+        assert result.verbose_logs is None
+
+    def test_handler_without_last_verbose_logs_attribute(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Handlers without last_verbose_logs produce None via isinstance guard."""
+        mock_manager = mocker.MagicMock()
+        mock_manager.system_config = None
+        mock_manager.judge_id = "primary"
+
+        handler = mocker.MagicMock(spec=["evaluate"])
+        handler.evaluate.return_value = (0.9, "Good")
+
+        token_tracker = mocker.MagicMock()
+        token_tracker.get_judge_counts.return_value = (10, 20)
+        token_tracker.get_embedding_counts.return_value = 0
+
+        orch = JudgeOrchestrator(
+            llm_manager=mock_manager,
+            primary_handlers={"ragas": handler},
+            handler_factory=mocker.MagicMock(),
+            status_determiner=lambda s, _: "PASS",
+        )
+        mock_manager.get_judges_for_metric.return_value = [mock_manager]
+
+        request = mocker.MagicMock()
+        request.metric_identifier = "ragas:faithfulness"
+        scope = mocker.MagicMock()
+
+        result = orch.evaluate_with_judges(request, scope, token_tracker, 0.7)
+
+        assert result.verbose_logs is None
+
+
 class TestHandlerCaching:
     """Tests for handler caching by judge_id."""
 


### PR DESCRIPTION
Currently, lightspeed-evaluation does not report when creating rubrics using a Judge (LLM).
For correctness or consistency, for example, it asks the judge to define the steps to get this rubric, and lightspeed-evaluation is
not reporting anywhere how it has been done.
This PR create a new  opt-in verbose_logs arg to surface GEval judge criteria, steps, and rubrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional verbose mode for GEval metrics to capture detailed evaluation logs.
  * Exposed verbose logs in evaluation results and JSON/CSV exports.
  * Persisted verbose logs in SQL-stored results with automatic schema migration.
  * Supports both turn-level and conversation-level evaluations.
  * Combined logs from multiple judges when available.

* **Bug Fixes**
  * Verbose logs now reset between evaluations and remain empty when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->