### PR TITLE
chore: consistent datamodels for nxm

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/models.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/models.py
@@ -1,12 +1,14 @@
 """Models for NxM behavioral evaluation orchestration."""
 
-from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass
-class RunContext:
+
+class RunContext(BaseModel):
     """Serializable context for a single evaluation run."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     config_dict: dict[str, Any]
     eval_data_dicts: list[dict[str, Any]]
@@ -17,8 +19,39 @@ class RunContext:
     extra: Optional[dict[str, Any]] = None
 
 
-@dataclass
-class RunResult:
+class RunSummary(BaseModel):
+    """Per-run summary for orchestrator and eval_report.json.
+
+    Orchestrator sets status counts + tokens + latency.
+    Consolidation adds pass_rate, by_metric, quality_score for the report.
+
+    Field order: status → metrics → quality → agent → judge → embedding.
+    """
+
+    # Status counts
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    error: int = 0
+    skipped: int = 0
+    # Metrics (set by consolidation, not orchestrator)
+    run_index: Optional[int] = None
+    pass_rate: Optional[float] = None
+    by_metric: Optional[dict[str, float]] = None
+    # Quality (set by consolidation)
+    quality_score: Optional[float] = None
+    # Agent
+    agent_latency: float = 0.0
+    agent_input_tokens: int = 0
+    agent_output_tokens: int = 0
+    # Judge
+    judge_input_tokens: int = 0
+    judge_output_tokens: int = 0
+    # Embedding
+    embedding_tokens: int = 0
+
+
+class RunResult(BaseModel):
     """Result metadata from a single evaluation run."""
 
     agent_name: str
@@ -26,4 +59,36 @@ class RunResult:
     output_dir: str
     success: bool = False
     error: Optional[str] = None
-    summary: Optional[dict[str, Any]] = field(default_factory=dict)
+    summary: RunSummary = Field(default_factory=RunSummary)
+
+
+class AgentConsolidated(BaseModel):
+    """Aggregated stats for one agent across N runs.
+
+    Field order: identity → overall → breakdowns → quality → runs.
+    overall includes pass_rate, latency, and token stats (flat, prefixed).
+    quality is separate because it has its own composition (weighted metrics).
+    """
+
+    # Identity
+    agent_name: str
+    runs_requested: int
+    runs_succeeded: int
+    conversations_count: int
+    # Aggregated stats (pass_rate + latency + tokens in one flat dict)
+    overall: dict[str, Optional[float]] = {}
+    # Breakdowns
+    by_metric: dict[str, dict[str, Optional[float]]] = {}
+    by_conversation: dict[str, dict[str, Optional[float]]] = {}
+    # Quality score (separate — weighted aggregation with metric composition)
+    quality_score: Optional[dict[str, Any]] = None
+    # Per-run snapshots
+    per_run: list[RunSummary] = []
+
+
+class EvalReport(BaseModel):
+    """Top-level evaluation report."""
+
+    summary: dict[str, Any]
+    agents: dict[str, AgentConsolidated]
+    comparison: Optional[dict[str, Any]] = None

--- a/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
@@ -21,7 +21,11 @@ from lightspeed_evaluation.core.system.exceptions import (
     ConfigurationError,
     DataValidationError,
 )
-from lightspeed_evaluation.pipeline.behavioral.models import RunContext, RunResult
+from lightspeed_evaluation.pipeline.behavioral.models import (
+    RunContext,
+    RunResult,
+    RunSummary,
+)
 from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
 logger = logging.getLogger(__name__)
@@ -293,7 +297,7 @@ def _run_single(ctx: RunContext) -> RunResult:
                 run_index=ctx.run_index,
                 output_dir=ctx.run_output_dir,
                 success=True,
-                summary=_empty_summary(),
+                summary=RunSummary(),
             )
 
         pinned = _pin_conversations_to_agent(filtered, ctx.agent_name)
@@ -341,51 +345,39 @@ def _run_single(ctx: RunContext) -> RunResult:
         )
 
 
-def _make_summary(results: list) -> dict[str, Any]:
-    """Build summary dict from evaluation results.
+def _make_summary(results: list) -> RunSummary:
+    """Build summary from evaluation results.
 
     Judge/embedding tokens are summed per result (each metric has its own).
     API tokens are deduplicated per turn to avoid overcounting when a turn
     has multiple metrics.
     """
     seen_turns: set[tuple[str, str]] = set()
