### PR TITLE
chore: prevent uv.lock modification during run due to exclude-newer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ uv-lock-regenerate: ## Regenerate both CPU and GPU lock files from pyproject.tom
 	@echo "Regenerating CPU lock file (uv.lock)..."
 	@echo "Cooldown: excluding packages newer than $(COOLDOWN_CUTOFF) ($(COOLDOWN_DAYS) days)"
 	uv lock --exclude-newer "$(COOLDOWN_CUTOFF)"
+	@sed -i.bak 's/^exclude-newer/# exclude-newer/' uv.lock && rm -f uv.lock.bak
 	@echo "Regenerating GPU lock file (uv-gpu.lock)..."
 	@# Use mktemp for safe temporary files
 	@( \
@@ -49,12 +50,14 @@ uv-lock-regenerate: ## Regenerate both CPU and GPU lock files from pyproject.tom
 		sed '/^\[tool\.uv\.sources\]/,/^torch = /d' pyproject.toml > $$TEMP_FILE; \
 		mv $$TEMP_FILE pyproject.toml; \
 		uv lock --locked 2>/dev/null || uv lock --exclude-newer "$(COOLDOWN_CUTOFF)"; \
+		sed -i.bak 's/^exclude-newer/# exclude-newer/' uv.lock && rm -f uv.lock.bak; \
 		mv uv.lock uv-gpu.lock; \
 		mv $$BACKUP_FILE pyproject.toml; \
 		trap - EXIT; \
 	)
 	@echo "Restoring CPU lock file (uv.lock)..."
 	uv lock --exclude-newer "$(COOLDOWN_CUTOFF)"
+	@sed -i.bak 's/^exclude-newer/# exclude-newer/' uv.lock && rm -f uv.lock.bak
 	@echo "✅ Done! Created uv.lock (CPU) and uv-gpu.lock (GPU) [cooldown=$(COOLDOWN_DAYS)d]"
 
 generate-requirements: ## Generate pinned requirements-*.txt from uv.lock (no -e ., safe without clone)

--- a/uv-gpu.lock
+++ b/uv-gpu.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-22T04:30:00Z"
+# exclude-newer = "2026-07-22T04:30:00Z"
 
 [[package]]
 name = "absl-py"

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-22T04:30:00Z"
+# exclude-newer = "2026-07-22T04:30:00Z"
 
 [[package]]
 name = "absl-py"


### PR DESCRIPTION
## Description

prevent uv.lock modification during run due to exclude-newer by commenting it.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the lock regeneration workflow to consistently produce clean CPU and GPU lock files.
  * Removed temporary backup files after lock updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->