### PR TITLE
feat: add custom:mrr metric for RAG retrieval quality evaluation

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -168,7 +168,7 @@ metrics_metadata:
       description: "LLM judge of agentic remediation workflow quality (diagnosis, actions, risk, verification)"
       default: false
 
-    "custom:mrr":
+    "nlp:mrr":
       threshold: 0.5
       description: "Mean Reciprocal Rank — position of first relevant context in retrieved list"
 

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -170,7 +170,8 @@ metrics_metadata:
 
     "nlp:mrr":
       threshold: 0.5
-      description: "Mean Reciprocal Rank — position of first relevant context in retrieved list"
+      description: "Mean Reciprocal Rank — position of first relevant context in retrieved list (semantic similarity matching)"
+      default_similarity_threshold: 0.65
 
     # Script-based metrics
     "script:action_eval":

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -168,6 +168,10 @@ metrics_metadata:
       description: "LLM judge of agentic remediation workflow quality (diagnosis, actions, risk, verification)"
       default: false
 
+    "custom:mrr":
+      threshold: 0.5
+      description: "Mean Reciprocal Rank — position of first relevant context in retrieved list"
+
     # Script-based metrics
     "script:action_eval":
       description: "Script-based evaluation for infrastructure/environment validation"

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -172,6 +172,10 @@ metrics_metadata:
       threshold: 0.5
       description: "Mean Reciprocal Rank — position of first relevant context in retrieved list (semantic similarity matching)"
       default_similarity_threshold: 0.65
+      # Opt-in: conformal risk control calibration (Angelopoulos et al., ICLR 2024)
+      # alpha: 0.1                     # target false-negative rate bound
+      # calibration_pairs:             # known-matching text pairs for threshold calibration
+      #   - ["text A", "paraphrase of A"]
 
     # Script-based metrics
     "script:action_eval":

--- a/src/lightspeed_evaluation/core/metrics/custom/__init__.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/__init__.py
@@ -1,5 +1,9 @@
 """Custom metrics components package."""
 
+from lightspeed_evaluation.core.metrics.custom.conformal import (
+    compute_mrr_threshold,
+    get_lhat,
+)
 from lightspeed_evaluation.core.metrics.custom.custom import CustomMetrics
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
 from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