-    api_in = 0
-    api_out = 0
+    agent_in = 0
+    agent_out = 0
+    latencies = []
     for r in results:
         turn_key = (r.conversation_group_id, r.turn_id or "")
         if turn_key not in seen_turns:
             seen_turns.add(turn_key)
-            api_in += r.api_input_tokens
-            api_out += r.api_output_tokens
+            agent_in += r.api_input_tokens
+            agent_out += r.api_output_tokens
+            if r.agent_latency > 0:
+                latencies.append(r.agent_latency)
 
-    return {
-        "TOTAL": len(results),
-        "PASS": sum(1 for r in results if r.result == "PASS"),
-        "FAIL": sum(1 for r in results if r.result == "FAIL"),
-        "ERROR": sum(1 for r in results if r.result == "ERROR"),
-        "SKIPPED": sum(1 for r in results if r.result == "SKIPPED"),
-        "judge_llm_input_tokens": sum(r.judge_llm_input_tokens for r in results),
-        "judge_llm_output_tokens": sum(r.judge_llm_output_tokens for r in results),
-        "embedding_tokens": sum(r.embedding_tokens for r in results),
-        "api_input_tokens": api_in,
-        "api_output_tokens": api_out,
-    }
-
-
-def _empty_summary() -> dict[str, Any]:
-    """Return empty summary for runs with no matching conversations."""
-    return {
-        "TOTAL": 0,
-        "PASS": 0,
-        "FAIL": 0,
-        "ERROR": 0,
-        "SKIPPED": 0,
-        "judge_llm_input_tokens": 0,
-        "judge_llm_output_tokens": 0,
-        "embedding_tokens": 0,
-        "api_input_tokens": 0,
-        "api_output_tokens": 0,
-    }
+    return RunSummary(
+        total=len(results),
+        passed=sum(1 for r in results if r.result == "PASS"),
+        failed=sum(1 for r in results if r.result == "FAIL"),
+        error=sum(1 for r in results if r.result == "ERROR"),
+        skipped=sum(1 for r in results if r.result == "SKIPPED"),
+        agent_input_tokens=agent_in,
+        agent_output_tokens=agent_out,
+        agent_latency=sum(latencies) / len(latencies) if latencies else 0.0,
+        judge_input_tokens=sum(r.judge_llm_input_tokens for r in results),
+        judge_output_tokens=sum(r.judge_llm_output_tokens for r in results),
+        embedding_tokens=sum(r.embedding_tokens for r in results),
+    )
 
 
 def _warn_resource_usage(num_runs: int, config: SystemConfig) -> None:

--- a/src/lightspeed_evaluation/runner/evaluation.py
+++ b/src/lightspeed_evaluation/runner/evaluation.py
@@ -77,11 +77,10 @@ def _print_run_summary(
     run_results: Optional[list] = None,
     output_dir: Optional[str] = None,
 ) -> None:
-    """Print evaluation summary and token usage.
+    """Print evaluation summary.
 
     Args:
