### PR TITLE
feat: split per-agent report from eval_report and remove data duplication

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/orchestrator.py
@@ -31,7 +31,10 @@ from lightspeed_evaluation.pipeline.behavioral.models import (
     RunResult,
     RunSummary,
 )
-from lightspeed_evaluation.pipeline.behavioral.report import save_report
+from lightspeed_evaluation.pipeline.behavioral.report import (
+    save_agent_report,
+    save_report,
+)
 from lightspeed_evaluation.pipeline.evaluation import EvaluationPipeline
 
 if TYPE_CHECKING:
@@ -401,7 +404,7 @@ def _build_and_save_report(
     repeat: int,
     timestamp: str,
 ) -> None:
-    """Consolidate results and save eval_report.json.
+    """Consolidate results and save agent + eval reports.
 
     Wrapped in try/except — consolidation failure does not fail the evaluation.
     """
@@ -429,6 +432,9 @@ def _build_and_save_report(
                 agent_name, runs_data, runs_requested=repeat
             )
 
+        for agent_name, agent in consolidated.items():
+            save_agent_report(agent, os.path.join(eval_dir, agent_name))
+
         comparable = {
             name: agent
             for name, agent in consolidated.items()
@@ -447,8 +453,7 @@ def _build_and_save_report(
             agents=consolidated,
             comparison=comparison,
         )
-        path = save_report(report, eval_dir)
-        logger.info("Eval report: %s", path)
+        logger.info("Eval report: %s", save_report(report, eval_dir))
     except Exception:  # pylint: disable=broad-exception-caught
         logger.error("Failed to generate eval report: %s", traceback.format_exc())
 

--- a/src/lightspeed_evaluation/pipeline/behavioral/report.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/report.py
@@ -1,13 +1,60 @@
-"""Save eval_report.json."""
+"""Save per-agent and comparison reports."""
 
 import json
 import os
 
-from lightspeed_evaluation.pipeline.behavioral.models import EvalReport
+from lightspeed_evaluation.pipeline.behavioral.models import (
+    AgentConsolidated,
+    EvalReport,
+)
+
+_AGENT_REPORT_FIELDS = {
+    "agent_name",
+    "runs_requested",
+    "runs_succeeded",
+    "conversations_count",
+    "overall",
+    "by_metric",
+    "by_conversation",
+    "quality_score",
+}
+
+_EVAL_REPORT_AGENT_FIELDS = {
+    "agent_name",
+    "runs_requested",
+    "runs_succeeded",
+    "conversations_count",
+    "overall",
+}
+
+
+def save_agent_report(agent: AgentConsolidated, agent_dir: str) -> str:
+    """Save per-agent consolidation report.
+
+    Contains cross-run aggregations only. Per-run detail is in the
+    run-level files. Adjust _AGENT_REPORT_FIELDS to expand.
+
+    Args:
+        agent: Consolidated agent data.
+        agent_dir: Agent's output directory (eval_<ts>/agent_name/).
+
+    Returns:
+        Path to the saved file.
+    """
+    os.makedirs(agent_dir, exist_ok=True)
+    path = os.path.join(agent_dir, "agent_report.json")
+    data = agent.model_dump(exclude_none=True)
+    data = {k: v for k, v in data.items() if k in _AGENT_REPORT_FIELDS}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return path
 
 
 def save_report(report: EvalReport, output_dir: str) -> str:
-    """Serialize and save eval_report.json.
+    """Save evaluation report with agent headlines and comparison.
+
+    Per-agent fields controlled by _EVAL_REPORT_AGENT_FIELDS.
+    Full agent detail is in agent_report.json.
 
     Args:
         report: The EvalReport to save.
@@ -18,6 +65,11 @@ def save_report(report: EvalReport, output_dir: str) -> str:
     """
     os.makedirs(output_dir, exist_ok=True)
     path = os.path.join(output_dir, "eval_report.json")
+    data = report.model_dump(exclude_none=True)
+    data["agents"] = {
+        name: {k: v for k, v in agent.items() if k in _EVAL_REPORT_AGENT_FIELDS}
+        for name, agent in data["agents"].items()
+    }
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(report.model_dump(exclude_none=True), f, indent=2)
+        json.dump(data, f, indent=2)
     return path

--- a/tests/unit/pipeline/behavioral/test_orchestrator.py
+++ b/tests/unit/pipeline/behavioral/test_orchestrator.py
@@ -550,6 +550,9 @@ class TestBuildAndSaveReport:
         mock_save = mocker.patch(
             "lightspeed_evaluation.pipeline.behavioral.orchestrator.save_report"
         )