@@ -14,10 +18,12 @@ from lightspeed_evaluation.core.metrics.custom.tool_eval import evaluate_tool_ca
 
 __all__ = [
     "CustomMetrics",
+    "compute_mrr_threshold",
     "evaluate_keywords",
     "evaluate_mrr",
     "evaluate_proposal_status",
     "evaluate_tool_calls",
+    "get_lhat",
     # Prompts
     "ANSWER_CORRECTNESS_PROMPT",
     "INTENT_EVALUATION_PROMPT",

--- a/src/lightspeed_evaluation/core/metrics/custom/__init__.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/__init__.py
@@ -2,6 +2,7 @@
 
 from lightspeed_evaluation.core.metrics.custom.custom import CustomMetrics
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
+from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
 from lightspeed_evaluation.core.metrics.custom.prompts import (
     ANSWER_CORRECTNESS_PROMPT,
     INTENT_EVALUATION_PROMPT,
@@ -14,6 +15,7 @@ from lightspeed_evaluation.core.metrics.custom.tool_eval import evaluate_tool_ca
 __all__ = [
     "CustomMetrics",
     "evaluate_keywords",
+    "evaluate_mrr",
     "evaluate_proposal_status",
     "evaluate_tool_calls",
     # Prompts

--- a/src/lightspeed_evaluation/core/metrics/custom/conformal.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/conformal.py
@@ -1,0 +1,77 @@
+"""Conformal Risk Control for semantic similarity threshold calibration.
+
+Vendored from https://github.com/aangelopoulos/conformal-risk
+MIT License — Angelopoulos, Bates, Fisch, Lei, Schuster (ICLR 2024)
+
+Reference: "Conformal Risk Control", ICLR 2024
+    https://arxiv.org/abs/2208.02814
+"""
+
+from typing import Optional
+
+import numpy as np
+
+
+def get_lhat(
+    calib_loss_table: np.ndarray,
+    lambdas: np.ndarray,
+    alpha: float,
+    upper_bound: float = 1,
+) -> float:
+    """Select the threshold that controls marginal risk for a monotone loss.
+
+    Core algorithm from the conformal-risk package.  The calibration loss
+    table rows correspond to calibration examples and columns to candidate
+    thresholds (lambdas).  Lambdas must be ordered so that the loss is
+    non-decreasing across columns (i.e. from permissive to strict).
+
+    Args:
+        calib_loss_table: Loss matrix of shape ``(n_calibration, n_lambdas)``.
+        lambdas: Candidate thresholds, ordered permissive-to-strict.
+        alpha: Target risk level.
+        upper_bound: Upper bound on the per-example loss (B in the paper).
+
+    Returns:
+        The selected threshold ``lambda_hat`` satisfying
+        ``E[L_{n+1}(lambda_hat)] <= alpha``.
+    """
+    n = calib_loss_table.shape[0]
+    rhat = calib_loss_table.mean(axis=0)
+    raw_idx = int(np.argmax(((n / (n + 1)) * rhat + upper_bound / (n + 1)) >= alpha))
+    lhat_idx = max(raw_idx - 1, 0)
+    return float(lambdas[lhat_idx])
+
+
+def compute_mrr_threshold(
+    calibration_similarities: list[float],
+    alpha: float = 0.1,
+    n_lambdas: int = 100,
+) -> Optional[float]:
+    """Compute a similarity threshold for MRR context matching.
+
+    Adapts :func:`get_lhat` to the semantic-matching case where the loss
+    is the false-negative indicator: ``L_i(tau) = 1{sim_i < tau}``.
+
+    Lambdas (candidate thresholds) run from 0.0 (most permissive) to 1.0
+    (strictest), so the loss is non-decreasing across the lambda grid.
+    ``get_lhat`` finds the largest threshold whose adjusted risk stays
+    below *alpha*.
+
+    Args:
+        calibration_similarities: Cosine similarities of known-positive
+            (matching) text pairs used for calibration.
+        alpha: Target false-negative rate bound.  Default 0.1 means that
+            at most 10 % of true matches will be missed.
+        n_lambdas: Resolution of the threshold grid.
+
+    Returns:
+        The calibrated similarity threshold, or ``None`` when calibration
+        data is empty.
+    """
+    if not calibration_similarities:
+        return None
+
+    sims = np.asarray(calibration_similarities, dtype=float)
+    lambdas = np.linspace(0.0, 1.0, n_lambdas)
+    calib_loss_table = (sims[:, None] < lambdas[None, :]).astype(float)
+    return get_lhat(calib_loss_table, lambdas, alpha)

--- a/src/lightspeed_evaluation/core/metrics/custom/custom.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/custom.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Optional
 from lightspeed_evaluation.core.llm.custom import BaseCustomLLM
 from lightspeed_evaluation.core.llm.manager import LLMManager
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
-from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
 from lightspeed_evaluation.core.metrics.custom.prompts import (
     ANSWER_CORRECTNESS_PROMPT,
     INTENT_EVALUATION_PROMPT,
@@ -49,7 +48,6 @@ class CustomMetrics:  # pylint: disable=too-few-public-methods
 
         self.supported_metrics = {
             "keywords_eval": evaluate_keywords,
-            "mrr": evaluate_mrr,
             "answer_correctness": self._evaluate_answer_correctness,
             "intent_eval": self._evaluate_intent,
             "tool_eval": self._evaluate_tool_calls,

--- a/src/lightspeed_evaluation/core/metrics/custom/custom.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/custom.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from lightspeed_evaluation.core.llm.custom import BaseCustomLLM
 from lightspeed_evaluation.core.llm.manager import LLMManager
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
+from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
 from lightspeed_evaluation.core.metrics.custom.prompts import (
     ANSWER_CORRECTNESS_PROMPT,
     INTENT_EVALUATION_PROMPT,
@@ -48,6 +49,7 @@ class CustomMetrics:  # pylint: disable=too-few-public-methods
 
         self.supported_metrics = {
             "keywords_eval": evaluate_keywords,
+            "mrr": evaluate_mrr,
             "answer_correctness": self._evaluate_answer_correctness,
             "intent_eval": self._evaluate_intent,
             "tool_eval": self._evaluate_tool_calls,

--- a/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
@@ -20,6 +20,8 @@ def _is_context_match(retrieved: str, expected: str) -> bool:
     """
     norm_retrieved = _normalize_text(retrieved)
     norm_expected = _normalize_text(expected)
+    if not norm_retrieved or not norm_expected:
+        return False
     return norm_expected in norm_retrieved or norm_retrieved in norm_expected
 
 

--- a/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
@@ -1,23 +1,30 @@
 """Mean Reciprocal Rank (MRR) evaluation for RAG retrieval quality.
 
 Uses semantic similarity (sentence-transformers embeddings + cosine similarity)
-for context matching with a configurable similarity threshold.
+for context matching, with optional Conformal Risk Control threshold calibration
+(Angelopoulos et al., ICLR 2024).
 
 Falls back to normalized substring containment when sentence-transformers is not
 installed.
 """
 
+import hashlib
+import json
 import logging
 import re
 from typing import Any, Optional
 
 import numpy as np
 
+from lightspeed_evaluation.core.metrics.custom.conformal import compute_mrr_threshold
 from lightspeed_evaluation.core.models import TurnData
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SIMILARITY_THRESHOLD = 0.65
+DEFAULT_ALPHA = 0.1
+
+_cached_threshold: dict[str, tuple[float, bool]] = {}
 
 
 def _normalize_text(text: str) -> str:
@@ -59,20 +66,58 @@ def _compute_similarity_matrix(
 
 def _resolve_threshold(
     mrr_config: Optional[dict[str, Any]],
-) -> float:
-    """Determine the similarity threshold from config.
+    model: Any,
+    model_name: str = "",
+) -> tuple[float, bool]:
+    """Determine the similarity threshold, optionally via conformal calibration.
 
     Args:
-        mrr_config: Metric metadata dict (may contain
-            ``default_similarity_threshold``).
+        mrr_config: Metric metadata dict (may contain ``calibration_pairs``,
+            ``alpha``, ``default_similarity_threshold``).
+        model: A SentenceTransformer model for encoding calibration pairs.
+        model_name: Embedding model identifier (included in cache key).
 
     Returns:
-        The similarity threshold.
+        ``(threshold, is_calibrated)`` where *is_calibrated* is ``True`` when
+        the threshold was computed via Conformal Risk Control.
     """
     config = mrr_config or {}
-    return float(
+    default_threshold = float(
         config.get("default_similarity_threshold", DEFAULT_SIMILARITY_THRESHOLD)
     )
+    calibration_pairs = config.get("calibration_pairs")
+
+    if not calibration_pairs or model is None:
+        return default_threshold, False
+
+    if not all(isinstance(p, (list, tuple)) and len(p) >= 2 for p in calibration_pairs):
+        logger.warning("calibration_pairs must be a list of [text_a, text_b] pairs")
+        return default_threshold, False
+
+    alpha = float(config.get("alpha", DEFAULT_ALPHA))
+    pairs_digest = hashlib.sha256(
+        json.dumps(calibration_pairs, sort_keys=True).encode()
+    ).hexdigest()[:16]
+    cache_key = f"{model_name}:{alpha}:{pairs_digest}"
+    if cache_key in _cached_threshold:
+        return _cached_threshold[cache_key]
+
+    emb_a = model.encode([p[0] for p in calibration_pairs], normalize_embeddings=True)
+    emb_b = model.encode([p[1] for p in calibration_pairs], normalize_embeddings=True)
+    sims = [float(np.dot(emb_a[i], emb_b[i])) for i in range(len(calibration_pairs))]
+
+    threshold = compute_mrr_threshold(sims, alpha=alpha)
+    if threshold is None:
+        return default_threshold, False
+
+    logger.info(
+        "CRC calibrated similarity threshold: %.4f (alpha=%.2f, n=%d)",
+        threshold,
+        alpha,
+        len(calibration_pairs),
+    )
+    _cached_threshold[cache_key] = (threshold, True)
+    return threshold, True
 
 
 def _validate_inputs(
@@ -101,14 +146,15 @@ def evaluate_mrr(
     is_conversation: bool,
     *,
     embedding_model: Any = None,
-    _embedding_model_name: str = "",
+    embedding_model_name: str = "",
     mrr_config: Optional[dict[str, Any]] = None,
 ) -> tuple[Optional[float], str]:
     """Evaluate Mean Reciprocal Rank of retrieved contexts.
 
     When *embedding_model* is provided (a ``SentenceTransformer`` instance),
-    matching uses cosine similarity with a configurable threshold.
-    Otherwise falls back to substring containment.
+    matching uses cosine similarity with a threshold calibrated via Conformal
+    Risk Control (if ``calibration_pairs`` are given in *mrr_config*) or a
+    sensible default.  Otherwise falls back to substring containment.
 
     Args:
         _conv_data: Conversation data (unused).
@@ -117,9 +163,8 @@ def evaluate_mrr(
         is_conversation: Whether this is conversation-level evaluation.
         embedding_model: Optional SentenceTransformer model for semantic
             matching.
-        embedding_model_name: Model identifier (unused in base, used by CRC).
         mrr_config: Optional metric metadata with keys such as
-            ``default_similarity_threshold``.
+            ``calibration_pairs``, ``alpha``, ``default_similarity_threshold``.
 
     Returns:
         Tuple of (score, reason).
@@ -141,6 +186,7 @@ def evaluate_mrr(
             turn_data.expected_contexts,
             embedding_model,
             mrr_config,
+            model_name=embedding_model_name,
         )
 
     return _evaluate_mrr_substring(turn_data.contexts, turn_data.expected_contexts)
@@ -173,25 +219,28 @@ def _evaluate_mrr_semantic(
     expected_contexts: list[str],
     model: Any,
     mrr_config: Optional[dict[str, Any]],
+    model_name: str = "",
 ) -> tuple[Optional[float], str]:
-    """MRR via semantic similarity with configurable threshold."""
-    threshold = _resolve_threshold(mrr_config)
+    """MRR via semantic similarity with conformal threshold."""
+    threshold, is_calibrated = _resolve_threshold(mrr_config, model, model_name)
     sim_matrix = _compute_similarity_matrix(contexts, expected_contexts, model)
 
     for rank in range(len(contexts)):
         row_max = float(np.max(sim_matrix[rank]))
         if row_max >= threshold:
             score = 1.0 / (rank + 1)
+            method = "CRC-calibrated" if is_calibrated else "default"
             return (
                 score,
                 f"MRR: {score:.4f} — first relevant context at rank {rank + 1} "
-                f"(similarity={row_max:.4f}, threshold={threshold:.4f})",
+                f"(similarity={row_max:.4f}, threshold={threshold:.4f}, {method})",
             )
 
     best_sim = float(np.max(sim_matrix))
+    method = "CRC-calibrated" if is_calibrated else "default"
     return (
         0.0,
         f"MRR: 0.0 — no context above threshold in "
         f"{len(contexts)} retrieved (best_similarity={best_sim:.4f}, "
-        f"threshold={threshold:.4f})",
+        f"threshold={threshold:.4f}, {method})",
     )

--- a/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
@@ -1,9 +1,23 @@
-"""Mean Reciprocal Rank (MRR) evaluation for RAG retrieval quality."""
+"""Mean Reciprocal Rank (MRR) evaluation for RAG retrieval quality.
 
+Uses semantic similarity (sentence-transformers embeddings + cosine similarity)
+for context matching with a configurable similarity threshold.
+
+Falls back to normalized substring containment when sentence-transformers is not
+installed.
+"""
+
+import logging
 import re
 from typing import Any, Optional
 
+import numpy as np
+
 from lightspeed_evaluation.core.models import TurnData
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SIMILARITY_THRESHOLD = 0.65
 
 
 def _normalize_text(text: str) -> str:
@@ -11,18 +25,54 @@ def _normalize_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.lower().strip())
 
 
-def _is_context_match(retrieved: str, expected: str) -> bool:
-    """Check if a retrieved context matches an expected context.
+def _is_context_match_substring(retrieved: str, expected: str) -> bool:
+    """Fallback substring containment match.
 
-    Uses normalized containment: a match occurs when either text
-    contains the other after normalization.  This handles retriever
-    chunks that are supersets or subsets of the ground-truth context.
+    Used when sentence-transformers is not available.
     """
     norm_retrieved = _normalize_text(retrieved)
     norm_expected = _normalize_text(expected)
     if not norm_retrieved or not norm_expected:
         return False
     return norm_expected in norm_retrieved or norm_retrieved in norm_expected
+
+
+def _compute_similarity_matrix(
+    retrieved_texts: list[str],
+    expected_texts: list[str],
+    model: Any,
+) -> np.ndarray:
+    """Compute cosine similarity matrix between retrieved and expected contexts.
+
+    Args:
+        retrieved_texts: Retrieved context strings.
+        expected_texts: Expected (ground-truth) context strings.
+        model: A SentenceTransformer model instance.
+
+    Returns:
+        Similarity matrix of shape ``(len(retrieved), len(expected))``.
+    """
+    ret_emb = model.encode(retrieved_texts, normalize_embeddings=True)
+    exp_emb = model.encode(expected_texts, normalize_embeddings=True)
+    return np.asarray(ret_emb) @ np.asarray(exp_emb).T
+
+
+def _resolve_threshold(
+    mrr_config: Optional[dict[str, Any]],
+) -> float:
+    """Determine the similarity threshold from config.
+
+    Args:
+        mrr_config: Metric metadata dict (may contain
+            ``default_similarity_threshold``).
+
+    Returns:
+        The similarity threshold.
+    """
+    config = mrr_config or {}
+    return float(
+        config.get("default_similarity_threshold", DEFAULT_SIMILARITY_THRESHOLD)
+    )
 
 
 def _validate_inputs(
@@ -49,19 +99,27 @@ def evaluate_mrr(
     _turn_idx: Optional[int],
     turn_data: Optional[TurnData],
     is_conversation: bool,
+    *,
+    embedding_model: Any = None,
+    _embedding_model_name: str = "",
+    mrr_config: Optional[dict[str, Any]] = None,
 ) -> tuple[Optional[float], str]:
     """Evaluate Mean Reciprocal Rank of retrieved contexts.
 
-    MRR measures how high the first relevant context appears in the
-    ranked list of retrieved contexts.  The score is 1/rank for the
-    first match, or 0.0 when no retrieved context matches any expected
-    context.
+    When *embedding_model* is provided (a ``SentenceTransformer`` instance),
+    matching uses cosine similarity with a configurable threshold.
+    Otherwise falls back to substring containment.
 
     Args:
         _conv_data: Conversation data (unused).
         _turn_idx: Turn index (unused).
         turn_data: Turn data with ``contexts`` and ``expected_contexts``.
         is_conversation: Whether this is conversation-level evaluation.
+        embedding_model: Optional SentenceTransformer model for semantic
+            matching.
+        embedding_model_name: Model identifier (unused in base, used by CRC).
+        mrr_config: Optional metric metadata with keys such as
+            ``default_similarity_threshold``.
 
     Returns:
         Tuple of (score, reason).
@@ -77,17 +135,63 @@ def evaluate_mrr(
     ):
         return None, "Invalid turn data after validation"
 
-    for rank, retrieved in enumerate(turn_data.contexts, start=1):
-        for expected in turn_data.expected_contexts:
-            if _is_context_match(retrieved, expected):
+    if embedding_model is not None:
+        return _evaluate_mrr_semantic(
+            turn_data.contexts,
+            turn_data.expected_contexts,
+            embedding_model,
+            mrr_config,
+        )
+
+    return _evaluate_mrr_substring(turn_data.contexts, turn_data.expected_contexts)
+
+
+def _evaluate_mrr_substring(
+    contexts: list[str],
+    expected_contexts: list[str],
+) -> tuple[Optional[float], str]:
+    """MRR via substring containment (fallback)."""
+    for rank, retrieved in enumerate(contexts, start=1):
+        for expected in expected_contexts:
+            if _is_context_match_substring(retrieved, expected):
                 score = 1.0 / rank
                 return (
                     score,
-                    f"MRR: {score:.4f} — first relevant context at rank {rank}",
+                    f"MRR: {score:.4f} — first relevant context at rank {rank} "
+                    f"(substring fallback)",
                 )
 
     return (
         0.0,
         f"MRR: 0.0 — no relevant context found in "
-        f"{len(turn_data.contexts)} retrieved contexts",
+        f"{len(contexts)} retrieved contexts (substring fallback)",
+    )
+
+
+def _evaluate_mrr_semantic(
+    contexts: list[str],
+    expected_contexts: list[str],
+    model: Any,
+    mrr_config: Optional[dict[str, Any]],
+) -> tuple[Optional[float], str]:
+    """MRR via semantic similarity with configurable threshold."""
+    threshold = _resolve_threshold(mrr_config)
+    sim_matrix = _compute_similarity_matrix(contexts, expected_contexts, model)
+
+    for rank in range(len(contexts)):
+        row_max = float(np.max(sim_matrix[rank]))
+        if row_max >= threshold:
+            score = 1.0 / (rank + 1)
+            return (
+                score,
+                f"MRR: {score:.4f} — first relevant context at rank {rank + 1} "
+                f"(similarity={row_max:.4f}, threshold={threshold:.4f})",
+            )
+
+    best_sim = float(np.max(sim_matrix))
+    return (
+        0.0,
+        f"MRR: 0.0 — no context above threshold in "
+        f"{len(contexts)} retrieved (best_similarity={best_sim:.4f}, "
+        f"threshold={threshold:.4f})",
     )

--- a/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/mrr_eval.py
@@ -1,0 +1,91 @@
+"""Mean Reciprocal Rank (MRR) evaluation for RAG retrieval quality."""
+
+import re
+from typing import Any, Optional
+
+from lightspeed_evaluation.core.models import TurnData
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize text for comparison: lowercase and collapse whitespace."""
+    return re.sub(r"\s+", " ", text.lower().strip())
+
+
+def _is_context_match(retrieved: str, expected: str) -> bool:
+    """Check if a retrieved context matches an expected context.
+
+    Uses normalized containment: a match occurs when either text
+    contains the other after normalization.  This handles retriever
+    chunks that are supersets or subsets of the ground-truth context.
+    """
+    norm_retrieved = _normalize_text(retrieved)
+    norm_expected = _normalize_text(expected)
+    return norm_expected in norm_retrieved or norm_retrieved in norm_expected
+
+
+def _validate_inputs(
+    is_conversation: bool, turn_data: Optional[TurnData]
+) -> Optional[tuple[Optional[float], str]]:
+    """Validate inputs for MRR evaluation."""
+    if is_conversation:
+        return None, "MRR is a turn-level metric"
+
+    if turn_data is None:
+        return None, "TurnData is required for MRR evaluation"
+
+    if not turn_data.contexts:
+        return None, "Retrieved contexts are required for MRR evaluation"
+
+    if not turn_data.expected_contexts:
+        return None, "Expected contexts are required for MRR evaluation"
+
+    return None
+
+
+def evaluate_mrr(
+    _conv_data: Any,
+    _turn_idx: Optional[int],
+    turn_data: Optional[TurnData],
+    is_conversation: bool,
+) -> tuple[Optional[float], str]:
+    """Evaluate Mean Reciprocal Rank of retrieved contexts.
+
+    MRR measures how high the first relevant context appears in the
+    ranked list of retrieved contexts.  The score is 1/rank for the
+    first match, or 0.0 when no retrieved context matches any expected
+    context.
+
+    Args:
+        _conv_data: Conversation data (unused).
+        _turn_idx: Turn index (unused).
+        turn_data: Turn data with ``contexts`` and ``expected_contexts``.
+        is_conversation: Whether this is conversation-level evaluation.
+
+    Returns:
+        Tuple of (score, reason).
+    """
+    validation_result = _validate_inputs(is_conversation, turn_data)
+    if validation_result:
+        return validation_result
+
+    if (
+        turn_data is None
+        or turn_data.contexts is None
+        or turn_data.expected_contexts is None
+    ):
+        return None, "Invalid turn data after validation"
+
+    for rank, retrieved in enumerate(turn_data.contexts, start=1):
+        for expected in turn_data.expected_contexts:
+            if _is_context_match(retrieved, expected):
+                score = 1.0 / rank
+                return (
+                    score,
+                    f"MRR: {score:.4f} — first relevant context at rank {rank}",
+                )
+
+    return (
+        0.0,
+        f"MRR: 0.0 — no relevant context found in "
+        f"{len(turn_data.contexts)} retrieved contexts",
+    )

--- a/src/lightspeed_evaluation/core/metrics/nlp.py
+++ b/src/lightspeed_evaluation/core/metrics/nlp.py
@@ -31,7 +31,6 @@ from lightspeed_evaluation.core.system.exceptions import MetricError
 logger = logging.getLogger(__name__)
 
 _DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
-_LOAD_FAILED = object()
 
 
 class NLPMetrics:  # pylint: disable=too-few-public-methods
@@ -50,11 +49,9 @@ class NLPMetrics:  # pylint: disable=too-few-public-methods
                 used for MRR semantic matching.  Falls back to substring
                 matching when sentence-transformers is not installed.
         """
-        self._default_embedding_model_name = (
-            embedding_model_name or _DEFAULT_EMBEDDING_MODEL
-        )
-        self._embedding_model_name = self._default_embedding_model_name
-        self._embedding_model: Any = None
+        self._default_model_name = embedding_model_name or _DEFAULT_EMBEDDING_MODEL
+        self._models: dict[str, Any] = {}
+        self._load_failed: set[str] = set()
 
         self.supported_metrics = {
             "bleu": self._evaluate_bleu,
@@ -65,37 +62,35 @@ class NLPMetrics:  # pylint: disable=too-few-public-methods
 
         logger.info("NLP Metrics initialized")
 
-    def _get_embedding_model(self) -> Any:
-        """Lazy-load and cache the sentence-transformers model."""
-        if self._embedding_model is None:
-            try:
-                import sentence_transformers  # type: ignore[import-not-found] # pylint: disable=import-outside-toplevel
-
-                self._embedding_model = sentence_transformers.SentenceTransformer(
-                    self._embedding_model_name
-                )
-                logger.info(
-                    "Loaded embedding model: %s",
-                    self._embedding_model_name,
-                )
-            except ImportError:
-                logger.warning(
-                    "sentence-transformers not installed — MRR will use "
-                    "substring fallback.  Install with: "
-                    "pip install 'lightspeed-evaluation[local-embeddings]'"
-                )
-                self._embedding_model = _LOAD_FAILED
-            except (OSError, RuntimeError) as exc:
-                logger.warning(
-                    "Failed to load embedding model '%s': %s — "
-                    "MRR will use substring fallback",
-                    self._embedding_model_name,
-                    exc,
-                )
-                self._embedding_model = _LOAD_FAILED
-        if self._embedding_model is _LOAD_FAILED:
+    def _get_embedding_model(self, model_name: str) -> Any:
+        """Lazy-load and cache the sentence-transformers model by name."""
+        if model_name in self._load_failed:
             return None
-        return self._embedding_model
+        if model_name in self._models:
+            return self._models[model_name]
+        try:
+            import sentence_transformers  # type: ignore[import-not-found] # pylint: disable=import-outside-toplevel
+
+            model = sentence_transformers.SentenceTransformer(model_name)
+            self._models[model_name] = model
+            logger.info("Loaded embedding model: %s", model_name)
+            return model
+        except ImportError:
+            logger.warning(
+                "sentence-transformers not installed — MRR will use "
+                "substring fallback.  Install with: "
+                "pip install 'lightspeed-evaluation[local-embeddings]'"
+            )
+            self._load_failed.add(model_name)
+        except (OSError, RuntimeError) as exc:
+            logger.warning(
+                "Failed to load embedding model '%s': %s — "
+                "MRR will use substring fallback",
+                model_name,
+                exc,
+            )
+            self._load_failed.add(model_name)
+        return None
 
     def _evaluate_mrr(
         self,
@@ -106,20 +101,15 @@ class NLPMetrics:  # pylint: disable=too-few-public-methods
     ) -> tuple[Optional[float], str]:
         """Evaluate MRR with semantic similarity when embeddings are available."""
         mrr_config = self._get_metric_metadata(turn_data, "nlp:mrr")
-        effective = (
-            mrr_config.get("embedding_model") or self._default_embedding_model_name
-        )
-        if effective != self._embedding_model_name:
-            self._embedding_model_name = effective
-            self._embedding_model = None
-        model = self._get_embedding_model()
+        model_name = mrr_config.get("embedding_model") or self._default_model_name
+        model = self._get_embedding_model(model_name)
         return evaluate_mrr(
             conv_data,
             turn_idx,
             turn_data,
             is_conversation,
             embedding_model=model,
-            embedding_model_name=self._embedding_model_name,
+            embedding_model_name=model_name,
             mrr_config=mrr_config,
         )
 

--- a/src/lightspeed_evaluation/core/metrics/nlp.py
+++ b/src/lightspeed_evaluation/core/metrics/nlp.py
@@ -119,6 +119,7 @@ class NLPMetrics:  # pylint: disable=too-few-public-methods
             turn_data,
             is_conversation,
             embedding_model=model,
+            embedding_model_name=self._embedding_model_name,
             mrr_config=mrr_config,
         )
 

--- a/src/lightspeed_evaluation/core/metrics/nlp.py
+++ b/src/lightspeed_evaluation/core/metrics/nlp.py
@@ -3,6 +3,7 @@
 This module provides text comparison metrics that don't require LLM calls:
 - BLEU Score: Measures n-gram overlap between response and reference
 - ROUGE Score: Measures recall-oriented n-gram overlap
+- MRR: Mean Reciprocal Rank with semantic similarity (sentence-transformers)
 - Semantic Similarity: Measures string similarity using distance measures
 """
 
@@ -29,27 +30,97 @@ from lightspeed_evaluation.core.system.exceptions import MetricError
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+_LOAD_FAILED = object()
+
 
 class NLPMetrics:  # pylint: disable=too-few-public-methods
     """Handles NLP-based metrics evaluation using Ragas non-LLM metrics.
 
     These metrics compare the generated response with the expected_response
     using traditional NLP techniques without requiring LLM calls.
+    MRR uses sentence-transformers embeddings when available.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, embedding_model_name: Optional[str] = None) -> None:
         """Initialize NLP Metrics.
 
-        No LLM or embedding manager required for these metrics.
+        Args:
+            embedding_model_name: Name of the sentence-transformers model
+                used for MRR semantic matching.  Falls back to substring
+                matching when sentence-transformers is not installed.
         """
+        self._default_embedding_model_name = (
+            embedding_model_name or _DEFAULT_EMBEDDING_MODEL
+        )
+        self._embedding_model_name = self._default_embedding_model_name
+        self._embedding_model: Any = None
+
         self.supported_metrics = {
             "bleu": self._evaluate_bleu,
-            "mrr": evaluate_mrr,
+            "mrr": self._evaluate_mrr,
             "rouge": self._evaluate_rouge,
             "semantic_similarity_distance": self._evaluate_semantic_similarity_distance,
         }
 
         logger.info("NLP Metrics initialized")
+
+    def _get_embedding_model(self) -> Any:
+        """Lazy-load and cache the sentence-transformers model."""
+        if self._embedding_model is None:
+            try:
+                import sentence_transformers  # type: ignore[import-not-found] # pylint: disable=import-outside-toplevel
+
+                self._embedding_model = sentence_transformers.SentenceTransformer(
+                    self._embedding_model_name
+                )
+                logger.info(
+                    "Loaded embedding model: %s",
+                    self._embedding_model_name,
+                )
+            except ImportError:
+                logger.warning(
+                    "sentence-transformers not installed — MRR will use "
+                    "substring fallback.  Install with: "
+                    "pip install 'lightspeed-evaluation[local-embeddings]'"
+                )
+                self._embedding_model = _LOAD_FAILED
+            except (OSError, RuntimeError) as exc:
+                logger.warning(
+                    "Failed to load embedding model '%s': %s — "
+                    "MRR will use substring fallback",
+                    self._embedding_model_name,
+                    exc,
+                )
+                self._embedding_model = _LOAD_FAILED
+        if self._embedding_model is _LOAD_FAILED:
+            return None
+        return self._embedding_model
+
+    def _evaluate_mrr(
+        self,
+        conv_data: Any,
+        turn_idx: Optional[int],
+        turn_data: Optional[TurnData],
+        is_conversation: bool,
+    ) -> tuple[Optional[float], str]:
+        """Evaluate MRR with semantic similarity when embeddings are available."""
+        mrr_config = self._get_metric_metadata(turn_data, "nlp:mrr")
+        effective = (
+            mrr_config.get("embedding_model") or self._default_embedding_model_name
+        )
+        if effective != self._embedding_model_name:
+            self._embedding_model_name = effective
+            self._embedding_model = None
+        model = self._get_embedding_model()
+        return evaluate_mrr(
+            conv_data,
+            turn_idx,
+            turn_data,
+            is_conversation,
+            embedding_model=model,
+            mrr_config=mrr_config,
+        )
 
     def _extract_turn_data(self, turn_data: Optional[TurnData]) -> tuple[str, str]:
         """Extract response and expected_response from turn data.

--- a/src/lightspeed_evaluation/core/metrics/nlp.py
+++ b/src/lightspeed_evaluation/core/metrics/nlp.py
@@ -23,6 +23,7 @@ from lightspeed_evaluation.core.constants import (
     SIMILARITY_LEVENSHTEIN,
     SUPPORTED_SIMILARITY_MEASURES,
 )
+from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
 from lightspeed_evaluation.core.models import EvaluationScope, TurnData
 from lightspeed_evaluation.core.system.exceptions import MetricError
 
@@ -43,6 +44,7 @@ class NLPMetrics:  # pylint: disable=too-few-public-methods
         """
         self.supported_metrics = {
             "bleu": self._evaluate_bleu,
+            "mrr": evaluate_mrr,
             "rouge": self._evaluate_rouge,
             "semantic_similarity_distance": self._evaluate_semantic_similarity_distance,
         }

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -168,6 +168,10 @@ class TurnData(StreamingMetricsMixin):
     contexts: Optional[list[str]] = Field(
         default=None, min_length=1, description="Contexts"
     )
+    expected_contexts: Optional[list[str]] = Field(
+        default=None,
+        description="Expected contexts for retrieval evaluation (ground truth)",
+    )
     expected_keywords: Optional[list[list[str]]] = Field(
         default=None,
         description="Expected keywords for keyword evaluation (list of alternatives)",

--- a/src/lightspeed_evaluation/core/models/data.py
+++ b/src/lightspeed_evaluation/core/models/data.py
@@ -170,6 +170,7 @@ class TurnData(StreamingMetricsMixin):
     )
     expected_contexts: Optional[list[str]] = Field(
         default=None,
+        min_length=1,
         description="Expected contexts for retrieval evaluation (ground truth)",
     )
     expected_keywords: Optional[list[list[str]]] = Field(

--- a/src/lightspeed_evaluation/core/system/validator.py
+++ b/src/lightspeed_evaluation/core/system/validator.py
@@ -80,6 +80,10 @@ METRIC_REQUIREMENTS = {
             "(Markdown workflow summary from ProposalAmender)"
         ),
     },
+    "custom:mrr": {
+        "required_fields": ["contexts", "expected_contexts"],
+        "description": "requires 'contexts' and 'expected_contexts' fields",
+    },
     "script:action_eval": {
         "required_fields": ["verify_script"],
         "description": "requires 'verify_script' field",

--- a/src/lightspeed_evaluation/core/system/validator.py
+++ b/src/lightspeed_evaluation/core/system/validator.py
@@ -80,7 +80,7 @@ METRIC_REQUIREMENTS = {
             "(Markdown workflow summary from ProposalAmender)"
         ),
     },
-    "custom:mrr": {
+    "nlp:mrr": {
         "required_fields": ["contexts", "expected_contexts"],
         "description": "requires 'contexts' and 'expected_contexts' fields",
     },

--- a/tests/unit/core/metrics/custom/test_conformal.py
+++ b/tests/unit/core/metrics/custom/test_conformal.py
@@ -1,0 +1,117 @@
+"""Tests for Conformal Risk Control threshold calibration."""
+
+import numpy as np
+
+from lightspeed_evaluation.core.metrics.custom.conformal import (
+    compute_mrr_threshold,
+    get_lhat,
+)
+
+
+class TestGetLhat:
+    """Tests for the vendored get_lhat function."""
+
+    def test_perfect_calibration_scores(self) -> None:
+        """All scores are 1.0 — zero risk at any threshold, result within bounds."""
+        lambdas = np.linspace(0.0, 1.0, 100)
+        sims = np.ones(50)
+        loss_table = (sims[:, None] < lambdas[None, :]).astype(float)
+
+        lhat = get_lhat(loss_table, lambdas, alpha=0.1)
+
+        assert 0.0 <= lhat <= 1.0
+
+    def test_low_calibration_scores(self) -> None:
+        """All calibration scores are low — threshold should be near those scores."""
+        lambdas = np.linspace(0.0, 1.0, 200)
+        sims = np.full(50, 0.3)
+        loss_table = (sims[:, None] < lambdas[None, :]).astype(float)
+
+        lhat = get_lhat(loss_table, lambdas, alpha=0.1)
+
+        assert lhat <= 0.35
+
+    def test_higher_alpha_yields_stricter_threshold(self) -> None:
+        """With higher alpha (more tolerance), threshold can be stricter."""
+        rng = np.random.default_rng(42)
+        sims = rng.uniform(0.5, 0.9, size=100)
+        lambdas = np.linspace(0.0, 1.0, 200)
+        loss_table = (sims[:, None] < lambdas[None, :]).astype(float)
+
+        lhat_strict = get_lhat(loss_table, lambdas, alpha=0.05)
+        lhat_loose = get_lhat(loss_table, lambdas, alpha=0.3)
+
+        assert lhat_loose >= lhat_strict
+
+    def test_single_calibration_point(self) -> None:
+        """Algorithm works with n=1."""
+        lambdas = np.linspace(0.0, 1.0, 50)
+        sims = np.array([0.7])
+        loss_table = (sims[:, None] < lambdas[None, :]).astype(float)
+
+        lhat = get_lhat(loss_table, lambdas, alpha=0.5)
+
+        assert 0.0 <= lhat <= 1.0
+
+    def test_empirical_risk_controlled(self) -> None:
+        """Validate that empirical false-negative rate respects alpha on held-out data."""
+        rng = np.random.default_rng(123)
+        alpha = 0.2
+        all_sims = rng.uniform(0.4, 0.95, size=400)
+        calib_sims = all_sims[:200]
+        test_sims = all_sims[200:]
+
+        lambdas = np.linspace(0.0, 1.0, 300)
+        loss_table = (calib_sims[:, None] < lambdas[None, :]).astype(float)
+        lhat = get_lhat(loss_table, lambdas, alpha=alpha)
+
+        fn_rate = float(np.mean(test_sims < lhat))
+        assert fn_rate <= alpha + 0.05
+
+
+class TestComputeMrrThreshold:
+    """Tests for the MRR-specific wrapper."""
+
+    def test_empty_calibration_returns_none(self) -> None:
+        """No calibration data yields None."""
+        assert compute_mrr_threshold([]) is None
+
+    def test_returns_float(self) -> None:
+        """Result is a plain float."""
+        result = compute_mrr_threshold([0.8, 0.9, 0.7, 0.85] * 10)
+        assert isinstance(result, float)
+
+    def test_threshold_within_bounds(self) -> None:
+        """Threshold is between 0 and 1."""
+        result = compute_mrr_threshold([0.6, 0.7, 0.8, 0.9, 0.5] * 10)
+        assert result is not None
+        assert 0.0 <= result <= 1.0
+
+    def test_high_sims_yield_high_threshold(self) -> None:
+        """Calibration pairs with high similarity yield a high threshold."""
+        sims = [0.95, 0.92, 0.98, 0.90, 0.93] * 10
+        result = compute_mrr_threshold(sims, alpha=0.1)
+        assert result is not None
+        assert result >= 0.8
+
+    def test_low_sims_yield_low_threshold(self) -> None:
+        """Calibration pairs with low similarity yield a low threshold."""
+        sims = [0.3, 0.25, 0.35, 0.28, 0.32] * 10
+        result = compute_mrr_threshold(sims, alpha=0.1)
+        assert result is not None
+        assert result <= 0.4
+
+    def test_alpha_affects_threshold(self) -> None:
+        """Lower alpha (stricter) should yield lower or equal threshold."""
+        sims = [0.6, 0.7, 0.8, 0.5, 0.65, 0.75] * 10
+        strict = compute_mrr_threshold(sims, alpha=0.05)
+        loose = compute_mrr_threshold(sims, alpha=0.3)
+        assert strict is not None
+        assert loose is not None
+        assert loose >= strict
+
+    def test_small_n_returns_permissive_threshold(self) -> None:
+        """With few samples, CRC returns permissive threshold (finite-sample correction)."""
+        result = compute_mrr_threshold([0.9, 0.8], alpha=0.1)
+        assert result is not None
+        assert result <= 0.5

--- a/tests/unit/core/metrics/custom/test_mrr_eval.py
+++ b/tests/unit/core/metrics/custom/test_mrr_eval.py
@@ -1,0 +1,306 @@
+"""Tests for MRR (Mean Reciprocal Rank) evaluation metric."""
+
+import pytest
+
+from lightspeed_evaluation.core.metrics.custom.mrr_eval import (
+    _is_context_match,
+    _normalize_text,
+    evaluate_mrr,
+)
+from lightspeed_evaluation.core.models import TurnData
+
+
+class TestNormalizeText:
+    """Test text normalization helper."""
+
+    def test_lowercase(self) -> None:
+        """Test that text is lowercased."""
+        assert _normalize_text("Hello World") == "hello world"
+
+    def test_collapse_whitespace(self) -> None:
+        """Test that multiple whitespace characters are collapsed."""
+        assert _normalize_text("hello   world") == "hello world"
+
+    def test_strip_whitespace(self) -> None:
+        """Test that leading and trailing whitespace is stripped."""
+        assert _normalize_text("  hello world  ") == "hello world"
+
+    def test_mixed_whitespace(self) -> None:
+        """Test tabs, newlines, and multiple spaces."""
+        assert _normalize_text("hello\t\n  world") == "hello world"
+
+
+class TestIsContextMatch:
+    """Test context matching logic."""
+
+    def test_exact_match(self) -> None:
+        """Test that identical strings match."""
+        assert _is_context_match("hello world", "hello world") is True
+
+    def test_case_insensitive(self) -> None:
+        """Test that matching is case-insensitive."""
+        assert _is_context_match("Hello World", "hello world") is True
+
+    def test_retrieved_contains_expected(self) -> None:
+        """Test match when retrieved context is a superset of expected."""
+        retrieved = (
+            "Introduction: RHEL is a Linux distribution. It is enterprise-grade."
+        )
+        expected = "RHEL is a Linux distribution"
+        assert _is_context_match(retrieved, expected) is True
+
+    def test_expected_contains_retrieved(self) -> None:
+        """Test match when expected context is a superset of retrieved."""
+        retrieved = "RHEL is a Linux distribution"
+        expected = "Introduction: RHEL is a Linux distribution. It is enterprise-grade."
+        assert _is_context_match(retrieved, expected) is True
+
+    def test_no_match(self) -> None:
+        """Test that unrelated strings do not match."""
+        assert _is_context_match("hello world", "goodbye moon") is False
+
+    def test_whitespace_normalization(self) -> None:
+        """Test match with different whitespace."""
+        assert _is_context_match("hello   world", "hello world") is True
+
+
+class TestEvaluateMrr:
+    """Test the main evaluate_mrr function."""
+
+    def test_first_context_matches(self) -> None:
+        """Test score is 1.0 when first retrieved context is relevant."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "RHEL is a Linux distribution",
+                "Ubuntu is another distribution",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+        assert "rank 1" in reason
+
+    def test_second_context_matches(self) -> None:
+        """Test score is 0.5 when second retrieved context is relevant."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Ubuntu is a distribution",
+                "RHEL is a Linux distribution",
+                "Fedora is upstream",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 0.5
+        assert "rank 2" in reason
+
+    def test_third_context_matches(self) -> None:
+        """Test score is 1/3 when third retrieved context is relevant."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Ubuntu is a distribution",
+                "Fedora is upstream",
+                "RHEL is a Linux distribution",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == pytest.approx(1.0 / 3)
+        assert "rank 3" in reason
+
+    def test_no_match_returns_zero(self) -> None:
+        """Test score is 0.0 when no retrieved context is relevant."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Ubuntu is a distribution",
+                "Fedora is upstream",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 0.0
+        assert "no relevant context found" in reason
+
+    def test_case_insensitive_matching(self) -> None:
+        """Test that matching is case-insensitive."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["rhel IS a LINUX Distribution"],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, _reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+
+    def test_whitespace_normalized_matching(self) -> None:
+        """Test that whitespace differences are normalized."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["RHEL  is\ta   Linux\ndistribution"],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, _reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+
+    def test_retrieved_superset_of_expected(self) -> None:
+        """Test match when retrieved context contains the expected text."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Introduction: RHEL is a Linux distribution. It is enterprise-grade.",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, _reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+
+    def test_expected_superset_of_retrieved(self) -> None:
+        """Test match when expected context contains the retrieved text."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["RHEL is a Linux distribution"],
+            expected_contexts=[
+                "Introduction: RHEL is a Linux distribution. It is enterprise-grade.",
+            ],
+        )
+
+        score, _reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+
+    def test_multiple_expected_contexts(self) -> None:
+        """Test with multiple expected contexts where second one matches."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Unrelated text",
+                "Fedora is the upstream project for RHEL",
+            ],
+            expected_contexts=[
+                "RHEL is a Linux distribution",
+                "Fedora is the upstream project for RHEL",
+            ],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 0.5
+        assert "rank 2" in reason
+
+    def test_conversation_level_returns_none(self) -> None:
+        """Test that conversation-level evaluation returns None."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["some context"],
+            expected_contexts=["some context"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, True)
+
+        assert score is None
+        assert "turn-level metric" in reason
+
+    def test_missing_turn_data_returns_none(self) -> None:
+        """Test that missing turn data returns None."""
+        score, reason = evaluate_mrr(None, 0, None, False)
+
+        assert score is None
+        assert "TurnData is required" in reason
+
+    def test_missing_contexts_returns_none(self) -> None:
+        """Test that missing retrieved contexts returns None."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score is None
+        assert "Retrieved contexts are required" in reason
+
+    def test_missing_expected_contexts_returns_none(self) -> None:
+        """Test that missing expected contexts returns None."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score is None
+        assert "Expected contexts are required" in reason
+
+    def test_empty_contexts_rejected_by_model(self) -> None:
+        """Test that empty contexts list is rejected by TurnData validation."""
+        with pytest.raises(Exception):
+            TurnData(
+                turn_id="t1",
+                query="What is RHEL?",
+                contexts=[],
+                expected_contexts=["RHEL is a Linux distribution"],
+            )
+
+    def test_empty_expected_contexts_returns_none(self) -> None:
+        """Test that empty expected contexts list returns None."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["RHEL is a Linux distribution"],
+            expected_contexts=[],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score is None
+        assert "Expected contexts are required" in reason
+
+    def test_first_expected_context_matches_first(self) -> None:
+        """Test that earliest rank wins when multiple expected match different ranks."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="Tell me about Linux",
+            contexts=[
+                "RHEL is enterprise Linux",
+                "Ubuntu is desktop Linux",
+                "Fedora is community Linux",
+            ],
+            expected_contexts=[
+                "Ubuntu is desktop Linux",
+                "RHEL is enterprise Linux",
+            ],
+        )
+
+        score, reason = evaluate_mrr(None, 0, turn_data, False)
+
+        assert score == 1.0
+        assert "rank 1" in reason

--- a/tests/unit/core/metrics/custom/test_mrr_eval.py
+++ b/tests/unit/core/metrics/custom/test_mrr_eval.py
@@ -396,6 +396,42 @@ class TestEvaluateMrrSemantic:
         assert score == 0.0
         assert "no context above threshold" in reason
 
+    def test_semantic_with_calibration(self, mock_model: Any) -> None:
+        """Test semantic matching with conformal calibration pairs."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Red Hat Enterprise Linux is an operating system",
+                "Kubernetes runs containers",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(
+            None,
+            0,
+            turn_data,
+            False,
+            embedding_model=mock_model,
+            mrr_config={
+                "alpha": 0.1,
+                "calibration_pairs": [
+                    [
+                        "RHEL is a Linux distribution",
+                        "Red Hat Enterprise Linux is an operating system",
+                    ],
+                    [
+                        "Ubuntu is a distribution",
+                        "Ubuntu is a distribution",
+                    ],
+                ],
+            },
+        )
+
+        assert score == 1.0
+        assert "CRC-calibrated" in reason
+
     def test_semantic_high_threshold_rejects(self, mock_model: Any) -> None:
         """Test that a very high threshold rejects moderate similarity."""
         turn_data = TurnData(

--- a/tests/unit/core/metrics/custom/test_mrr_eval.py
+++ b/tests/unit/core/metrics/custom/test_mrr_eval.py
@@ -1,10 +1,15 @@
 """Tests for MRR (Mean Reciprocal Rank) evaluation metric."""
 
+from typing import Any
+
+import numpy as np
 import pytest
 from pydantic import ValidationError
+from pytest_mock import MockerFixture
 
 from lightspeed_evaluation.core.metrics.custom.mrr_eval import (
-    _is_context_match,
+    _compute_similarity_matrix,
+    _is_context_match_substring,
     _normalize_text,
     evaluate_mrr,
 )
@@ -31,16 +36,16 @@ class TestNormalizeText:
         assert _normalize_text("hello\t\n  world") == "hello world"
 
 
-class TestIsContextMatch:
-    """Test context matching logic."""
+class TestIsContextMatchSubstring:
+    """Test substring fallback matching logic."""
 
     def test_exact_match(self) -> None:
         """Test that identical strings match."""
-        assert _is_context_match("hello world", "hello world") is True
+        assert _is_context_match_substring("hello world", "hello world") is True
 
     def test_case_insensitive(self) -> None:
         """Test that matching is case-insensitive."""
-        assert _is_context_match("Hello World", "hello world") is True
+        assert _is_context_match_substring("Hello World", "hello world") is True
 
     def test_retrieved_contains_expected(self) -> None:
         """Test match when retrieved context is a superset of expected."""
@@ -48,25 +53,33 @@ class TestIsContextMatch:
             "Introduction: RHEL is a Linux distribution. It is enterprise-grade."
         )
         expected = "RHEL is a Linux distribution"
-        assert _is_context_match(retrieved, expected) is True
+        assert _is_context_match_substring(retrieved, expected) is True
 
     def test_expected_contains_retrieved(self) -> None:
         """Test match when expected context is a superset of retrieved."""
         retrieved = "RHEL is a Linux distribution"
         expected = "Introduction: RHEL is a Linux distribution. It is enterprise-grade."
-        assert _is_context_match(retrieved, expected) is True
+        assert _is_context_match_substring(retrieved, expected) is True
 
     def test_no_match(self) -> None:
         """Test that unrelated strings do not match."""
-        assert _is_context_match("hello world", "goodbye moon") is False
+        assert _is_context_match_substring("hello world", "goodbye moon") is False
 
     def test_whitespace_normalization(self) -> None:
         """Test match with different whitespace."""
-        assert _is_context_match("hello   world", "hello world") is True
+        assert _is_context_match_substring("hello   world", "hello world") is True
+
+    def test_empty_retrieved(self) -> None:
+        """Test that empty retrieved text returns False."""
+        assert _is_context_match_substring("   ", "hello") is False
+
+    def test_empty_expected(self) -> None:
+        """Test that empty expected text returns False."""
+        assert _is_context_match_substring("hello", "   ") is False
 
 
-class TestEvaluateMrr:
-    """Test the main evaluate_mrr function."""
+class TestEvaluateMrrSubstring:
+    """Test evaluate_mrr with substring fallback (no embedding model)."""
 
     def test_first_context_matches(self) -> None:
         """Test score is 1.0 when first retrieved context is relevant."""
@@ -84,6 +97,7 @@ class TestEvaluateMrr:
 
         assert score == 1.0
         assert "rank 1" in reason
+        assert "substring fallback" in reason
 
     def test_second_context_matches(self) -> None:
         """Test score is 0.5 when second retrieved context is relevant."""
@@ -214,6 +228,10 @@ class TestEvaluateMrr:
         assert score == 0.5
         assert "rank 2" in reason
 
+
+class TestEvaluateMrrValidation:
+    """Test input validation shared by both matching paths."""
+
     def test_conversation_level_returns_none(self) -> None:
         """Test that conversation-level evaluation returns None."""
         turn_data = TurnData(
@@ -301,3 +319,124 @@ class TestEvaluateMrr:
 
         assert score == 1.0
         assert "rank 1" in reason
+
+
+class TestEvaluateMrrSemantic:
+    """Test evaluate_mrr with a mock embedding model."""
+
+    @pytest.fixture()
+    def mock_model(self, mocker: MockerFixture) -> Any:
+        """Create a mock SentenceTransformer model."""
+        model = mocker.MagicMock()
+
+        def fake_encode(
+            texts: list[str], normalize_embeddings: bool = False
+        ) -> np.ndarray:
+            vectors = {
+                "RHEL is a Linux distribution": [0.9, 0.1, 0.0],
+                "Red Hat Enterprise Linux is an operating system": [0.85, 0.15, 0.05],
+                "Ubuntu is a distribution": [0.1, 0.9, 0.0],
+                "Fedora is upstream": [0.3, 0.6, 0.1],
+                "Kubernetes runs containers": [0.0, 0.0, 1.0],
+            }
+            result = []
+            for text in texts:
+                vec = np.array(vectors.get(text, [0.33, 0.33, 0.33]), dtype=float)
+                if normalize_embeddings:
+                    vec = vec / (np.linalg.norm(vec) + 1e-10)
+                result.append(vec)
+            return np.array(result)
+
+        model.encode = fake_encode
+        return model
+
+    def test_semantic_match_at_rank_1(self, mock_model: Any) -> None:
+        """Test semantic matching finds relevant context at rank 1."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=[
+                "Red Hat Enterprise Linux is an operating system",
+                "Kubernetes runs containers",
+            ],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(
+            None,
+            0,
+            turn_data,
+            False,
+            embedding_model=mock_model,
+            mrr_config={"default_similarity_threshold": 0.5},
+        )
+
+        assert score == 1.0
+        assert "rank 1" in reason
+        assert "similarity=" in reason
+
+    def test_semantic_no_match(self, mock_model: Any) -> None:
+        """Test semantic matching returns 0.0 for unrelated contexts."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["Kubernetes runs containers"],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, reason = evaluate_mrr(
+            None,
+            0,
+            turn_data,
+            False,
+            embedding_model=mock_model,
+            mrr_config={"default_similarity_threshold": 0.5},
+        )
+
+        assert score == 0.0
+        assert "no context above threshold" in reason
+
+    def test_semantic_high_threshold_rejects(self, mock_model: Any) -> None:
+        """Test that a very high threshold rejects moderate similarity."""
+        turn_data = TurnData(
+            turn_id="t1",
+            query="What is RHEL?",
+            contexts=["Fedora is upstream"],
+            expected_contexts=["RHEL is a Linux distribution"],
+        )
+
+        score, _reason = evaluate_mrr(
+            None,
+            0,
+            turn_data,
+            False,
+            embedding_model=mock_model,
+            mrr_config={"default_similarity_threshold": 0.99},
+        )
+
+        assert score == 0.0
+
+
+class TestComputeSimilarityMatrix:
+    """Test the similarity matrix computation."""
+
+    def test_identity(self, mocker: MockerFixture) -> None:
+        """Test that same texts produce high similarity."""
+        model = mocker.MagicMock()
+        model.encode = lambda texts, normalize_embeddings=False: np.eye(3)[: len(texts)]
+
+        matrix = _compute_similarity_matrix(["a"], ["a"], model)
+
+        assert matrix.shape == (1, 1)
+        assert matrix[0, 0] == pytest.approx(1.0)
+
+    def test_matrix_shape(self, mocker: MockerFixture) -> None:
+        """Test output shape matches input counts."""
+        model = mocker.MagicMock()
+        model.encode = lambda texts, normalize_embeddings=False: np.random.default_rng(
+            0
+        ).random((len(texts), 4))
+
+        matrix = _compute_similarity_matrix(["a", "b", "c"], ["x", "y"], model)
+
+        assert matrix.shape == (3, 2)

--- a/tests/unit/core/metrics/custom/test_mrr_eval.py
+++ b/tests/unit/core/metrics/custom/test_mrr_eval.py
@@ -1,6 +1,7 @@
 """Tests for MRR (Mean Reciprocal Rank) evaluation metric."""
 
 import pytest
+from pydantic import ValidationError
 
 from lightspeed_evaluation.core.metrics.custom.mrr_eval import (
     _is_context_match,
@@ -270,19 +271,15 @@ class TestEvaluateMrr:
                 expected_contexts=["RHEL is a Linux distribution"],
             )
 
-    def test_empty_expected_contexts_returns_none(self) -> None:
-        """Test that empty expected contexts list returns None."""
-        turn_data = TurnData(
-            turn_id="t1",
-            query="What is RHEL?",
-            contexts=["RHEL is a Linux distribution"],
-            expected_contexts=[],
-        )
-
-        score, reason = evaluate_mrr(None, 0, turn_data, False)
-
-        assert score is None
-        assert "Expected contexts are required" in reason
+    def test_empty_expected_contexts_rejected_by_model(self) -> None:
+        """Test that empty expected contexts list is rejected by Pydantic validation."""
+        with pytest.raises(ValidationError):
+            TurnData(
+                turn_id="t1",
+                query="What is RHEL?",
+                contexts=["RHEL is a Linux distribution"],
+                expected_contexts=[],
+            )
 
     def test_first_expected_context_matches_first(self) -> None:
         """Test that earliest rank wins when multiple expected match different ranks."""


### PR DESCRIPTION
Mean Reciprocal Rank (MRR) is a well-established information retrieval   metric introduced by Voorhees (1999) in the TREC-8 Question Answering   Track Report. It measures the rank position of the first relevant   result in a ranked list, computed as 1/rank, yielding 1.0 when the
  first retrieved item is relevant, 0.5 for the second, and so on.

  ▎ "The reciprocal rank of a query response is the multiplicative 
  ▎ inverse of the rank of the first correct answer."
  ▎  Voorhees, E.M. (1999). The TREC-8 Question Answering Track Report.
  ▎ Proceedings of the 8th Text REtrieval Conference (TREC-8), NIST 
  ▎ Special Publication 500-246, pp. 77–82.

In the context of RAG (Retrieval-Augmented Generation) evaluation, MRR   provides a deterministic, non-LLM signal that directly measures   retrieval ranking quality 
It mesuares  how quickly the system surfaces a relevant  context chunk. This complements the existing LLM-judge-based Ragas  metrics (context_recall, context_precision, context_relevance) by  adding a fast, reproducible, and cost-free retrieval quality   indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NLP-based Mean Reciprocal Rank (MRR) with optional semantic matching via embeddings.
  * Introduced configurable embedding model selection and similarity thresholding, with default similarity and optional conformal calibration.

* **Validation**
  * MRR now requires non-empty retrieved and expected contexts.
  * Renamed metric identifier from `custom:mrr` to `nlp:mrr`.

* **Tests**
  * Expanded unit coverage for substring scoring, semantic behavior, threshold calibration, and stricter input validation.
  * Added dedicated tests for conformal calibration logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->