-        totals: Aggregated summary dict with TOTAL/PASS/FAIL/ERROR/SKIPPED
-            and token fields.
+        totals: Aggregated dict with TOTAL/PASS/FAIL/ERROR/SKIPPED.
         run_results: Run results from orchestrator (agent mode).
         output_dir: Explicit output directory (offline mode).
     """
@@ -111,47 +110,24 @@ def _print_run_summary(
     if totals.get("ERROR", 0) > 0:
         print(f"⚠️ {totals['ERROR']} evaluations had errors - check detailed report")
 
-    judge_in = totals.get("judge_llm_input_tokens", 0)
-    judge_out = totals.get("judge_llm_output_tokens", 0)
-    embed = totals.get("embedding_tokens", 0)
-    api_in = totals.get("api_input_tokens", 0)
-    api_out = totals.get("api_output_tokens", 0)
-
-    print("\n📊 Token Usage Summary:")
-    print(
-        f"Judge LLM: {judge_in + judge_out:,} tokens "
-        f"(Input: {judge_in:,}, Output: {judge_out:,})"
-    )
-    print(f"Embeddings: {embed:,} tokens")
-    if api_in + api_out > 0:
-        print(
-            f"API Calls: {api_in + api_out:,} tokens "
-            f"(Input: {api_in:,}, Output: {api_out:,})"
-        )
-    total_tokens = judge_in + judge_out + embed + api_in + api_out
-    if total_tokens > 0:
-        print(f"Total: {total_tokens:,} tokens")
-
 
 def _aggregate_totals(run_results: list) -> dict[str, int]:
-    """Aggregate summary totals from multiple run results."""
-    totals: dict[str, int] = {
-        "TOTAL": 0,
-        "PASS": 0,
-        "FAIL": 0,
-        "ERROR": 0,
-        "SKIPPED": 0,
-        "judge_llm_input_tokens": 0,
-        "judge_llm_output_tokens": 0,
-        "embedding_tokens": 0,
-        "api_input_tokens": 0,
-        "api_output_tokens": 0,
-    }
+    """Aggregate status counts from multiple run results."""
+    total = passed = failed = error = skipped = 0
     for rr in run_results:
         if rr.summary:
-            for key, val in rr.summary.items():
-                totals[key] = totals.get(key, 0) + val
-    return totals
+            total += rr.summary.total
+            passed += rr.summary.passed
+            failed += rr.summary.failed
+            error += rr.summary.error
+            skipped += rr.summary.skipped
+    return {
+        "TOTAL": total,
+        "PASS": passed,
+        "FAIL": failed,
+        "ERROR": error,
+        "SKIPPED": skipped,
+    }
 
 
 def _copy_flat_output(run_results: list, output_dir: str) -> None:
@@ -182,8 +158,7 @@ def run_evaluation(  # pylint: disable=too-many-locals
         eval_args: Parsed command line arguments
 
     Returns:
-        dict: Summary statistics with keys TOTAL, PASS, FAIL, ERROR, SKIPPED
-            and token usage fields (judge_llm, embedding, api).
+        dict: Summary statistics with keys TOTAL, PASS, FAIL, ERROR, SKIPPED.
     """
     print("🚀 Lightspeed Evaluation Framework")
     print("=" * 50)
@@ -236,18 +211,7 @@ def run_evaluation(  # pylint: disable=too-many-locals
         if len(evaluation_data) == 0:
             print("\n⚠️ No conversation groups matched the filter criteria")
             print("   Nothing to evaluate - returning empty results")
-            return {
-                "TOTAL": 0,
-                "PASS": 0,
-                "FAIL": 0,
-                "ERROR": 0,
-                "SKIPPED": 0,
-                "judge_llm_input_tokens": 0,
-                "judge_llm_output_tokens": 0,
-                "embedding_tokens": 0,
-                "api_input_tokens": 0,
-                "api_output_tokens": 0,
-            }
+            return {"TOTAL": 0, "PASS": 0, "FAIL": 0, "ERROR": 0, "SKIPPED": 0}
 
         # Run evaluation
         print("\n🔄 Running Evaluation...")
@@ -289,11 +253,6 @@ def run_evaluation(  # pylint: disable=too-many-locals
                 "FAIL": summary.failed,
                 "ERROR": summary.error,
                 "SKIPPED": summary.skipped,
-                "judge_llm_input_tokens": summary.total_judge_llm_input_tokens,
-                "judge_llm_output_tokens": summary.total_judge_llm_output_tokens,
-                "embedding_tokens": summary.total_embedding_tokens,
-                "api_input_tokens": 0,
-                "api_output_tokens": 0,
             }
             print("\n🎉 Evaluation Complete!")
             _print_run_summary(totals, output_dir=out_dir)

--- a/tests/unit/pipeline/behavioral/test_orchestrator.py
+++ b/tests/unit/pipeline/behavioral/test_orchestrator.py
@@ -271,11 +271,11 @@ class TestMakeSummary:
             ),
         ]
         summary = _make_summary(results)