+        mock_agent_save = mocker.patch(
+            "lightspeed_evaluation.pipeline.behavioral.orchestrator.save_agent_report"
+        )
 
         results = [
             RunResult(
@@ -564,10 +567,10 @@ class TestBuildAndSaveReport:
             results, str(tmp_path), repeat=1, timestamp="20260810_120000"
         )
 
+        mock_agent_save.assert_called_once()
         mock_save.assert_called_once()
         report = mock_save.call_args[0][0]
         assert "model_a" in report.agents
-        assert report.agents["model_a"].agent_name == "model_a"
         assert report.agents["model_a"].runs_requested == 1
         assert report.comparison is None
         assert report.summary.total_agents == 1

--- a/tests/unit/pipeline/behavioral/test_report.py
+++ b/tests/unit/pipeline/behavioral/test_report.py
@@ -7,54 +7,95 @@ from lightspeed_evaluation.pipeline.behavioral.models import (
     AgentConsolidated,
     EvalMetadata,
     EvalReport,
+    RunSummary,
 )
-from lightspeed_evaluation.pipeline.behavioral.report import save_report
+from lightspeed_evaluation.pipeline.behavioral.report import (
+    _AGENT_REPORT_FIELDS,
+    _EVAL_REPORT_AGENT_FIELDS,
+    save_agent_report,
+    save_report,
+)
+
+
+def _make_agent() -> AgentConsolidated:
+    """Build an AgentConsolidated with all fields populated."""
+    return AgentConsolidated(
+        agent_name="model_a",
+        runs_requested=2,
+        runs_succeeded=2,
+        conversations_count=5,
+        overall={"pass_rate_mean": 85.0, "pass_rate_std": 5.0},
+        by_metric={"ragas:faithfulness": {"mean": 0.9, "std": 0.05}},
+        by_conversation={"conv_1": {"pass_rate_mean": 80.0}},
+        quality_score={"mean": 0.85, "metrics": {}},
+        per_run=[RunSummary(run_index=1, total=10, passed=8)],
+    )
 
 
 def _make_report() -> EvalReport:
-    """Build a minimal EvalReport for testing."""
+    """Build a minimal EvalReport."""
     return EvalReport(
         summary=EvalMetadata(
-            timestamp="20260810_120000",
+            timestamp="2026-08-11T04:45:36+00:00",
             total_agents=1,
             total_runs=2,
             repeat=1,
         ),
-        agents={
-            "model_a": AgentConsolidated(
-                agent_name="model_a",
-                runs_requested=2,
-                runs_succeeded=2,
-                conversations_count=5,
-                overall={"pass_rate_mean": 85.0, "pass_rate_std": 5.0},
-            ),
-        },
+        agents={"model_a": _make_agent()},
     )
+
+
+class TestSaveAgentReport:
+    """Tests for save_agent_report()."""
+
+    def test_has_aggregated_data(self, tmp_path: Path) -> None:
+        """Agent report contains cross-run aggregations."""
+        path = save_agent_report(_make_agent(), str(tmp_path))
+
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert data["agent_name"] == "model_a"
+        assert data["overall"]["pass_rate_mean"] == 85.0
+        assert "ragas:faithfulness" in data["by_metric"]
+        assert "conv_1" in data["by_conversation"]
+        assert "quality_score" in data
+
+    def test_excludes_per_run(self, tmp_path: Path) -> None:
+        """Per-run snapshots are in run-level files, not agent report."""
+        path = save_agent_report(_make_agent(), str(tmp_path))
+
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert "per_run" not in data
 
 
 class TestSaveReport:
     """Tests for save_report()."""
 
-    def test_writes_json(self, tmp_path: Path) -> None:
-        """Saves eval_report.json with correct structure."""
-        report = _make_report()
-
-        path = save_report(report, str(tmp_path))
-
-        assert Path(path).exists()
-        assert Path(path).name == "eval_report.json"
-        data = json.loads(Path(path).read_text(encoding="utf-8"))
-        assert "summary" in data
-        assert data["summary"]["timestamp"] == "20260810_120000"
-        assert "agents" in data
-        assert "model_a" in data["agents"]
-
-    def test_excludes_none_fields(self, tmp_path: Path) -> None:
-        """None fields are excluded from output."""
-        report = _make_report()
-
-        path = save_report(report, str(tmp_path))
+    def test_agent_headlines_only(self, tmp_path: Path) -> None:
+        """Eval report has agent identity and overall stats."""
+        path = save_report(_make_report(), str(tmp_path))
 
         data = json.loads(Path(path).read_text(encoding="utf-8"))
-        assert "comparison" not in data
-        assert "quality_score" not in data["agents"]["model_a"]
+        agent = data["agents"]["model_a"]
+        assert "overall" in agent
+        assert "agent_name" in agent
+        assert "by_metric" not in agent
+        assert "by_conversation" not in agent
+        assert "per_run" not in agent
+        assert "quality_score" not in agent
+
+    def test_has_summary(self, tmp_path: Path) -> None:
+        """Eval report has metadata."""
+        path = save_report(_make_report(), str(tmp_path))
+
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert data["summary"]["timestamp"] == "2026-08-11T04:45:36+00:00"
+        assert data["summary"]["total_agents"] == 1
+
+
+def test_field_sets_cover_all_model_fields() -> None:
+    """Guard: every AgentConsolidated field is in a field set or explicitly excluded."""
+    all_fields = set(AgentConsolidated.model_fields.keys())
+    covered = _AGENT_REPORT_FIELDS | _EVAL_REPORT_AGENT_FIELDS | {"per_run"}
+    assert (
+        all_fields == covered
+    ), f"New fields not in any field set: {all_fields - covered}"


### PR DESCRIPTION
## Description

1. New agent_report.json per agent at eval_<ts>/agent_name/ — contains cross-run aggregations: by_metric, by_conversation, quality_score
2. eval_report.json slimmed to agent headlines (identity + overall) + comparison (deltas, rankings)
3. per_run excluded from both reports — raw data lives in per-run files only
4. Field sets (_AGENT_REPORT_FIELDS, _EVAL_REPORT_AGENT_FIELDS) control what each report includes — easy to expand
5. No model changes, no consolidation changes — purely output structure

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Behavioral evaluations now provide a dedicated report for each consolidated agent.
  - Aggregate evaluation reports now present concise headline information for each agent, while detailed results remain available in the individual reports.
  - Report metadata uses standardized ISO-8601 timestamps for improved consistency and readability.

- **Tests**
  - Expanded coverage verifies individual and aggregate report contents and confirms complete agent data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->