### PR TITLE
[LEADS-572] Storing result in langfuse dataset (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The `storage` list in `system.yaml` selects where results go. You can use **seve
 |--------|---------|
 | **File backend** | CSV, JSON, and TXT under `output_dir`; tune formats with `enabled_outputs` and columns with `csv_columns`. |
 | **Database (optional)** | SQLite, PostgreSQL, or MySQL for querying and analysis; writes are **incremental** per conversation; storage errors are logged as warnings and **do not** abort the evaluation run. |
-| **Langfuse (optional)** | Export evaluation scores to [Langfuse](https://langfuse.com) for observability and analytics. Creates one trace per run with per-metric numeric scores. Requires `pip install 'lightspeed-evaluation[langfuse]'` or `uv sync --extra langfuse`. |
+| **Langfuse (optional)** | Export evaluation scores to [Langfuse](https://langfuse.com) for observability and analytics. Writes per-turn traces with per-metric scores incrementally (CSV-shaped metadata), then a run-level aggregate summary at finalize (including eval status). Optionally set `dataset_name` to also link those turns into a Langfuse Dataset **run** (Datasets → Runs) for side-by-side comparison. Requires `pip install 'lightspeed-evaluation[langfuse]'` or `uv sync --extra langfuse`. |
 | **MLflow (optional)** | Export metrics, traces, and results to [MLflow](https://mlflow.org) for experiment tracking. Logs incremental metrics, per-result traces, aggregates, a results table, and registered models (`provider>model`). Requires `pip install 'lightspeed-evaluation[mlflow]'` or `uv sync --extra mlflow`. |
 
 For field tables, full YAML examples (file-only, file + SQLite, file + Postgres, file + MLflow), CSV column reference, and notes on API token columns, see **[Storage](docs/configuration.md#storage)** in the configuration guide.

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -314,6 +314,8 @@ storage:
   # Or provide them inline below:
   # - type: "langfuse"
   #   host: "https://cloud.langfuse.com"
+  #   # Optional — also link per-turn traces into a Dataset run (Datasets → Runs)
+  #   dataset_name: "eval-baseline-v1"
 
   # MLflow backend (optional) - export metrics, traces, and results to MLflow
   # Requires: pip install 'lightspeed-evaluation[mlflow]'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,7 +402,19 @@ Save results to a database for querying and analysis. Supports SQLite, PostgreSQ
 > **Note:** Database storage is incremental - results are saved as each conversation completes. Storage failures are logged as warnings but don't stop the evaluation.
 
 ### Langfuse Backend (Optional)
-Export evaluation scores to [Langfuse](https://langfuse.com) for observability, analytics, and score tracking. Creates one trace per evaluation run with one numeric score per metric result.
+Export evaluation scores to [Langfuse](https://langfuse.com) for observability, analytics, and score tracking.
+
+**Unified export (always):**
+- One **per-turn** trace per unique `(conversation_group_id, turn_id)` with CSV-shaped metadata (written incrementally on each conversation `save_run`)
+- One numeric score per metric result on that turn trace (metadata = full CSV row / `SUPPORTED_CSV_COLUMNS`)
+- One **run-level aggregate** span at finalize with `aggregate/*` scores plus `eval_status` / `eval/success` from the evaluation outcome
+
+**Optional `dataset_name`:** Also links the same per-turn traces into a [Langfuse Dataset](https://langfuse.com/docs/evaluation/experiments/datasets) **run** (visible under **Datasets → Runs**):
+- Upserts one Dataset **item** per turn (stable input / expected output)
+- Creates one Dataset **run** named `{run_label}__{run_id_prefix}`
+- Creates one **run item** per turn linking the item to the turn trace
+
+Reuse the same `dataset_name` across evaluations to compare two runs side-by-side in the Runs tab. Omit `dataset_name` (or leave it blank) to keep traces, scores, and aggregates without Dataset linking.
 
 Requires the Langfuse SDK v4:
 ```bash
@@ -419,9 +431,11 @@ uv sync --extra langfuse
 | host | `null` | Langfuse API host URL (falls back to `LANGFUSE_HOST` env var) |
 | public_key | `null` | Langfuse public key (falls back to `LANGFUSE_PUBLIC_KEY` env var) |
 | secret_key | `null` | Langfuse secret key (falls back to `LANGFUSE_SECRET_KEY` env var) |
+| dataset_name | `null` | Optional Langfuse Dataset name. When set, also upserts items and creates a Dataset **run** (Datasets → Runs) linking the same per-turn traces. Blank/whitespace is treated as unset. |
 
 > **Credentials:** Configure credentials via environment variables (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`) or inline in the YAML config. Environment variables are the recommended approach — inline config fields take precedence when set.
-> **Score handling:** Results with a numeric score (PASS/FAIL) are exported as `NUMERIC` scores. Results without a score (`score=None`, e.g. ERROR/SKIPPED) are skipped. All Langfuse errors are logged but never abort the evaluation.
+> **Score handling:** Results with a numeric score (PASS/FAIL) are exported as `NUMERIC` scores on the turn trace. Results without a score (`score=None`, e.g. ERROR/SKIPPED) are skipped. Run-level `aggregate/*` scores and `eval/success` are written at finalize from the evaluation outcome. All Langfuse errors (including dataset link failures) are logged but never abort the evaluation; per-turn export and aggregates continue when Dataset linking fails.
+> **Dataset comparison:** Keep the same `dataset_name` (for example `eval-baseline-v1`) across evaluations. Each evaluation becomes a separate run under **Datasets → Runs** (run names include a short `run_id` suffix). Open two runs to compare scores and CSV fields.
 
 ### Example: Langfuse via Environment Variables
 ```yaml
@@ -446,6 +460,19 @@ storage:
     public_key: "pk-lf-..."
     secret_key: "sk-lf-..."
 ```
+
+### Example: Langfuse with Optional Dataset Run Export
+```yaml
+storage:
+  - type: "file"
+    output_dir: "./eval_output"
+  - type: "langfuse"
+    host: "https://cloud.langfuse.com"
+    # Also creates Dataset items + a Dataset run (compare under Datasets → Runs)
+    dataset_name: "eval-baseline-v1"
+```
+
+Run evaluation twice against the same `dataset_name` (for example baseline vs candidate model). In Langfuse open **Datasets → eval-baseline-v1 → Runs** and select both runs to compare.
 
 ### MLflow Backend (Optional)
 Export evaluation metrics, traces, and results to [MLflow](https://mlflow.org) for experiment tracking and comparison. Creates one MLflow run per evaluation run, logs metrics incrementally as each result arrives, and writes aggregates plus a results table at finalize.

--- a/src/lightspeed_evaluation/core/storage/config.py
+++ b/src/lightspeed_evaluation/core/storage/config.py
@@ -129,8 +129,11 @@ class DatabaseBackendConfig(BaseModel):
 class LangfuseBackendConfig(BaseModel):
     """Configuration for Langfuse observability storage backend.
 
-    Exports evaluation scores to Langfuse as a trace with per-metric scores.
-    Requires the ``langfuse`` optional extra: ``pip install 'lightspeed-evaluation[langfuse]'``
+    Always exports per-turn traces with per-metric scores and a run-level
+    aggregate summary. When ``dataset_name`` is set, also links turns into a
+    Langfuse Dataset **run** (Datasets → Runs) for cross-run comparison.
+    Requires the ``langfuse`` optional extra:
+    ``pip install 'lightspeed-evaluation[langfuse]'``
 
     Credentials are resolved from config fields first, then ``LANGFUSE_PUBLIC_KEY``,
     ``LANGFUSE_SECRET_KEY``, and ``LANGFUSE_HOST`` environment variables as fallback.
@@ -138,6 +141,7 @@ class LangfuseBackendConfig(BaseModel):
     Example:
         - type: "langfuse"
           host: "https://cloud.langfuse.com"
+          dataset_name: "eval-baseline-v1"  # optional — enables Datasets → Runs
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -155,6 +159,23 @@ class LangfuseBackendConfig(BaseModel):
         default=None,
         description="Langfuse secret key (falls back to LANGFUSE_SECRET_KEY env var)",
     )
+    dataset_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "If set, also upsert dataset items and create a Dataset run "
+            "(Datasets → Runs) linking the same per-turn traces. "
+            "Omit or leave blank to export traces/scores/aggregates only."
+        ),
+    )
+
+    @field_validator("dataset_name")
+    @classmethod
+    def normalize_dataset_name(cls, value: Optional[str]) -> Optional[str]:
+        """Treat blank/whitespace dataset names as unset (no Dataset linking)."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
 
 
 class MLflowBackendConfig(BaseModel):

--- a/src/lightspeed_evaluation/core/storage/langfuse_storage.py
+++ b/src/lightspeed_evaluation/core/storage/langfuse_storage.py
@@ -15,17 +15,24 @@ behavior).
 
 Lifecycle:
     1. ``initialize(run_info)`` — creates the Langfuse client.
-    2. ``save_run(results)``    — accumulates all results (called per conversation).
-    3. ``finalize()``           — creates a trace span, writes scores, and flushes.
-    4. ``close()``              — shuts down the client.
+    2. ``save_result`` / ``save_run`` — accumulate results and export per-turn
+       traces/scores (and optional Dataset links) incrementally.
+    3. ``finalize(success)`` — export any remaining turns, write run-level
+       aggregates, and record eval status (complete/failed).
+    4. ``close()`` — shuts down the client.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import logging
+from collections import OrderedDict
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from pydantic import ValidationError
+
+from lightspeed_evaluation.core.constants import SUPPORTED_CSV_COLUMNS
 from lightspeed_evaluation.core.models.data import EvaluationData, EvaluationResult
 from lightspeed_evaluation.core.storage.config import LangfuseBackendConfig
 from lightspeed_evaluation.core.storage.protocol import RunInfo
@@ -33,18 +40,93 @@ from lightspeed_evaluation.core.storage.protocol import RunInfo
 logger = logging.getLogger(__name__)
 
 _HAS_LANGFUSE = importlib.util.find_spec("langfuse") is not None
+_MAX_TEXT = 8000
+
+# Per-metric columns excluded from turn-level csv_turn convenience metadata.
+_TURN_LEVEL_CSV_EXCLUDE = frozenset(
+    {
+        "metric_identifier",
+        "metric_metadata",
+        "result",
+        "score",
+        "threshold",
+        "reason",
+        "judge_scores",
+    }
+)
+_TURN_CSV_KEYS = tuple(
+    column for column in SUPPORTED_CSV_COLUMNS if column not in _TURN_LEVEL_CSV_EXCLUDE
+)
+
+
+def _langfuse_errors() -> tuple[type[BaseException], ...]:
+    """SDK/network errors that must not abort the evaluation pipeline.
+
+    Broader than local constructor failures alone: export paths also raise
+    ``ValidationError`` (response parse), ``ApiError``, ``httpx.HTTPError``,
+    and timeouts. Shared by ``initialize``, ``save_*``, ``finalize``, and
+    ``close`` so lifecycle handling stays consistent.
+    """
+    errors: list[type[BaseException]] = [
+        RuntimeError,
+        ValueError,
+        TypeError,
+        OSError,
+        ConnectionError,
+        TimeoutError,
+        ValidationError,
+    ]
+    if not _HAS_LANGFUSE:
+        return tuple(errors)
+    try:
+        api_error_mod = importlib.import_module("langfuse.api.core.api_error")
+        errors.append(api_error_mod.ApiError)
+    except ImportError:
+        pass
+    try:
+        httpx_mod = importlib.import_module("httpx")
+        errors.append(httpx_mod.HTTPError)
+    except ImportError:
+        pass
+    return tuple(errors)
+
+
+_LANGFUSE_ERRORS = _langfuse_errors()
+
+
+@dataclass
+class _ExportState:
+    """Mutable per-run export progress for incremental Langfuse writes."""
+
+    exported_turn_keys: set[tuple[str, str]] = field(default_factory=set)
+    # (conversation_group_id, turn_id, metric_identifier) already scored.
+    exported_metric_keys: set[tuple[str, str, str]] = field(default_factory=set)
+    # Existing Langfuse trace id per turn — used to append late metric scores.
+    turn_trace_ids: dict[tuple[str, str], str] = field(default_factory=dict)
+    # None = not attempted; "" = ensure failed; otherwise dataset name.
+    dataset_ready: Optional[str] = None
+    turns_written: int = 0
+    items_upserted: int = 0
+    run_items_created: int = 0
 
 
 class LangfuseStorageBackend:
     """Storage backend that exports evaluation results to Langfuse.
 
-    Creates one Langfuse trace (observation span) per evaluation run and
-    one score per evaluation result via ``create_score()``.
-    Results with ``score=None`` (ERROR/SKIPPED) are skipped from numeric
-    scoring but their status is logged.
+    Unified flow (aligned with MLflow's incremental + aggregate model):
+
+      1. **Per-turn traces + scores** (incremental in ``save_*``) — one trace per
+         ``(conversation_group_id, turn_id)`` with CSV-shaped metadata and one
+         ``create_score()`` per metric row (``score=None`` rows are skipped).
+      2. **Optional Dataset run** — when ``dataset_name`` is set, upserts Dataset
+         items and creates run items linking each turn to a Datasets → Runs entry.
+      3. **Run-level aggregates** (finalize) — a summary span with ``aggregate/*``
+         scores plus ``eval_status`` / ``eval/success`` from ``finalize(success)``.
 
     Uses the Langfuse Python SDK v4 API:
-    ``start_as_current_observation()``, ``create_score()``, ``flush()``.
+    ``start_as_current_observation()``, ``create_score()``,
+    ``create_dataset()`` / ``get_dataset()``, ``create_dataset_item()``,
+    ``api.dataset_run_items.create()``, ``flush()``.
 
     All Langfuse SDK errors are caught and logged — they never fail
     the evaluation pipeline.
@@ -55,12 +137,13 @@ class LangfuseStorageBackend:
 
         Args:
             config: Langfuse backend configuration with optional host,
-                public_key, and secret_key fields.
+                public_key, secret_key, and dataset_name fields.
         """
         self._config = config
         self._client: Any = None
         self._run_info: Optional[RunInfo] = None
         self._results: list[EvaluationResult] = []
+        self._export = _ExportState()
 
     @property
     def backend_name(self) -> str:
@@ -71,6 +154,7 @@ class LangfuseStorageBackend:
         """Create the Langfuse client for this run."""
         self._run_info = run_info
         self._results = []
+        self._export = _ExportState()
 
         if not _HAS_LANGFUSE:
             logger.error(
@@ -84,17 +168,32 @@ class LangfuseStorageBackend:
         kwargs = self._build_client_kwargs()
         try:
             self._client = langfuse_mod.Langfuse(**kwargs)
-        except (RuntimeError, ValueError, OSError, ConnectionError):
+        except _LANGFUSE_ERRORS:
             logger.exception("langfuse: failed to initialize client")
             self._client = None
 
     def save_result(self, result: EvaluationResult) -> None:
-        """Accumulate a single result for batch export at finalize."""
+        """Accumulate a result; turn export happens in ``save_run`` / ``finalize``.
+
+        Individual ``save_result`` calls may be partial turns (one metric), so
+        they are buffered. The evaluation pipeline writes complete conversation
+        batches via ``save_run``, which exports turns incrementally. Late metric
+        rows for an already-exported turn are appended to that turn's trace in
+        ``finalize`` (or a later ``save_run``).
+        """
         self._results.append(result)
 
     def save_run(self, results: list[EvaluationResult]) -> None:
-        """Accumulate conversation results for batch export at finalize."""
+        """Accumulate conversation results and export their turns immediately."""
+        if not results:
+            return
         self._results.extend(results)
+        if self._client is None:
+            return
+        try:
+            self._export_turn_batch(results, flush=True)
+        except _LANGFUSE_ERRORS:
+            logger.exception("langfuse: failed to export run batch incrementally")
 
     def set_evaluation_context(
         self, evaluation_data: Optional[list[EvaluationData]] = None
@@ -103,8 +202,14 @@ class LangfuseStorageBackend:
         _ = evaluation_data
 
     def finalize(self, success: bool = True) -> None:
-        """Create a trace span, write all scores, and flush to Langfuse."""
-        _ = success
+        """Flush remaining turns, write aggregates, and record eval status.
+
+        Args:
+            success: ``True`` for a complete eval (``eval_status=complete``);
+                ``False`` for an aborted eval (``eval_status=failed``).
+                Incremental turn traces and final aggregates are written in
+                both cases.
+        """
         if self._client is None:
             return
 
@@ -113,16 +218,49 @@ class LangfuseStorageBackend:
             return
 
         try:
-            self._write_trace_and_scores()
-        except (RuntimeError, ValueError, OSError, ConnectionError):
-            logger.exception("langfuse: failed to write trace and scores")
+            # Cover save_result-only paths, unexported turns, and late metric rows
+            # for turns that were already exported.
+            pending = [
+                result
+                for result in self._results
+                if _metric_export_key(result) not in self._export.exported_metric_keys
+            ]
+            if pending:
+                self._export_turn_batch(pending, flush=False)
+        except _LANGFUSE_ERRORS:
+            logger.exception("langfuse: failed to export remaining turns")
+
+        try:
+            self._write_aggregate_summary(self._dataset_run_name(), success=success)
+        except _LANGFUSE_ERRORS:
+            logger.exception("langfuse: failed to write aggregate summary")
+
+        # Always flush buffered SDK events, even if aggregate write failed.
+        try:
+            self._client.flush()
+        except _LANGFUSE_ERRORS:
+            logger.exception("langfuse: flush after finalize failed")
+
+        logger.info(
+            "langfuse: exported %d turn trace(s)%s; wrote aggregate summary "
+            "(eval_status=%s)",
+            self._export.turns_written,
+            (
+                f", dataset={self._export.dataset_ready!r} "
+                f"items={self._export.items_upserted} "
+                f"run_items={self._export.run_items_created}"
+                if self._export.dataset_ready
+                else ""
+            ),
+            "complete" if success else "failed",
+        )
 
     def close(self) -> None:
         """Shut down the Langfuse client."""
         if self._client is not None:
             try:
                 self._client.shutdown()
-            except (RuntimeError, OSError, ConnectionError):
+            except _LANGFUSE_ERRORS:
                 logger.debug("langfuse: shutdown raised; ignoring")
             self._client = None
 
@@ -137,101 +275,511 @@ class LangfuseStorageBackend:
             kwargs["host"] = self._config.host.strip()
         return kwargs
 
-    def _write_trace_and_scores(self) -> None:
-        """Create one trace span and emit one score per result row.
+    def _run_label(self) -> str:
+        """Human-readable base name for this evaluation run."""
+        if self._run_info and self._run_info.name:
+            return self._run_info.name
+        return "evaluation"
 
-        Uses the v4 observation-centric API:
-        - ``start_as_current_observation()`` to create the trace span
-        - ``create_score()`` to attach scores by trace_id
-        - ``flush()`` to ensure all events are sent
-        """
-        run_name = self._run_info.name if self._run_info else "evaluation"
-        trace_name = _truncate(f"lightspeed_eval__{run_name}", 256)
+    def _dataset_run_name(self) -> str:
+        """Unique Langfuse dataset run name (stable across item upserts)."""
+        base = self._run_label()
+        run_id = self._run_info.run_id if self._run_info else "unknown"
+        return _truncate(f"{base}__{run_id[:8]}", 200)
 
-        trace_meta: dict[str, Any] = {
-            "run_name": run_name,
-            "result_count": len(self._results),
-            "rows_preview": self._build_rows_preview(),
-        }
+    def _export_turn_batch(
+        self, results: list[EvaluationResult], *, flush: bool = True
+    ) -> None:
+        """Export not-yet-written turns from *results* (traces, scores, links)."""
+        if self._client is None or not results:
+            return
+
+        export_run_name = self._dataset_run_name()
+        dataset_name = self._link_dataset_if_configured()
+        run_description = (
+            f"lightspeed-evaluation run '{self._run_label()}' "
+            f"({len(self._results)} metric row(s))"
+        )
+
+        for (conversation_group_id, turn_id), turn_results in _group_results_by_turn(
+            results
+        ):
+            turn_key = (conversation_group_id, turn_id)
+            pending_metrics = [
+                result
+                for result in turn_results
+                if _metric_export_key(result) not in self._export.exported_metric_keys
+            ]
+            if not pending_metrics:
+                continue
+            try:
+                existing_trace_id = self._export.turn_trace_ids.get(turn_key)
+                if existing_trace_id:
+                    # Late metric rows for an already-exported turn: append scores
+                    # to the existing trace so per-turn and aggregate stay aligned.
+                    self._append_scores_to_trace(
+                        trace_id=existing_trace_id,
+                        results=pending_metrics,
+                    )
+                    continue
+
+                representative = pending_metrics[0]
+                turn_trace_id = self._write_turn_trace_and_scores(
+                    run_name=export_run_name,
+                    representative=representative,
+                    turn_results=pending_metrics,
+                )
+                if not turn_trace_id:
+                    continue
+                self._export.turn_trace_ids[turn_key] = turn_trace_id
+                self._export.exported_turn_keys.add(turn_key)
+                self._export.turns_written += 1
+                self._mark_metrics_exported(pending_metrics)
+
+                if not dataset_name:
+                    continue
+
+                item_id = _item_id(dataset_name, conversation_group_id, turn_id)
+                try:
+                    self._upsert_dataset_item(
+                        dataset_name=dataset_name,
+                        item_id=item_id,
+                        representative=representative,
+                        source_trace_id=turn_trace_id,
+                    )
+                    self._export.items_upserted += 1
+                    self._create_dataset_run_item(
+                        {
+                            "run_name": export_run_name,
+                            "dataset_item_id": item_id,
+                            "run_description": run_description,
+                            "metadata": {
+                                "source": "lightspeed-evaluation",
+                                "run_label": self._run_label(),
+                                "conversation_group_id": conversation_group_id,
+                                "turn_id": turn_id,
+                                "metric_count": len(pending_metrics),
+                            },
+                            "trace_id": turn_trace_id,
+                        }
+                    )
+                    self._export.run_items_created += 1
+                except _LANGFUSE_ERRORS:
+                    logger.exception(
+                        "langfuse: dataset link failed for turn %s/%s; "
+                        "continuing remaining turns",
+                        conversation_group_id,
+                        turn_id or "conversation",
+                    )
+            except _LANGFUSE_ERRORS:
+                logger.exception(
+                    "langfuse: turn export failed for %s/%s; "
+                    "continuing remaining turns",
+                    conversation_group_id,
+                    turn_id or "conversation",
+                )
+
+        if not flush:
+            return
+        try:
+            self._client.flush()
+        except _LANGFUSE_ERRORS:
+            logger.exception("langfuse: flush after turn batch failed")
+
+    def _link_dataset_if_configured(self) -> Optional[str]:
+        """Ensure dataset exists when configured; cache success/failure per run."""
+        if self._export.dataset_ready is not None:
+            return self._export.dataset_ready or None
+
+        dataset_name = self._config.dataset_name
+        if not dataset_name:
+            self._export.dataset_ready = ""
+            return None
+        try:
+            self._ensure_dataset(dataset_name)
+            self._export.dataset_ready = dataset_name
+            return dataset_name
+        except _LANGFUSE_ERRORS:
+            logger.exception(
+                "langfuse: failed to ensure dataset %r; "
+                "continuing with per-turn traces and aggregates only",
+                dataset_name,
+            )
+            self._export.dataset_ready = ""
+            return None
+
+    def _write_aggregate_summary(
+        self, export_run_name: str, *, success: bool = True
+    ) -> None:
+        """Emit a run-level aggregate span with summary scores (MLflow-like)."""
+        aggregates = _compute_aggregate_scores(self._results)
+        eval_status = "complete" if success else "failed"
+        trace_name = _truncate(f"lightspeed_eval_aggregate__{export_run_name}", 256)
+        rows_preview = self._build_rows_preview()
 
         with self._client.start_as_current_observation(
             name=trace_name,
             as_type="span",
-            metadata=trace_meta,
+            input={
+                "run_name": export_run_name,
+                "result_count": len(self._results),
+                "eval_status": eval_status,
+            },
+            output={"aggregates": aggregates, "rows_preview": rows_preview},
+            metadata={
+                "run_name": export_run_name,
+                "result_count": len(self._results),
+                "source": "lightspeed-evaluation",
+                "eval_status": eval_status,
+            },
         ) as span:
-            trace_id = span.trace_id
-
-            for r in self._results:
-                if r.score is None:
-                    logger.debug(
-                        "langfuse: skipping score for %s "
-                        "(status=%s, no numeric score)",
-                        r.metric_identifier,
-                        r.result,
-                    )
-                    continue
-
+            trace_id = str(span.trace_id)
+            for name, value in aggregates.items():
                 self._client.create_score(
                     trace_id=trace_id,
-                    name=_truncate(r.metric_identifier, 200),
-                    value=float(r.score),
+                    name=_truncate(name, 200),
+                    value=float(value),
                     data_type="NUMERIC",
-                    comment=_format_comment(r),
-                    metadata=_build_score_metadata(r),
+                    comment=f"aggregate | run={export_run_name}",
+                    metadata={
+                        "source": "lightspeed-evaluation",
+                        "kind": "aggregate",
+                        "run_name": export_run_name,
+                        "eval_status": eval_status,
+                    },
                 )
+            self._client.create_score(
+                trace_id=trace_id,
+                name="eval/success",
+                value=1.0 if success else 0.0,
+                data_type="NUMERIC",
+                comment=f"eval_status={eval_status}",
+                metadata={
+                    "source": "lightspeed-evaluation",
+                    "kind": "status",
+                    "run_name": export_run_name,
+                    "eval_status": eval_status,
+                },
+            )
 
-        self._client.flush()
+    def _upsert_dataset_item(
+        self,
+        *,
+        dataset_name: str,
+        item_id: str,
+        representative: EvaluationResult,
+        source_trace_id: str,
+    ) -> None:
+        """Upsert a dataset item, tolerating known SDK/server response skew."""
+        try:
+            self._client.create_dataset_item(
+                dataset_name=dataset_name,
+                id=item_id,
+                input=_build_dataset_item_input(representative),
+                expected_output=_build_dataset_item_expected(representative),
+                metadata=_build_dataset_item_metadata(representative),
+                source_trace_id=source_trace_id,
+            )
+        except ValidationError as exc:
+            # Langfuse Python SDK v4 requires media_references on DatasetItem;
+            # some self-hosted OSS servers omit it even after a successful create.
+            if _is_missing_field_validation_error(exc, "media_references"):
+                logger.warning(
+                    "langfuse: dataset item %r upsert likely succeeded; "
+                    "ignoring SDK parse error for missing media_references "
+                    "(self-hosted Langfuse/SDK version skew)",
+                    item_id,
+                )
+                return
+            raise
+
+    def _create_dataset_run_item(self, create_kwargs: dict[str, Any]) -> None:
+        """Create a dataset run item, tolerating known SDK/server response skew."""
+        dataset_item_id = create_kwargs.get("dataset_item_id", "")
+        try:
+            self._client.api.dataset_run_items.create(**create_kwargs)
+        except ValidationError as exc:
+            # Same class of skew as dataset items: HTTP 2xx then strict parse fails.
+            if _is_missing_field_validation_error(exc, "media_references"):
+                logger.warning(
+                    "langfuse: dataset run item for %r likely created; "
+                    "ignoring SDK parse error for missing media_references "
+                    "(self-hosted Langfuse/SDK version skew)",
+                    dataset_item_id,
+                )
+                return
+            raise
+
+    def _write_turn_trace_and_scores(
+        self,
+        *,
+        run_name: str,
+        representative: EvaluationResult,
+        turn_results: list[EvaluationResult],
+    ) -> Optional[str]:
+        """Create a per-turn trace with CSV fields and attach metric scores."""
+        turn_key = representative.turn_id or "conversation"
+        span_name = _truncate(
+            f"eval__{representative.conversation_group_id}__{turn_key}",
+            256,
+        )
+        csv_rows = [_result_to_csv_fields(result) for result in turn_results]
+        turn_meta = {
+            "run_name": run_name,
+            "conversation_group_id": representative.conversation_group_id,
+            "turn_id": representative.turn_id or "",
+            "metric_identifiers": [r.metric_identifier for r in turn_results],
+            # Full CSV-equivalent rows for this turn (one object per metric).
+            "csv_rows": csv_rows,
+            # Convenience: shared turn-level fields from the first metric row.
+            "csv_turn": {
+                key: csv_rows[0].get(key)
+                for key in _TURN_CSV_KEYS
+                if key in csv_rows[0]
+            },
+        }
+
+        with self._client.start_as_current_observation(
+            name=span_name,
+            as_type="span",
+            input=_build_dataset_item_input(representative),
+            output={
+                "response": (
+                    _truncate(representative.response, _MAX_TEXT)
+                    if representative.response
+                    else ""
+                ),
+            },
+            metadata=turn_meta,
+        ) as span:
+            trace_id = str(span.trace_id)
+            for result in turn_results:
+                self._write_score(trace_id=trace_id, result=result)
+
+        return trace_id
+
+    def _append_scores_to_trace(
+        self, *, trace_id: str, results: list[EvaluationResult]
+    ) -> None:
+        """Attach late metric scores to an existing turn trace."""
+        for result in results:
+            self._write_score(trace_id=trace_id, result=result)
+            self._export.exported_metric_keys.add(_metric_export_key(result))
+
+    def _mark_metrics_exported(self, results: list[EvaluationResult]) -> None:
+        """Record metric rows as exported so finalize does not skip/re-emit them."""
+        for result in results:
+            self._export.exported_metric_keys.add(_metric_export_key(result))
+
+    def _write_score(self, *, trace_id: str, result: EvaluationResult) -> None:
+        """Emit one numeric score for a result, or skip when score is missing."""
+        if result.score is None:
+            logger.debug(
+                "langfuse: skipping score for %s (status=%s, no numeric score)",
+                result.metric_identifier,
+                result.result,
+            )
+            return
+
+        self._client.create_score(
+            trace_id=trace_id,
+            name=_truncate(result.metric_identifier, 200),
+            value=float(result.score),
+            data_type="NUMERIC",
+            comment=_format_comment(result),
+            metadata=_result_to_csv_fields(result),
+        )
+
+    def _ensure_dataset(self, name: str) -> None:
+        """Get an existing Langfuse Dataset or create it if missing."""
+        try:
+            self._client.get_dataset(name)
+            logger.debug("langfuse: reusing existing dataset %r", name)
+            return
+        except _LANGFUSE_ERRORS:
+            logger.debug(
+                "langfuse: dataset %r not found or unavailable; creating",
+                name,
+                exc_info=True,
+            )
+
+        try:
+            self._client.create_dataset(
+                name=name,
+                metadata={"source": "lightspeed-evaluation"},
+            )
+            logger.info("langfuse: created dataset %r", name)
+        except _LANGFUSE_ERRORS:
+            # Race or name already exists — verify via get.
+            self._client.get_dataset(name)
+            logger.debug("langfuse: dataset %r already exists after create race", name)
 
     def _build_rows_preview(self) -> list[dict[str, Any]]:
         """Build a compact preview of the first 50 rows for trace metadata."""
         preview: list[dict[str, Any]] = []
-        for i, r in enumerate(self._results[:50]):
+        for i, result in enumerate(self._results[:50]):
             preview.append(
                 {
                     "idx": i,
-                    "conversation_group_id": r.conversation_group_id,
-                    "turn_id": r.turn_id or "",
-                    "metric": r.metric_identifier,
-                    "result": r.result,
-                    "score": r.score,
+                    "conversation_group_id": result.conversation_group_id,
+                    "turn_id": result.turn_id or "",
+                    "metric": result.metric_identifier,
+                    "result": result.result,
+                    "score": result.score,
                 }
             )
         return preview
 
 
-def _format_comment(r: EvaluationResult) -> str:
+def _is_missing_field_validation_error(exc: ValidationError, field_name: str) -> bool:
+    """Return True when *exc* is a missing required field named *field_name*."""
+    for err in exc.errors():
+        if err.get("type") != "missing":
+            continue
+        loc = err.get("loc") or ()
+        if field_name in loc:
+            return True
+    return False
+
+
+def _metric_export_key(result: EvaluationResult) -> tuple[str, str, str]:
+    """Stable key for whether a metric row has been written to Langfuse."""
+    return (
+        result.conversation_group_id,
+        result.turn_id or "",
+        result.metric_identifier,
+    )
+
+
+def _compute_aggregate_scores(results: list[EvaluationResult]) -> dict[str, float]:
+    """Build MLflow-like aggregate score map from evaluation results."""
+    scores = [float(r.score) for r in results if r.score is not None]
+    pass_values = [
+        1.0 if r.result == "PASS" else 0.0
+        for r in results
+        if r.result in ("PASS", "FAIL")
+    ]
+    aggregates: dict[str, float] = {
+        "aggregate/result_count": float(len(results)),
+    }
+    if scores:
+        aggregates["aggregate/mean_score"] = sum(scores) / len(scores)
+    if pass_values:
+        aggregates["aggregate/pass_rate"] = sum(pass_values) / len(pass_values)
+
+    per_metric: OrderedDict[str, list[EvaluationResult]] = OrderedDict()
+    for result in results:
+        per_metric.setdefault(result.metric_identifier, []).append(result)
+
+    for metric_id, metric_results in per_metric.items():
+        metric_scores = [float(r.score) for r in metric_results if r.score is not None]
+        metric_passes = [
+            1.0 if r.result == "PASS" else 0.0
+            for r in metric_results
+            if r.result in ("PASS", "FAIL")
+        ]
+        safe_metric = _truncate(metric_id, 120)
+        if metric_scores:
+            aggregates[f"aggregate/mean_score/{safe_metric}"] = sum(
+                metric_scores
+            ) / len(metric_scores)
+        if metric_passes:
+            aggregates[f"aggregate/pass_rate/{safe_metric}"] = sum(metric_passes) / len(
+                metric_passes
+            )
+    return aggregates
+
+
+def _group_results_by_turn(
+    results: list[EvaluationResult],
+) -> list[tuple[tuple[str, str], list[EvaluationResult]]]:
+    """Group metric rows by conversation/turn, preserving first-seen order."""
+    groups: OrderedDict[tuple[str, str], list[EvaluationResult]] = OrderedDict()
+    for result in results:
+        key = (result.conversation_group_id, result.turn_id or "")
+        groups.setdefault(key, []).append(result)
+    return list(groups.items())
+
+
+def _item_id(dataset_name: str, conversation_group_id: str, turn_id: str) -> str:
+    """Build a project-unique Langfuse dataset item id."""
+    return _truncate(
+        f"{dataset_name}::{conversation_group_id}::{turn_id or 'conversation'}",
+        256,
+    )
+
+
+def _result_to_csv_fields(result: EvaluationResult) -> dict[str, Any]:
+    """Serialize an evaluation result using the same columns as detailed CSV."""
+    row: dict[str, Any] = {}
+    for column in SUPPORTED_CSV_COLUMNS:
+        if not hasattr(result, column):
+            continue
+        value = getattr(result, column)
+        if column == "judge_scores" and value is not None:
+            row[column] = [js.model_dump(mode="json") for js in value]
+        elif column == "tag" and value is not None:
+            row[column] = sorted(value) if isinstance(value, set) else value
+        elif column == "expected_response":
+            row[column] = _format_expected_response(value, _MAX_TEXT)
+        elif isinstance(value, str):
+            row[column] = _truncate(value, _MAX_TEXT)
+        else:
+            row[column] = value
+    return row
+
+
+def _build_dataset_item_input(result: EvaluationResult) -> dict[str, Any]:
+    """Build Langfuse dataset item input from an evaluation result."""
+    return {
+        "query": _truncate(result.query, _MAX_TEXT) if result.query else "",
+        "conversation_group_id": result.conversation_group_id,
+        "turn_id": result.turn_id or "",
+    }
+
+
+def _build_dataset_item_expected(result: EvaluationResult) -> dict[str, Any]:
+    """Build Langfuse dataset item expected_output from expected_* fields."""
+    expected: dict[str, Any] = {}
+    expected_response = _format_expected_response(result.expected_response, _MAX_TEXT)
+    if expected_response:
+        expected["expected_response"] = expected_response
+    expected_intent = _safe_truncate(result.expected_intent, _MAX_TEXT)
+    if expected_intent:
+        expected["expected_intent"] = expected_intent
+    expected_tool_calls = _safe_truncate(result.expected_tool_calls, _MAX_TEXT)
+    if expected_tool_calls:
+        expected["expected_tool_calls"] = expected_tool_calls
+    expected_keywords = _safe_truncate(result.expected_keywords, _MAX_TEXT)
+    if expected_keywords:
+        expected["expected_keywords"] = expected_keywords
+    return expected
+
+
+def _build_dataset_item_metadata(result: EvaluationResult) -> dict[str, Any]:
+    """Build stable dataset-item metadata (not run-specific outputs)."""
+    return {
+        "tags": sorted(result.tag) if result.tag else [],
+        "source": "lightspeed-evaluation",
+    }
+
+
+def _format_comment(result: EvaluationResult) -> str:
     """Build a human-readable comment for a Langfuse score entry."""
     parts: list[str] = [
-        f"result={r.result}",
-        f"conversation_group_id={r.conversation_group_id}",
-        f"turn_id={r.turn_id or ''}",
+        f"result={result.result}",
+        f"conversation_group_id={result.conversation_group_id}",
+        f"turn_id={result.turn_id or ''}",
     ]
-    if r.reason:
+    if result.reason:
         max_reason = 1200
         reason = (
-            r.reason
-            if len(r.reason) <= max_reason
-            else r.reason[: max_reason - 3] + "..."
+            result.reason
+            if len(result.reason) <= max_reason
+            else result.reason[: max_reason - 3] + "..."
         )
         parts.append(f"reason={reason}")
     return " | ".join(parts)
-
-
-def _build_score_metadata(r: EvaluationResult) -> dict[str, Any]:
-    """Build per-score metadata mirroring evaluation CSV fields."""
-    max_text = 8000
-    return {
-        "query": _truncate(r.query, max_text) if r.query else "",
-        "response": _truncate(r.response, max_text) if r.response else "",
-        "conversation_group_id": r.conversation_group_id,
-        "turn_id": r.turn_id or "",
-        "tool_calls": _safe_truncate(r.tool_calls, max_text),
-        "contexts": _safe_truncate(r.contexts, max_text),
-        "expected_response": _format_expected_response(r.expected_response, max_text),
-        "expected_intent": _safe_truncate(r.expected_intent, max_text),
-        "expected_tool_calls": _safe_truncate(r.expected_tool_calls, max_text),
-        "expected_keywords": _safe_truncate(r.expected_keywords, max_text),
-    }
 
 
 def _safe_truncate(value: Optional[str], max_len: int) -> str:

--- a/tests/unit/core/storage/test_langfuse_storage.py
+++ b/tests/unit/core/storage/test_langfuse_storage.py
@@ -4,14 +4,34 @@
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from lightspeed_evaluation.core.models.data import EvaluationResult
 from lightspeed_evaluation.core.storage import create_pipeline_storage_backend
 from lightspeed_evaluation.core.storage.config import LangfuseBackendConfig
-from lightspeed_evaluation.core.storage.langfuse_storage import LangfuseStorageBackend
+from lightspeed_evaluation.core.storage.langfuse_storage import (
+    LangfuseStorageBackend,
+    _compute_aggregate_scores,
+    _is_missing_field_validation_error,
+)
 from lightspeed_evaluation.core.storage.protocol import RunInfo
 from lightspeed_evaluation.core.system.loader import ConfigLoader
+
+
+def _score_names(mock_client: Any) -> list[str]:
+    """Return create_score name kwargs in call order."""
+    return [c.kwargs["name"] for c in mock_client.create_score.call_args_list]
+
+
+def _metric_score_count(mock_client: Any) -> int:
+    """Count per-metric evaluation scores (exclude aggregate/status scores)."""
+    return sum(
+        1
+        for name in _score_names(mock_client)
+        if not name.startswith("aggregate/") and not name.startswith("eval/")
+    )
+
 
 _RESULT_DEFAULTS: dict = {
     "conversation_group_id": "conv_1",
@@ -22,12 +42,40 @@ _RESULT_DEFAULTS: dict = {
     "reason": "Looks good",
     "query": "What is OpenShift?",
     "response": "OpenShift is a Kubernetes platform.",
+    "expected_response": "OpenShift is a Kubernetes platform.",
 }
 
 
 def _make_result(**overrides: Any) -> EvaluationResult:
     """Build a minimal EvaluationResult for testing."""
     return EvaluationResult(**{**_RESULT_DEFAULTS, **overrides})
+
+
+def _wire_mock_span(mock_client: Any, mocker: MockerFixture, *trace_ids: str) -> Any:
+    """Attach context-manager span mock(s) with distinct trace IDs per call."""
+    ids = list(trace_ids) or ["trace-abc-123"]
+    spans = []
+    for trace_id in ids:
+        span = mocker.MagicMock()
+        span.trace_id = trace_id
+        spans.append(span)
+
+    # Advance through provided IDs; reuse the last ID if more spans are created.
+    span_iter = iter(spans)
+
+    def _enter(_cm: Any = None) -> Any:
+        try:
+            return next(span_iter)
+        except StopIteration:
+            return spans[-1]
+
+    mock_client.start_as_current_observation.return_value.__enter__ = mocker.MagicMock(
+        side_effect=_enter
+    )
+    mock_client.start_as_current_observation.return_value.__exit__ = mocker.MagicMock(
+        return_value=False
+    )
+    return spans[0]
 
 
 class TestLangfuseStorageBackend:
@@ -39,7 +87,7 @@ class TestLangfuseStorageBackend:
         assert backend.backend_name == "langfuse"
 
     def test_save_run_accumulates_results(self) -> None:
-        """save_run extends internal results list."""
+        """save_run extends internal results list when client is unset."""
         backend = LangfuseStorageBackend(LangfuseBackendConfig())
         backend.save_run([_make_result(), _make_result()])
         assert len(backend._results) == 2
@@ -109,20 +157,13 @@ class TestLangfuseStorageBackend:
         assert backend._client is None
 
     def test_finalize_creates_trace_and_scores(self, mocker: MockerFixture) -> None:
-        """finalize() creates a trace span and scores via v4 create_score API."""
+        """finalize() writes per-turn scores plus a run-level aggregate span."""
         mock_client = mocker.MagicMock()
-        mock_span = mocker.MagicMock()
-        mock_span.trace_id = "trace-abc-123"
-        mock_client.start_as_current_observation.return_value.__enter__ = (
-            mocker.MagicMock(return_value=mock_span)
-        )
-        mock_client.start_as_current_observation.return_value.__exit__ = (
-            mocker.MagicMock(return_value=False)
-        )
+        _wire_mock_span(mock_client, mocker, "trace-turn-1", "trace-agg-1")
 
         backend = LangfuseStorageBackend(LangfuseBackendConfig())
         backend._client = mock_client
-        backend._run_info = RunInfo(name="eval_run")
+        backend._run_info = RunInfo(name="eval_run", run_id="abcd1234-5678")
         backend._results = [
             _make_result(metric_identifier="ragas:relevancy", score=0.9),
             _make_result(metric_identifier="custom:accuracy", score=0.3, result="FAIL"),
@@ -130,30 +171,39 @@ class TestLangfuseStorageBackend:
 
         backend.finalize()
 
-        call_kwargs = mock_client.start_as_current_observation.call_args.kwargs
-        assert call_kwargs["as_type"] == "span"
-        assert "eval_run" in call_kwargs["name"]
+        # One turn span + one aggregate span.
+        assert mock_client.start_as_current_observation.call_count == 2
+        turn_span = mock_client.start_as_current_observation.call_args_list[0].kwargs
+        assert turn_span["as_type"] == "span"
+        assert "conv_1" in turn_span["name"]
+        agg_span = mock_client.start_as_current_observation.call_args_list[1].kwargs
+        assert "aggregate" in agg_span["name"]
+        assert agg_span["input"]["result_count"] == 2
 
-        assert mock_client.create_score.call_count == 2
+        assert _metric_score_count(mock_client) == 2
         first_score = mock_client.create_score.call_args_list[0].kwargs
-        assert first_score["trace_id"] == "trace-abc-123"
+        assert first_score["trace_id"] == "trace-turn-1"
         assert first_score["name"] == "ragas:relevancy"
         assert first_score["value"] == pytest.approx(0.9)
         assert first_score["data_type"] == "NUMERIC"
+        assert first_score["metadata"]["conversation_group_id"] == "conv_1"
+        assert first_score["metadata"]["query"] == "What is OpenShift?"
+        assert first_score["metadata"]["score"] == pytest.approx(0.9)
+
+        score_names = _score_names(mock_client)
+        assert "aggregate/mean_score" in score_names
+        assert "aggregate/pass_rate" in score_names
+        assert "aggregate/result_count" in score_names
 
         mock_client.flush.assert_called_once()
+        mock_client.create_dataset.assert_not_called()
+        mock_client.create_dataset_item.assert_not_called()
+        mock_client.api.dataset_run_items.create.assert_not_called()
 
     def test_finalize_skips_none_scores(self, mocker: MockerFixture) -> None:
         """finalize() skips results with score=None (ERROR/SKIPPED)."""
         mock_client = mocker.MagicMock()
-        mock_span = mocker.MagicMock()
-        mock_span.trace_id = "trace-xyz"
-        mock_client.start_as_current_observation.return_value.__enter__ = (
-            mocker.MagicMock(return_value=mock_span)
-        )
-        mock_client.start_as_current_observation.return_value.__exit__ = (
-            mocker.MagicMock(return_value=False)
-        )
+        _wire_mock_span(mock_client, mocker, "trace-xyz", "trace-agg")
 
         backend = LangfuseStorageBackend(LangfuseBackendConfig())
         backend._client = mock_client
@@ -165,7 +215,7 @@ class TestLangfuseStorageBackend:
 
         backend.finalize()
 
-        assert mock_client.create_score.call_count == 1
+        assert _metric_score_count(mock_client) == 1
 
     def test_finalize_noop_when_no_client(self) -> None:
         """finalize() is a no-op when client failed to initialize."""
@@ -184,6 +234,553 @@ class TestLangfuseStorageBackend:
 
         mock_client.shutdown.assert_called_once()
         assert backend._client is None
+
+    def test_finalize_without_dataset_name_still_writes_turns(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Without dataset_name, per-turn traces and aggregates are still exported."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-turn", "trace-agg")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="no_dataset", run_id="aabbccdd-0001")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+        mock_client.get_dataset.assert_not_called()
+        mock_client.create_dataset.assert_not_called()
+        mock_client.create_dataset_item.assert_not_called()
+        mock_client.api.dataset_run_items.create.assert_not_called()
+
+    def test_finalize_blank_dataset_name_skips_dataset_link(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Blank/whitespace dataset_name skips Dataset linking only."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-blank", "trace-agg")
+
+        config = LangfuseBackendConfig(dataset_name="   ")
+        assert config.dataset_name is None
+
+        backend = LangfuseStorageBackend(config)
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="blank_ds", run_id="blank001-0001")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        mock_client.create_dataset_item.assert_not_called()
+        mock_client.api.dataset_run_items.create.assert_not_called()
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/result_count" in _score_names(mock_client)
+
+    def test_finalize_exports_dataset_run_when_name_set(
+        self, mocker: MockerFixture
+    ) -> None:
+        """With dataset_name, links items + run items on top of per-turn traces."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(
+            mock_client, mocker, "trace-turn-1", "trace-turn-2", "trace-agg"
+        )
+        mock_client.get_dataset.side_effect = RuntimeError("not found")
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="dataset_run", run_id="deadbeef-0001")
+        backend._results = [
+            _make_result(metric_identifier="ragas:relevancy", score=0.9),
+            _make_result(
+                metric_identifier="custom:accuracy",
+                score=0.3,
+                result="FAIL",
+            ),
+            _make_result(
+                conversation_group_id="conv_2",
+                turn_id="turn_1",
+                metric_identifier="ragas:relevancy",
+                score=0.7,
+                query="What is Kubernetes?",
+            ),
+        ]
+
+        backend.finalize()
+
+        mock_client.create_dataset.assert_called_once_with(
+            name="eval-baseline-v1",
+            metadata={"source": "lightspeed-evaluation"},
+        )
+        # Two turn spans + one aggregate span.
+        assert mock_client.start_as_current_observation.call_count == 3
+        assert mock_client.create_dataset_item.call_count == 2
+        assert mock_client.api.dataset_run_items.create.call_count == 2
+        assert _metric_score_count(mock_client) == 3
+        assert "aggregate/mean_score" in _score_names(mock_client)
+
+        first_item = mock_client.create_dataset_item.call_args_list[0].kwargs
+        assert first_item["dataset_name"] == "eval-baseline-v1"
+        assert first_item["id"] == "eval-baseline-v1::conv_1::turn_1"
+        assert first_item["source_trace_id"] == "trace-turn-1"
+        assert first_item["input"]["query"] == "What is OpenShift?"
+        assert first_item["expected_output"]["expected_response"] == (
+            "OpenShift is a Kubernetes platform."
+        )
+        assert first_item["metadata"]["source"] == "lightspeed-evaluation"
+        assert "response" not in first_item["metadata"]
+
+        first_run_item = mock_client.api.dataset_run_items.create.call_args_list[
+            0
+        ].kwargs
+        assert first_run_item["run_name"] == "dataset_run__deadbeef"
+        assert first_run_item["dataset_item_id"] == "eval-baseline-v1::conv_1::turn_1"
+        assert first_run_item["trace_id"] == "trace-turn-1"
+
+        second_run_item = mock_client.api.dataset_run_items.create.call_args_list[
+            1
+        ].kwargs
+        assert second_run_item["trace_id"] == "trace-turn-2"
+        assert second_run_item["trace_id"] != first_run_item["trace_id"]
+
+        second_item = mock_client.create_dataset_item.call_args_list[1].kwargs
+        assert second_item["id"] == "eval-baseline-v1::conv_2::turn_1"
+        assert second_item["source_trace_id"] == "trace-turn-2"
+
+        turn_span = mock_client.start_as_current_observation.call_args_list[0].kwargs
+        assert turn_span["input"]["conversation_group_id"] == "conv_1"
+        assert turn_span["output"]["response"] == (
+            "OpenShift is a Kubernetes platform."
+        )
+        assert "csv_rows" in turn_span["metadata"]
+        assert len(turn_span["metadata"]["csv_rows"]) == 2
+        assert turn_span["metadata"]["csv_rows"][0]["metric_identifier"] == (
+            "ragas:relevancy"
+        )
+        assert "query" in turn_span["metadata"]["csv_turn"]
+        assert "metric_identifier" not in turn_span["metadata"]["csv_turn"]
+
+        mock_client.flush.assert_called()
+
+    def test_finalize_reuses_existing_dataset(self, mocker: MockerFixture) -> None:
+        """Existing dataset name is reused; run items are still created."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-reuse", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="reuse_run", run_id="aabbccdd-9999")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        mock_client.get_dataset.assert_called_once_with("eval-baseline-v1")
+        mock_client.create_dataset.assert_not_called()
+        mock_client.create_dataset_item.assert_called_once()
+        mock_client.api.dataset_run_items.create.assert_called_once()
+        item = mock_client.create_dataset_item.call_args.kwargs
+        assert item["id"] == "eval-baseline-v1::conv_1::turn_1"
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+
+    def test_finalize_dataset_ensure_failure_keeps_turn_export(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Dataset ensure failure still writes per-turn scores and aggregates."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-fail-ds", "trace-agg")
+        mock_client.get_dataset.side_effect = ConnectionError("dataset down")
+        mock_client.create_dataset.side_effect = ConnectionError("dataset down")
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-broken")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="fail_ds", run_id="fail0001-0001")
+        backend._results = [_make_result()]
+
+        with caplog.at_level("ERROR"):
+            backend.finalize()
+
+        assert "failed to ensure dataset" in caplog.text
+        assert "eval-broken" in caplog.text
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+        mock_client.api.dataset_run_items.create.assert_not_called()
+
+    def test_finalize_partial_dataset_link_continues_turns(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Mid-run dataset link failure continues other turns and aggregates."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-t1", "trace-t2", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+        mock_client.create_dataset_item.side_effect = [
+            None,
+            RuntimeError("dataset item create failed"),
+        ]
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-partial")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="partial_run", run_id="partial01-0001")
+        backend._results = [
+            _make_result(conversation_group_id="conv_1", turn_id="turn_1"),
+            _make_result(conversation_group_id="conv_2", turn_id="turn_1"),
+        ]
+
+        with caplog.at_level("ERROR"):
+            backend.finalize()
+
+        assert "dataset link failed" in caplog.text
+        # Two turn metric scores + aggregates; no duplicated metric pass.
+        assert _metric_score_count(mock_client) == 2
+        assert "aggregate/mean_score" in _score_names(mock_client)
+        assert mock_client.api.dataset_run_items.create.call_count == 1
+
+    def test_finalize_get_failure_creates_dataset(self, mocker: MockerFixture) -> None:
+        """Any get_dataset failure falls through to create_dataset."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-nf", "trace-agg")
+        mock_client.get_dataset.side_effect = RuntimeError("missing")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig(dataset_name="eval-new"))
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="nf_run", run_id="11223344-5566")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        mock_client.create_dataset.assert_called_once_with(
+            name="eval-new",
+            metadata={"source": "lightspeed-evaluation"},
+        )
+        assert mock_client.create_dataset_item.call_count == 1
+        assert mock_client.api.dataset_run_items.create.call_count == 1
+        assert _metric_score_count(mock_client) == 1
+
+    def test_finalize_tolerates_media_references_parse_error(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """SDK/server skew on media_references must not block dataset runs."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-media", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+        mock_client.create_dataset_item.side_effect = (
+            ValidationError.from_exception_data(
+                "DatasetItem",
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("media_references",),
+                        "input": {},
+                    }
+                ],
+            )
+        )
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="compat_run", run_id="cafebabe-0001")
+        backend._results = [_make_result()]
+
+        with caplog.at_level("WARNING"):
+            backend.finalize()
+
+        assert "media_references" in caplog.text
+        mock_client.api.dataset_run_items.create.assert_called_once()
+        assert _metric_score_count(mock_client) == 1
+        mock_client.flush.assert_called()
+
+    def test_finalize_does_not_treat_payload_validation_as_skew(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Non-missing ValidationError on media_references must not look like success."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-payload", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+        mock_client.create_dataset_item.side_effect = (
+            ValidationError.from_exception_data(
+                "DatasetItem",
+                [
+                    {
+                        "type": "list_type",
+                        "loc": ("media_references",),
+                        "input": "bad",
+                    }
+                ],
+            )
+        )
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="payload_run", run_id="badf00d0-0001")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        # Upsert failed for real; do not create a run item against a missing item.
+        mock_client.api.dataset_run_items.create.assert_not_called()
+        # Per-turn + aggregate export still completes.
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+
+    def test_finalize_continues_after_run_item_payload_validation(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Non-skew run-item ValidationError is logged; export continues."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-run-item", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+        mock_client.api.dataset_run_items.create.side_effect = (
+            ValidationError.from_exception_data(
+                "DatasetRunItem",
+                [
+                    {
+                        "type": "string_type",
+                        "loc": ("trace_id",),
+                        "input": 123,
+                    }
+                ],
+            )
+        )
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="run_item_bad", run_id="feedface-0001")
+        backend._results = [_make_result()]
+
+        backend.finalize()
+
+        mock_client.create_dataset_item.assert_called_once()
+        assert mock_client.api.dataset_run_items.create.call_count == 1
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+
+    def test_finalize_tolerates_run_item_media_references_skew(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing media_references on run-item response is treated as skew."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-run-skew", "trace-agg")
+        mock_client.get_dataset.return_value = mocker.MagicMock(name="existing")
+        mock_client.api.dataset_run_items.create.side_effect = (
+            ValidationError.from_exception_data(
+                "DatasetRunItem",
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("media_references",),
+                        "input": {},
+                    }
+                ],
+            )
+        )
+
+        backend = LangfuseStorageBackend(
+            LangfuseBackendConfig(dataset_name="eval-baseline-v1")
+        )
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="run_item_skew", run_id="0ddba11f-0001")
+        backend._results = [_make_result()]
+
+        with caplog.at_level("WARNING"):
+            backend.finalize()
+
+        assert "media_references" in caplog.text
+        mock_client.flush.assert_called()
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+
+
+class TestLangfuseStorageHelpers:
+    """Unit tests for Langfuse storage helpers and export resilience."""
+
+    def test_save_run_exports_turns_incrementally(self, mocker: MockerFixture) -> None:
+        """save_run writes per-turn traces immediately (before finalize)."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-incremental")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="inc_run", run_id="inc00001-0001")
+
+        backend.save_run([_make_result()])
+
+        assert mock_client.start_as_current_observation.call_count == 1
+        assert _metric_score_count(mock_client) == 1
+        mock_client.create_dataset_item.assert_not_called()
+        assert "aggregate/mean_score" not in _score_names(mock_client)
+        assert "eval/success" not in _score_names(mock_client)
+
+    def test_finalize_records_eval_status(self, mocker: MockerFixture) -> None:
+        """finalize(success=...) records eval_status and eval/success score."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-turn", "trace-agg")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="status_run", run_id="status01-0001")
+        backend._results = [_make_result()]
+
+        backend.finalize(success=False)
+
+        agg_span = mock_client.start_as_current_observation.call_args_list[-1].kwargs
+        assert agg_span["metadata"]["eval_status"] == "failed"
+        assert "eval/success" in _score_names(mock_client)
+        success_score = next(
+            c.kwargs
+            for c in mock_client.create_score.call_args_list
+            if c.kwargs["name"] == "eval/success"
+        )
+        assert success_score["value"] == pytest.approx(0.0)
+
+    def test_finalize_turn_trace_failure_still_writes_aggregates(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A later turn-trace failure must not skip the aggregate summary."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-t1", "trace-agg")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="turn_fail", run_id="turnfail-0001")
+        backend._results = [
+            _make_result(conversation_group_id="conv_1", turn_id="turn_1"),
+            _make_result(conversation_group_id="conv_2", turn_id="turn_1"),
+        ]
+
+        original = backend._write_turn_trace_and_scores
+        call_count = {"n": 0}
+
+        def _flaky_turn(**kwargs: Any) -> Any:
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise ConnectionError("turn span failed")
+            return original(**kwargs)
+
+        mocker.patch.object(
+            backend, "_write_turn_trace_and_scores", side_effect=_flaky_turn
+        )
+
+        with caplog.at_level("ERROR"):
+            backend.finalize()
+
+        assert "turn export failed" in caplog.text
+        assert _metric_score_count(mock_client) == 1
+        assert "aggregate/mean_score" in _score_names(mock_client)
+        assert mock_client.start_as_current_observation.call_count >= 2
+
+    def test_finalize_late_metric_appends_to_existing_trace(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Late metric rows for an exported turn append scores to that trace."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-turn-1", "trace-agg")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="late_metric", run_id="late-0001")
+
+        first = _make_result(metric_identifier="ragas:answer_relevancy", score=0.8)
+        backend.save_run([first])
+        backend.save_result(
+            _make_result(metric_identifier="ragas:faithfulness", score=0.7)
+        )
+        backend.finalize()
+
+        assert _metric_score_count(mock_client) == 2
+        metric_calls = [
+            c
+            for c in mock_client.create_score.call_args_list
+            if not c.kwargs["name"].startswith("aggregate/")
+            and not c.kwargs["name"].startswith("eval/")
+        ]
+        assert {c.kwargs["name"] for c in metric_calls} == {
+            "ragas:answer_relevancy",
+            "ragas:faithfulness",
+        }
+        assert {c.kwargs["trace_id"] for c in metric_calls} == {"trace-turn-1"}
+        # One turn span + one aggregate span (no second turn span for late metric).
+        assert mock_client.start_as_current_observation.call_count == 2
+
+    def test_finalize_aggregate_failure_still_flushes(
+        self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Aggregate write errors must not skip the final SDK flush."""
+        mock_client = mocker.MagicMock()
+        _wire_mock_span(mock_client, mocker, "trace-t1")
+
+        backend = LangfuseStorageBackend(LangfuseBackendConfig())
+        backend._client = mock_client
+        backend._run_info = RunInfo(name="agg_fail", run_id="aggfail-0001")
+        backend._results = [_make_result()]
+
+        mocker.patch.object(
+            backend,
+            "_write_aggregate_summary",
+            side_effect=ConnectionError("aggregate failed"),
+        )
+
+        with caplog.at_level("ERROR"):
+            backend.finalize()
+
+        assert "failed to write aggregate summary" in caplog.text
+        mock_client.flush.assert_called_once()
+
+    def test_matches_structured_missing_field(self) -> None:
+        """Only type=missing with field in loc is treated as skew."""
+        exc = ValidationError.from_exception_data(
+            "DatasetItem",
+            [{"type": "missing", "loc": ("media_references",), "input": {}}],
+        )
+        assert _is_missing_field_validation_error(exc, "media_references") is True
+
+    def test_rejects_non_missing_errors_mentioning_field(self) -> None:
+        """Payload/type errors must not match via substring of the message."""
+        exc = ValidationError.from_exception_data(
+            "DatasetItem",
+            [{"type": "list_type", "loc": ("media_references",), "input": "x"}],
+        )
+        assert _is_missing_field_validation_error(exc, "media_references") is False
+        assert "media_references" in str(exc)
+
+    def test_compute_aggregate_scores_overall_and_per_metric(self) -> None:
+        """Aggregates include overall and per-metric mean/pass rate."""
+        results = [
+            _make_result(metric_identifier="ragas:relevancy", score=0.9, result="PASS"),
+            _make_result(metric_identifier="custom:accuracy", score=0.3, result="FAIL"),
+        ]
+        aggregates = _compute_aggregate_scores(results)
+        assert aggregates["aggregate/result_count"] == pytest.approx(2.0)
+        assert aggregates["aggregate/mean_score"] == pytest.approx(0.6)
+        assert aggregates["aggregate/pass_rate"] == pytest.approx(0.5)
+        assert aggregates["aggregate/mean_score/ragas:relevancy"] == pytest.approx(0.9)
+        assert aggregates["aggregate/pass_rate/custom:accuracy"] == pytest.approx(0.0)
+
+    def test_compute_aggregate_scores_skips_missing_numeric_scores(self) -> None:
+        """ERROR/SKIPPED rows without scores still count toward result_count."""
+        results = [
+            _make_result(score=None, result="ERROR"),
+            _make_result(score=0.8, result="PASS"),
+        ]
+        aggregates = _compute_aggregate_scores(results)
+        assert aggregates["aggregate/result_count"] == pytest.approx(2.0)
+        assert aggregates["aggregate/mean_score"] == pytest.approx(0.8)
+        assert aggregates["aggregate/pass_rate"] == pytest.approx(1.0)
 
 
 class TestLangfuseFactoryAndLoader:
@@ -204,3 +801,24 @@ class TestLangfuseFactoryAndLoader:
         assert len(configs) == 1
         assert isinstance(configs[0], LangfuseBackendConfig)
         assert configs[0].host == "https://cloud.langfuse.com"
+
+    def test_loader_parses_dataset_name(self) -> None:
+        """ConfigLoader parses optional dataset_name onto LangfuseBackendConfig."""
+        loader = ConfigLoader()
+        configs = loader._parse_storage_config(
+            [
+                {
+                    "type": "langfuse",
+                    "host": "https://cloud.langfuse.com",
+                    "dataset_name": "eval-baseline-v1",
+                }
+            ]
+        )
+        assert len(configs) == 1
+        assert isinstance(configs[0], LangfuseBackendConfig)
+        assert configs[0].dataset_name == "eval-baseline-v1"
+
+    def test_dataset_name_blank_normalized_to_none(self) -> None:
+        """Blank dataset_name normalizes to None on the config model."""
+        config = LangfuseBackendConfig(dataset_name="")
+        assert config.dataset_name is None


### PR DESCRIPTION
## Description

Optional Langfuse **Dataset run** linking for evaluation results (LEADS-572), on top of a **unified** Langfuse export path (MLflow-aligned).

### Unified export

1. **Incremental per-turn traces + scores** on each conversation `save_run`:
   - One trace per unique `(conversation_group_id, turn_id)` with CSV-shaped metadata
   - One numeric score per metric result on that turn trace
2. **Optional Dataset linking** when `dataset_name` is set (same turns → Datasets → Runs):
   - Upserts one Dataset **item** per turn
   - Creates a Dataset **run** named `{run_label}__{run_id[:8]}`
   - Creates one **run item** per turn linking the item to the turn trace
3. **Finalize aggregates + status** via `finalize(success=...)`:
   - Run-level `aggregate/*` scores (mean score, pass rate, per-metric means)
   - `eval_status` metadata and `eval/success` score (`complete` / `failed`)

When `dataset_name` is omitted or blank, traces/scores/aggregates are still exported; only Dataset linking is skipped.

Self-hosted Langfuse / SDK v4 response skew (`media_references` missing after HTTP 2xx) is tolerated for item and run-item creates. Unknown `ValidationError`s are re-raised. Dataset ensure/link failures and individual turn export failures are logged; remaining turns and end-of-run aggregates still run.

## Type of change

- [x] New feature

## Tools used to create PR

- Assisted-by: Grok 4.5
- Generated by: Cursor

## Related Tickets & Documents

- Related Issue: https://redhat.atlassian.net/browse/LEADS-572

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Install Langfuse extra: `pip install 'lightspeed-evaluation[langfuse]'` (or `uv sync --extra langfuse`).
2. Configure storage in `system.yaml` (optional `dataset_name` for Dataset linking).
3. Set `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` (and host if not inline).
4. Run evaluation and confirm per-turn traces appear as conversations complete, then aggregate + `eval/success` at finalize.
5. With `dataset_name` set, run twice and compare under **Datasets → Runs**.
6. Unit coverage: `uv run pytest tests/unit/core/storage/test_langfuse_storage.py`.

### Known notes

- Self-hosted Langfuse OSS may omit `media_references` in DatasetItem / run-item responses; treated as non-fatal after a successful create.
- Dataset/turn export failures are logged; remaining turns continue and finalize still writes aggregates + eval status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Langfuse exports now include per-turn traces, metric scores, and aggregate run summaries.
  * Optionally link results to a Langfuse Dataset for side-by-side comparisons and reusable runs.
  * Dataset items and run metadata include trace links and evaluation details.

* **Bug Fixes**
  * Blank dataset names are handled safely.
  * Export errors no longer interrupt evaluation results; scores-only export remains available.

* **Documentation**
  * Updated setup guidance covering dataset linking, score handling, and comparison workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->