-        assert summary["api_input_tokens"] == 100
-        assert summary["api_output_tokens"] == 50
-        assert summary["judge_llm_input_tokens"] == 350
-        assert summary["judge_llm_output_tokens"] == 140
-        assert summary["embedding_tokens"] == 15
+        assert summary.agent_input_tokens == 100
+        assert summary.agent_output_tokens == 50
+        assert summary.judge_input_tokens == 350
+        assert summary.judge_output_tokens == 140
+        assert summary.embedding_tokens == 15
 
     def test_different_turns_counted_separately(self) -> None:
         """API tokens from different turns are summed."""
@@ -298,8 +298,43 @@ class TestMakeSummary:
             ),
         ]
         summary = _make_summary(results)
-        assert summary["api_input_tokens"] == 300
-        assert summary["api_output_tokens"] == 130
+        assert summary.agent_input_tokens == 300
+        assert summary.agent_output_tokens == 130
+
+    def test_latency_averages_positive_values(self) -> None:
+        """Agent latency is the mean of positive per-turn latencies."""
+        results = [
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="m1",
+                result="PASS",
+                agent_latency=2.0,
+            ),
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t2",
+                metric_identifier="m1",
+                result="PASS",
+                agent_latency=4.0,
+            ),
+        ]
+        summary = _make_summary(results)
+        assert summary.agent_latency == 3.0
+
+    def test_latency_zero_when_no_positive(self) -> None:
+        """Returns 0.0 when no turn has positive latency."""
+        results = [
+            EvaluationResult(
+                conversation_group_id="c1",
+                turn_id="t1",
+                metric_identifier="m1",
+                result="PASS",
+                agent_latency=0.0,
+            ),
+        ]
+        summary = _make_summary(results)
+        assert summary.agent_latency == 0.0
 
 
 class TestRunOrchestrator:

--- a/tests/unit/runner/test_evaluation.py
+++ b/tests/unit/runner/test_evaluation.py
@@ -24,7 +24,7 @@ from lightspeed_evaluation.core.system.exceptions import (
     DataValidationError,
     StorageError,
 )
-from lightspeed_evaluation.pipeline.behavioral.models import RunResult
+from lightspeed_evaluation.pipeline.behavioral.models import RunResult, RunSummary
 from lightspeed_evaluation.runner.evaluation import (
     _aggregate_totals,
     _clear_caches,
@@ -107,7 +107,7 @@ def _setup_runner_mocks(
                 run_index=1,
                 output_dir="/tmp/out",
                 success=True,
-                summary={"TOTAL": 1, "PASS": 1, "FAIL": 0, "ERROR": 0, "SKIPPED": 0},
+                summary=RunSummary(total=1, passed=1),
             )
         ]
 
@@ -191,13 +191,7 @@ class TestRunEvaluation:
                     run_index=1,
                     output_dir="/tmp/out",
                     success=True,
-                    summary={
-                        "TOTAL": 1,
-                        "PASS": 1,
-                        "FAIL": 0,
-                        "ERROR": 0,
-                        "SKIPPED": 0,
-                    },
+                    summary=RunSummary(total=1, passed=1),
                 )
             ],
         )
@@ -309,13 +303,7 @@ class TestRunEvaluation:
                     run_index=1,
                     output_dir="/tmp/out",
                     success=True,
-                    summary={
-                        "TOTAL": 10,
-                        "PASS": 5,
-                        "FAIL": 2,
-                        "ERROR": 3,
-                        "SKIPPED": 0,
-                    },
+                    summary=RunSummary(total=10, passed=5, failed=2, error=3),
                 )
             ],
         )
@@ -684,13 +672,7 @@ class TestRunEvaluationCacheWarmup:
                     run_index=1,
                     output_dir="/tmp/out",
                     success=True,
-                    summary={
-                        "TOTAL": 1,
-                        "PASS": 1,
-                        "FAIL": 0,
-                        "ERROR": 0,
-                        "SKIPPED": 0,
-                    },
+                    summary=RunSummary(total=1, passed=1),
                 )
             ],
         )
@@ -841,75 +823,62 @@ class TestMain:
 class TestAggregateTotals:
     """Tests for _aggregate_totals helper."""
 
-    def test_aggregates_all_fields(self) -> None:
-        """All token and status fields are summed across runs."""
+    def test_aggregates_status_counts(self) -> None:
+        """Status counts are summed across runs."""
         results = [
             RunResult(
                 agent_name="a",
                 run_index=1,
                 output_dir="/out",
                 success=True,
-                summary={
-                    "TOTAL": 3,
-                    "PASS": 2,
-                    "FAIL": 1,
-                    "ERROR": 0,
-                    "SKIPPED": 0,
-                    "judge_llm_input_tokens": 100,
-                    "judge_llm_output_tokens": 50,
-                    "embedding_tokens": 10,
-                    "api_input_tokens": 200,
-                    "api_output_tokens": 80,
-                },
+                summary=RunSummary(total=3, passed=2, failed=1),
             ),
             RunResult(
                 agent_name="b",
                 run_index=1,
                 output_dir="/out2",
                 success=True,
-                summary={
-                    "TOTAL": 2,
-                    "PASS": 1,
-                    "FAIL": 0,
-                    "ERROR": 1,
-                    "SKIPPED": 0,
-                    "judge_llm_input_tokens": 50,
-                    "judge_llm_output_tokens": 20,
-                    "embedding_tokens": 5,
-                    "api_input_tokens": 100,
-                    "api_output_tokens": 40,
-                },
+                summary=RunSummary(total=2, passed=1, error=1),
             ),
         ]
         totals = _aggregate_totals(results)
-        assert totals["TOTAL"] == 5
-        assert totals["PASS"] == 3
-        assert totals["FAIL"] == 1
-        assert totals["ERROR"] == 1
-        assert totals["judge_llm_input_tokens"] == 150
-        assert totals["api_input_tokens"] == 300
-        assert totals["embedding_tokens"] == 15
+        assert totals == {
+            "TOTAL": 5,
+            "PASS": 3,
+            "FAIL": 1,
+            "ERROR": 1,
+            "SKIPPED": 0,
+        }
 
-    def test_skips_none_summary(self) -> None:
-        """Runs with no summary are skipped."""
+    def test_default_summary_contributes_zeros(self) -> None:
+        """Failed runs with default summary contribute zero counts."""
         results = [
             RunResult(
                 agent_name="a",
                 run_index=1,
                 output_dir="/out",
                 success=False,
-                summary=None,
             ),
         ]
         totals = _aggregate_totals(results)
-        assert totals["TOTAL"] == 0
-        assert totals["judge_llm_input_tokens"] == 0
+        assert totals == {
+            "TOTAL": 0,
+            "PASS": 0,
+            "FAIL": 0,
+            "ERROR": 0,
+            "SKIPPED": 0,
+        }
 
     def test_empty_results(self) -> None:
         """Empty results list returns zeroed totals."""
         totals = _aggregate_totals([])
-        assert totals["TOTAL"] == 0
-        assert all(v == 0 for v in totals.values())
+        assert totals == {
+            "TOTAL": 0,
+            "PASS": 0,
+            "FAIL": 0,
+            "ERROR": 0,
+            "SKIPPED": 0,
+        }
 
 
 class TestCopyFlatOutput:


### PR DESCRIPTION
## Description

New Pydantic models: RunSummary, AgentConsolidated, EvalReport for consolidation (PR 2 foundation)
RunContext/RunResult converted from dataclass to Pydantic
CI return narrowed to 5 keys only — tokens/latency removed from console and return dict
Field naming: agent_* not api_*, judge_* not judge_llm_*, latency in seconds

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced typed, structured run summary reporting (status counts with optional quality/latency breakdowns) and consolidated per-agent evaluation summaries, along with a top-level evaluation report object.

- **Improvements**
  - Standardized summaries for completed, empty, and offline evaluations using consistent zero-value defaults.
  - Updated aggregation behavior: token/usage totals were removed from evaluation-run reporting, and token fields are no longer included for empty/offline results.
  - Updated tests to reflect the new structured summary APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->