### PR TITLE
[LEADS-510] Loop and cycle detection in agent execution

### DIFF
--- a/.ai/spec/how/metrics-implementation.md
+++ b/.ai/spec/how/metrics-implementation.md
@@ -13,6 +13,7 @@
 | `core/metrics/custom/custom.py` | `CustomMetrics` | Custom LLM-based metric handler |
 | `core/metrics/custom/keywords_eval.py` | — | Keyword matching evaluation logic |
 | `core/metrics/custom/tool_eval.py` | — | Tool use evaluation logic |
+| `core/metrics/custom/loop_eval.py` | — | Deterministic tool-loop / thrashing / recursive-depth detection |
 | `core/metrics/custom/proposal_eval.py` | `evaluate_proposal_status()` | Proposal status assertion metric (phase, duration, attempts, conditions) |
 | `core/metrics/custom/prompts.py` | — | Prompt templates for custom metrics |
 | `pipeline/evaluation/evaluator.py` | `MetricsEvaluator` | Metric dispatch, multi-expected-response logic, status determination |

--- a/.ai/spec/how/project-structure.md
+++ b/.ai/spec/how/project-structure.md
@@ -28,6 +28,7 @@
 | `core/metrics/custom/custom.py` | `CustomMetrics` | Custom LLM-based metric handler |
 | `core/metrics/custom/keywords_eval.py` | — | Keyword matching evaluation |
 | `core/metrics/custom/tool_eval.py` | — | Tool use evaluation |
+| `core/metrics/custom/loop_eval.py` | — | Tool-loop / thrashing detection |
 | `core/metrics/custom/proposal_eval.py` | `evaluate_proposal_status()` | Proposal status assertion metric |
 | `core/metrics/custom/prompts.py` | — | Prompt templates for custom metrics |
 | `core/llm/manager.py` | `LLMManager` | LLM provider abstraction, judge panel creation |

--- a/.ai/spec/what/metrics.md
+++ b/.ai/spec/what/metrics.md
@@ -9,7 +9,7 @@ Metrics are the scoring functions that evaluate LLM-powered application outputs 
 - **Ragas metrics** (`ragas:*`): RAG evaluation — faithfulness, response_relevancy, context_relevance, context_precision, context_recall, context_utilization. Require LLM judge and often embedding model.
 - **DeepEval metrics** (`deepeval:*`): Conversation-level analysis — conversation_completeness, conversation_relevancy, knowledge_retention. Require LLM judge.
 - **User-defined criteria** (`geval:*`): LLM-as-judge with custom evaluation criteria defined in metric metadata (powered by DeepEval's GEval). Require LLM judge.
-- **Custom metrics** (`custom:*`): Domain-specific evaluation registered under the custom framework. Some use LLM judges (answer_correctness, intent_eval, proposal_evaluation_correctness), others use pure comparison logic without LLM (keywords_eval, tool_eval, proposal_status).
+- **Custom metrics** (`custom:*`): Domain-specific evaluation registered under the custom framework. Some use LLM judges (answer_correctness, intent_eval, proposal_evaluation_correctness), others use pure comparison logic without LLM (keywords_eval, tool_eval, loop_eval, proposal_status).
 - **NLP metrics** (`nlp:*`): No-LLM statistical metrics — BLEU, ROUGE, semantic similarity distance. No judge required.
 - **Script metrics** (`script:*`): External Python scripts that perform real-world validation (e.g., OpenShift state checks). No judge required.
 

--- a/.claude/skills/eval-init/SKILL.md
+++ b/.claude/skills/eval-init/SKILL.md
@@ -39,6 +39,7 @@ Frame as outcomes, not framework terminology. One at a time.
 | Context quality | `ragas:context_precision`, `ragas:context_recall` | response, contexts, expected_response |
 | Context relevance | `ragas:context_relevance`, `ragas:context_utilization` | response, contexts |
 | Tool correctness | `custom:tool_eval` | tool_calls, expected_tool_calls |
+| Tool looping / thrashing | `custom:loop_eval` | tool_calls |
 | Keywords | `custom:keywords_eval` | response, expected_keywords |
 | Intent | `custom:intent_eval` | response, expected_intent |
 | Text similarity | `nlp:bleu`, `nlp:rouge`, `nlp:semantic_similarity_distance` | response, expected_response |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ uv run lightspeed-eval --system-config <AGENTS_CONFIG.yaml> --eval-data <AGENTIC
     - [`keywords_eval`](src/lightspeed_evaluation/core/metrics/custom/keywords_eval.py) - Keywords evaluation with alternatives (ALL keywords must match, case insensitive)
   - Tool Evaluation
     - [`tool_eval`](src/lightspeed_evaluation/core/metrics/custom/tool_eval.py) - Validates tool calls, arguments, and optional results with regex pattern matching
+    - [`loop_eval`](src/lightspeed_evaluation/core/metrics/custom/loop_eval.py) - Detects exact tool loops, same-tool thrashing, and excessive recursive call depth (no LLM)
   - Agentic Workflow Evaluation
     - [`openshift_agentic_run_status`](src/lightspeed_evaluation/core/metrics/custom/openshift_agentic_run_eval.py) - Deterministic assertions on AgenticRun CRD status (phase, timing, analysis, execution, verification)
     - [`openshift_agentic_run_evaluation_correctness`](src/lightspeed_evaluation/core/metrics/custom/custom.py) - LLM-as-judge evaluation of agentic remediation workflow quality (diagnosis, actions, risk, verification)
@@ -431,6 +432,7 @@ Examples
 > - `expected_response`: Required for `custom:answer_correctness`
 > - `expected_intent`: Required for `custom:intent_eval`
 > - `expected_tool_calls`: Required for `custom:tool_eval` (multiple alternative sets format)
+> - `tool_calls`: Required for `custom:loop_eval` (empty list is valid: no loops). Also required for `custom:tool_eval`
 > - `verify_script`: Required for `script:action_eval` (used when API is enabled)
 > - `response`: Required for most metrics (auto-populated if API enabled)
 > - `openshift_agentic_run_spec`: Required for `custom:openshift_agentic_run_status` (CRD-based agent workflows)

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -163,6 +163,14 @@ metrics_metadata:
       ordered: true       # true (default): sequence order matters, false: any order allowed
       full_match: true    # true (default): exact 1:1 match, false: expected tools found in actual (extras allowed)
 
+    "custom:loop_eval":
+      threshold: 1.0  # 1.0 = no loops; any detected loop fails unless threshold is lowered
+      description: "Detect exact tool loops, soft thrashing, and excessive recursive call depth"
+      exact_loop_threshold: 3    # consecutive identical tool+args
+      soft_loop_threshold: 3     # consecutive same tool, any args
+      max_recursive_depth: 10    # parent-child span/tool chain depth
+      default: false
+
     "custom:openshift_agentic_run_evaluation_correctness":
       threshold: 0.75
       description: "LLM judge of OpenShift agentic remediation workflow quality (diagnosis, actions, risk, verification)"
@@ -244,6 +252,14 @@ metrics_metadata:
     "deepeval:knowledge_retention":
       threshold: 0.7
       description: "How well the model retains information from previous turns"
+
+    "custom:loop_eval":
+      threshold: 1.0
+      description: "Detect exact tool loops, soft thrashing, and excessive recursive call depth within each turn"
+      exact_loop_threshold: 3
+      soft_loop_threshold: 3
+      max_recursive_depth: 10
+      default: false
 
     # GEval conversation-level metrics (criteria = required; evaluation_steps, rubrics = optional)
     "geval:conversation_coherence":

--- a/docs/EVALUATION_GUIDE.md
+++ b/docs/EVALUATION_GUIDE.md
@@ -420,6 +420,56 @@ expected_tool_calls:
 
 ---
 
+#### Loop Evaluation
+
+**What it measures:** Did the agent get stuck repeating the same tool instead of making progress?
+
+**Plain English:** "Did the agent call the same tool over and over (same or similar arguments), or nest tool calls too deeply?"
+
+**Score:** 1.0 = no loops, down to 0.0 = severe looping
+
+**How it works (deterministic, no LLM):**
+- **Exact loop:** same tool + identical arguments N+ times consecutively (default N=3)
+- **Soft loop:** same tool N+ times consecutively regardless of arguments (thrashing)
+- **Recursive depth:** number of spans in the parent chain (including the root and the current span) greater than `max_recursive_depth` (default 10). Put `span_id` / `parent_span_id` on each dict inside `turns[].tool_calls` (`list[list[dict]]`). Evaluation YAML has no `traces` or `trace` field. A separate Python helper (`evaluate_loops_from_trace`) can score a normalized `Trace`; that is not eval YAML input and is not used by the evaluation pipeline.
+
+**Conversation-level:** Detection stays inside each turn. Consecutive calls are not joined across queries, because repeating a tool for a new user question is not thrashing. The conversation score is the worst per-turn finding.
+
+This is **not** an extension of `custom:tool_eval`. `tool_eval` matches actual calls against expected calls. `loop_eval` only looks at the actual sequence. Ragas and DeepEval do not provide loop detection; GEval can approximate it subjectively if you prefer an LLM judge.
+
+**Example:**
+```yaml
+turns:
+  - turn_id: "stuck-search"
+    query: "Find the crashlooping pod"
+    tool_calls:
+      - - tool_name: search
+          arguments: {q: crashloop}
+      - - tool_name: search
+          arguments: {q: crashloop}
+      - - tool_name: search
+          arguments: {q: crashloop}
+    turn_metrics:
+      - custom:loop_eval
+```
+
+**Configuration** (system or turn `metrics_metadata`):
+```yaml
+"custom:loop_eval":
+  threshold: 1.0                 # any detected loop fails
+  exact_loop_threshold: 3
+  soft_loop_threshold: 3
+  max_recursive_depth: 10
+```
+
+**When to use:** Tool-calling agents in production that may retry or recurse without making progress
+
+**Threshold:** 1.0 (any loop fails unless you lower it)
+
+**Required fields:** `tool_calls` (empty list is valid and scores 1.0)
+
+---
+
 #### Proposal Evaluation Correctness
 
 **What it measures:** How good is the agentic remediation workflow? Evaluates diagnosis, actions, risk management, and verification.
@@ -692,7 +742,8 @@ What are you evaluating?
 │  │
 │  ├─ Tool Calls & AI Behavior?
 │  │  ├─ Right intent? → intent_eval
-│  │  └─ Right tools + arguments? → tool_eval
+│  │  ├─ Right tools + arguments? → tool_eval
+│  │  └─ Stuck repeating tools? → loop_eval
 │  │
 │  ├─ Agentic Workflows?
 │  │  ├─ Workflow reached expected state? → proposal_status
@@ -740,6 +791,7 @@ conversation_metrics:
 ```yaml
 turn_metrics:
   - custom:tool_eval            # Right tool + params?
+  - custom:loop_eval            # Not stuck repeating tools?
   - ragas:response_relevancy    # Good explanation?
 ```
 
@@ -1660,7 +1712,7 @@ exit $?
 |----------|---------------------|
 | Customer Support (Single Q&A) | response_relevancy, faithfulness, answer_correctness |
 | Multi-turn Conversations | conversation_completeness, knowledge_retention |
-| Tool-calling Agents | tool_eval, response_relevancy |
+| Tool-calling Agents | tool_eval, loop_eval, response_relevancy |
 | Infrastructure Automation | script:action_eval, tool_eval |
 
 ### 3. Set Realistic Thresholds
@@ -1830,6 +1882,7 @@ response: "This is the answer"
 | answer_correctness | query, response, expected_response |
 | intent_eval | query, response, expected_intent |
 | tool_eval | expected_tool_calls, tool_calls |
+| loop_eval | tool_calls |
 | action_eval | verify_script (API mode) |
 
 ---
@@ -1994,6 +2047,7 @@ lightspeed-eval --eval-data config/eval_batch2.yaml
 | **custom:answer_correctness** | 0-1 | Matches expected answer | 0.75 | query, response, expected_response |
 | **custom:intent_eval** | 0/1 | Has right intent | 1 | query, response, expected_intent |
 | **custom:tool_eval** | 0/1 | Called correct tools with expected results | 1 | expected_tool_calls, tool_calls |
+| **custom:loop_eval** | 0-1 | No exact/soft tool loops or excessive recursive depth | 1 | tool_calls |
 | **custom:proposal_evaluation_correctness** | 0-1 | Agentic workflow quality (diagnosis, actions, risk) | 0.75 | response (workflow summary) |
 | **custom:keywords_eval** | 0/1 | Expected keywords present | 1 | response, expected_keywords |
 | **custom:proposal_status** | 0/1 | Proposal CRD reached expected state | 1 | expected_proposal_status |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,6 +311,57 @@ For **user-defined criteria** metrics (`geval:...`), you can define custom evalu
 
 User-defined criteria metrics return a score in **[0, 1]**.
 
+For **`custom:loop_eval`** (turn-level and conversation-level), additional keys control detection.
+
+**Eval-data contract:** The pipeline reads `turns[].tool_calls` only (`list[list[dict]]`). Evaluation YAML has no `traces` or `trace` field — do not submit MLflow, Langfuse, or OpenTelemetry payloads as a sibling of `tool_calls`. Recursive depth uses optional identity keys **on each tool-call dict**, not a nested `Trace` object:
+
+```yaml
+turns:
+  - turn_id: nested_tools
+    query: Diagnose nested agent tool use
+    tool_calls:
+      - - tool_name: plan          # also accepts name
+          arguments: {}            # also accepts args
+          span_id: s1              # optional; also accepts id
+      - - tool_name: search
+          arguments:
+            q: pods
+          span_id: s2
+          parent_span_id: s1       # optional; also accepts parent_id
+      - - tool_name: oc_get
+          arguments:
+            kind: pod
+          span_id: s3
+          parent_span_id: s2
+```
+
+`evaluate_loops_from_trace` can score a normalized `Trace` from Python after adapter conversion. That helper is not configuration, not eval-data input, and is not called by `lightspeed-eval`. See [Internal Trace Model](trace_model.md).
+
+- **`exact_loop_threshold`** (default `3`): Consecutive identical tool name + arguments that count as an exact loop.
+- **`soft_loop_threshold`** (default `3`): Consecutive same tool name with any arguments that count as thrashing.
+- **`max_recursive_depth`** (default `10`): Maximum allowed number of spans in a parent chain, including the root and the current span (`span_id` / `parent_span_id` on `tool_calls`). A chain fails only when its span count is **greater than** this value (for example, `root → child → leaf` is 3 and fails when the setting is `2`).
+- **`threshold`** (default `1.0`): Score at or above this is PASS. `1.0` means any detected loop fails.
+
+**Conversation-level:** Exact/soft loops and recursive depth are detected **within each turn** (one user query). Tool-call sequences are not concatenated across turns — repeating the same tool for a later query is not a loop. The conversation score uses the worst per-turn finding.
+
+```yaml
+metrics_metadata:
+  turn_level:
+    "custom:loop_eval":
+      threshold: 1.0
+      exact_loop_threshold: 3
+      soft_loop_threshold: 3
+      max_recursive_depth: 10
+      default: false
+  conversation_level:
+    "custom:loop_eval":
+      threshold: 1.0
+      exact_loop_threshold: 3
+      soft_loop_threshold: 3
+      max_recursive_depth: 10
+      default: false
+```
+
 By default no metrics are computed (`default` is set to `false`).
 
 | Setting (metrics_metadata.) | Description |

--- a/examples/02_metrics/README.md
+++ b/examples/02_metrics/README.md
@@ -10,6 +10,7 @@ Demonstrates different evaluation metrics available in the framework.
 | `conversation_quality`  | conversation_completeness, conversation_relevancy, knowledge_retention     | Multi-turn dialogue evaluation (LLM-based) |
 | `context_quality`       | context_recall, context_relevance, context_precision (with/without reference)    | RAG/retrieval evaluation (LLM-based)                |
 | `tool_evaluation`       | tool_eval                                                                  | Tool call validation (binary)     |
+| `loop_evaluation`       | loop_eval                                                                  | Agent tool-call loop / thrashing detection (no LLM) |
 | `keywords_evaluation`   | keywords_eval                                                              | Response evaluation - Pattern matching (binary)               |
 | `nlp_metrics`           | bleu, rouge, semantic_similarity_distance                                  | Response evaluation - Standard NLP based comparison (no LLM)        |
 

--- a/examples/02_metrics/loop_evaluation/README.md
+++ b/examples/02_metrics/loop_evaluation/README.md
@@ -1,0 +1,41 @@
+# Loop Detection Evaluation
+
+Deterministic detection of agent tool-call loops: exact repeats, soft thrashing, and excessive recursive depth. No LLM judge required.
+
+## Run Example
+
+```bash
+# From project root
+uv run lightspeed-eval \
+  --system-config examples/02_metrics/loop_evaluation/system.yaml \
+  --eval-data examples/02_metrics/loop_evaluation/eval_data.yaml
+```
+
+## Metrics & Required Data
+
+**Current Config:** Offline mode (`agents.enabled: false`) - all data in eval_data.yaml
+
+| Metric             | Name           | Description                                                                 | Required Data (Offline) | Required Data (Live) |
+|--------------------|----------------|-----------------------------------------------------------------------------|-------------------------|----------------------|
+| `custom:loop_eval` | Loop Detection | Consecutive identical calls, same-tool thrashing, and recursive call depth | tool_calls              | query, tool_calls (API-populated) |
+
+## Configuration Options
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `exact_loop_threshold` | 3 | Consecutive identical tool+args that count as a loop |
+| `soft_loop_threshold` | 3 | Consecutive same tool name (any args) that count as thrashing |
+| `max_recursive_depth` | 10 | Max allowed span count in a parent chain, including root and current span. Fails only when count is greater than this value (needs `span_id` / `parent_span_id` on `tool_calls`) |
+| `threshold` | 1.0 | Score at or above this is PASS. 1.0 means any detected loop fails |
+
+**Scoring:** 1.0 = no loops. Penalty grows with how far a finding exceeds its threshold, down to 0.0 for severe looping. The reason names the tool(s) and the flattened index where the loop started.
+
+**Conversation-level:** Scores each turn independently, then uses the worst finding. Sequences are not concatenated across queries.
+
+**Empty `tool_calls`:** Valid. Score 1.0 (nothing to loop).
+
+**Traces:** `lightspeed-eval` does not read traces. Recursive depth uses parent ids on `tool_calls`. `evaluate_loops_from_trace` is a programmatic helper only.
+
+**Not `custom:tool_eval`:** `tool_eval` checks that the *right* tools were called. `loop_eval` checks that the agent did not get stuck repeating tools. Use both for tool-calling agents.
+
+Results written to: `examples/02_metrics/loop_evaluation/eval_output/`

--- a/examples/02_metrics/loop_evaluation/eval_data.yaml
+++ b/examples/02_metrics/loop_evaluation/eval_data.yaml
@@ -1,0 +1,85 @@
+- conversation_group_id: no_loops
+  description: Distinct consecutive tools should score 1.0
+  tag: loops
+  turns:
+  - turn_id: mixed_tools
+    query: Show pods then describe the first one
+    tool_calls:
+    - - tool_name: oc_get
+        arguments:
+          kind: pod
+          namespace: default
+    - - tool_name: oc_describe
+        arguments:
+          kind: pod
+          name: my-pod
+
+- conversation_group_id: exact_loop
+  description: Same tool with identical arguments three times
+  tag: loops
+  turns:
+  - turn_id: repeated_get
+    query: List pods in default
+    tool_calls:
+    - - tool_name: oc_get
+        arguments:
+          kind: pod
+          namespace: default
+    - - tool_name: oc_get
+        arguments:
+          kind: pod
+          namespace: default
+    - - tool_name: oc_get
+        arguments:
+          kind: pod
+          namespace: default
+
+- conversation_group_id: soft_loop
+  description: Same tool called with different arguments (thrashing)
+  tag: loops
+  turns:
+  - turn_id: search_thrash
+    query: Find the crashlooping pod
+    tool_calls:
+    - - tool_name: search
+        arguments:
+          q: crashloop
+    - - tool_name: search
+        arguments:
+          q: CrashLoopBackOff
+    - - tool_name: search
+        arguments:
+          q: pod restart
+
+- conversation_group_id: recursive_depth
+  description: Nested tool chain deeper than max_recursive_depth (10 by default, 2 in this turn)
+  tag: loops
+  turns:
+  - turn_id: nested_tools
+    query: Diagnose nested agent tool use
+    turn_metrics_metadata:
+      custom:loop_eval:
+        max_recursive_depth: 2
+    tool_calls:
+    - - tool_name: plan
+        arguments: {}
+        span_id: s1
+    - - tool_name: search
+        arguments:
+          q: pods
+        span_id: s2
+        parent_span_id: s1
+    - - tool_name: oc_get
+        arguments:
+          kind: pod
+        span_id: s3
+        parent_span_id: s2
+
+- conversation_group_id: empty_tools
+  description: No tool calls is a pass (nothing to loop)
+  tag: loops
+  turns:
+  - turn_id: no_tools
+    query: What is a namespace?
+    response: A namespace is a logical cluster partition.
+    tool_calls: []

--- a/examples/02_metrics/loop_evaluation/system.yaml
+++ b/examples/02_metrics/loop_evaluation/system.yaml
@@ -1,0 +1,49 @@
+core:
+  max_threads: 1
+  cache_enabled: false
+
+agents:
+  enabled: false
+
+metrics_metadata:
+  turn_level:
+    custom:loop_eval:
+      threshold: 1.0
+      description: Detect exact tool loops, soft thrashing, and excessive recursive depth
+      default: true
+      exact_loop_threshold: 3
+      soft_loop_threshold: 3
+      max_recursive_depth: 10
+
+storage:
+- type: file
+  output_dir: examples/02_metrics/loop_evaluation/eval_output
+  base_filename: evaluation
+  enabled_outputs:
+  - csv
+  - json
+  - txt
+  csv_columns:
+  - conversation_group_id
+  - turn_id
+  - metric_identifier
+  - score
+  - threshold
+  - result
+  - reason
+  - query
+
+visualization:
+  figsize:
+  - 10
+  - 6
+  dpi: 150
+  enabled_graphs:
+  - pass_rates
+  - status_breakdown
+
+logging:
+  source_level: INFO
+  package_level: WARNING
+  log_format: '%(asctime)s - %(levelname)s - %(message)s'
+  show_timestamps: true

--- a/src/lightspeed_evaluation/core/metrics/custom/__init__.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/__init__.py
@@ -6,6 +6,10 @@ from lightspeed_evaluation.core.metrics.custom.conformal import (
 )
 from lightspeed_evaluation.core.metrics.custom.custom import CustomMetrics
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
+from lightspeed_evaluation.core.metrics.custom.loop_eval import (
+    evaluate_loop_calls,
+    evaluate_loops,
+)
 from lightspeed_evaluation.core.metrics.custom.mrr_eval import evaluate_mrr
 from lightspeed_evaluation.core.metrics.custom.openshift_agentic_run_eval import (
     evaluate_openshift_agentic_run_status,
@@ -21,6 +25,8 @@ __all__ = [
     "compute_mrr_threshold",
     "evaluate_openshift_agentic_run_status",
     "evaluate_keywords",
+    "evaluate_loop_calls",
+    "evaluate_loops",
     "evaluate_mrr",
     "evaluate_tool_calls",
     "get_lhat",

--- a/src/lightspeed_evaluation/core/metrics/custom/custom.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/custom.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING, Any, Optional
 from lightspeed_evaluation.core.llm.custom import BaseCustomLLM
 from lightspeed_evaluation.core.llm.manager import LLMManager
 from lightspeed_evaluation.core.metrics.custom.keywords_eval import evaluate_keywords
+from lightspeed_evaluation.core.metrics.custom.loop_eval import (
+    LOOP_EVAL_DEFAULTS,
+    config_from_metadata,
+    evaluate_loops,
+)
 from lightspeed_evaluation.core.metrics.custom.openshift_agentic_run_eval import (
     evaluate_openshift_agentic_run_status,
 )
@@ -51,6 +56,7 @@ class CustomMetrics:  # pylint: disable=too-few-public-methods
             "answer_correctness": self._evaluate_answer_correctness,
             "intent_eval": self._evaluate_intent,
             "tool_eval": self._evaluate_tool_calls,
+            "loop_eval": self._evaluate_loops,
             "openshift_agentic_run_status": evaluate_openshift_agentic_run_status,
             "openshift_agentic_run_evaluation_correctness": (
                 self._evaluate_openshift_agentic_run_evaluation_correctness
@@ -214,8 +220,11 @@ class CustomMetrics:  # pylint: disable=too-few-public-methods
         # Get actual tool calls from turn data (will be populated by API)
         actual_tool_calls = getattr(turn_data, "tool_calls", []) or []
 
-        # Get tool_eval configuration with proper priority hierarchy
-        metadata = self._get_tool_eval_metadata(turn_data, _conv_data)
+        metadata = self._get_metric_metadata(
+            "custom:tool_eval",
+            turn_data,
+            _conv_data,
+        ) or {"ordered": True, "full_match": True}
         ordered = metadata.get("ordered", True)
         full_match = metadata.get("full_match", True)
 
@@ -230,37 +239,67 @@ class CustomMetrics:  # pylint: disable=too-few-public-methods
 
         return score, details
 
-    def _get_tool_eval_metadata(
+    def _evaluate_loops(
         self,
-        turn_data: TurnData,
+        conv_data: Any,
+        _turn_idx: Optional[int],
+        turn_data: Optional[TurnData],
+        is_conversation: bool,
+    ) -> tuple[Optional[float], str]:
+        """Detect exact loops, soft loops, and excessive recursive depth."""
+        level = MetricLevel.CONVERSATION if is_conversation else MetricLevel.TURN
+        metadata = (
+            self._get_metric_metadata(
+                "custom:loop_eval",
+                turn_data,
+                conv_data,
+                level,
+            )
+            or LOOP_EVAL_DEFAULTS
+        )
+        return evaluate_loops(
+            conv_data,
+            _turn_idx,
+            turn_data,
+            is_conversation,
+            config_from_metadata(metadata),
+        )
+
+    def _get_metric_metadata(
+        self,
+        metric_identifier: str,
+        turn_data: Optional[TurnData],
         conv_data: Any = None,
-    ) -> dict[str, Any]:
-        """Get tool_eval configuration with proper priority hierarchy.
+        level: MetricLevel = MetricLevel.TURN,
+    ) -> Optional[dict[str, Any]]:
+        """Resolve metric metadata from MetricManager or level-specific overrides.
 
         Args:
-            turn_data: Turn data containing turn_metrics_metadata
-            conv_data: Optional conversation data for MetricManager
+            metric_identifier: Fully qualified metric id (e.g. ``custom:tool_eval``).
+            turn_data: Turn data for turn-level overrides.
+            conv_data: Conversation data for conversation-level overrides.
+            level: Whether to read turn or conversation metadata.
 
         Returns:
-            Dictionary with tool_eval configuration (ordered, full_match)
+            Metadata dictionary, or None when nothing is configured.
         """
-        # Use MetricManager if available for proper system defaults
         if self.metric_manager is not None:
-            metadata = self.metric_manager.get_metric_metadata(
-                metric_identifier="custom:tool_eval",
-                level=MetricLevel.TURN,
+            return self.metric_manager.get_metric_metadata(
+                metric_identifier=metric_identifier,
+                level=level,
                 conv_data=conv_data,
                 turn_data=turn_data,
             )
-            if metadata:
-                return metadata
-            return {"ordered": True, "full_match": True}
 
-        # Fallback: read directly from turn_data (backwards compatibility)
-        turn_metadata = turn_data.turn_metrics_metadata or {}
-        return turn_metadata.get(
-            "custom:tool_eval", {"ordered": True, "full_match": True}
-        )
+        if level == MetricLevel.CONVERSATION and conv_data is not None:
+            conv_metadata = (
+                getattr(conv_data, "conversation_metrics_metadata", None) or {}
+            )
+            return conv_metadata.get(metric_identifier)
+        if turn_data is not None:
+            turn_metadata = turn_data.turn_metrics_metadata or {}
+            return turn_metadata.get(metric_identifier)
+        return None
 
     def _evaluate_intent(
         self,

--- a/src/lightspeed_evaluation/core/metrics/custom/loop_eval.py
+++ b/src/lightspeed_evaluation/core/metrics/custom/loop_eval.py
@@ -1,0 +1,546 @@
+"""Deterministic agent loop detection from tool-call sequences.
+
+Detects exact consecutive repeats, same-tool thrashing, and excessive
+parent-child depth. The evaluation pipeline (``custom:loop_eval``) reads
+``TurnData.tool_calls`` only. :func:`evaluate_loops_from_trace` is a
+programmatic helper for the internal trace model; it is not eval-data input
+and is not called by ``lightspeed-eval``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from lightspeed_evaluation.core.models import EvaluationData, TurnData
+from lightspeed_evaluation.core.models.trace import Span, SpanType, Trace
+from lightspeed_evaluation.core.system.exceptions import ConfigurationError
+
+DEFAULT_EXACT_LOOP_THRESHOLD = 3
+DEFAULT_SOFT_LOOP_THRESHOLD = 3
+DEFAULT_MAX_RECURSIVE_DEPTH = 10
+
+_PARENT_KEYS = ("parent_span_id", "parent_id")
+_SPAN_ID_KEYS = ("span_id", "id")
+
+
+@dataclass(frozen=True)
+class LoopEvalConfig:
+    """Thresholds for loop and depth detection.
+
+    All values must be integers ``>= 1``. Direct construction with an invalid
+    threshold raises :class:`ConfigurationError` so scoring cannot divide by
+    zero. YAML and metric metadata should use :func:`config_from_metadata`,
+    which substitutes defaults for missing or invalid keys.
+
+    Raises:
+        ConfigurationError: If any threshold is not an integer ``>= 1``.
+    """
+
+    exact_loop_threshold: int = DEFAULT_EXACT_LOOP_THRESHOLD
+    soft_loop_threshold: int = DEFAULT_SOFT_LOOP_THRESHOLD
+    max_recursive_depth: int = DEFAULT_MAX_RECURSIVE_DEPTH
+
+    def __post_init__(self) -> None:
+        """Reject non-positive or non-integer thresholds."""
+        for name in (
+            "exact_loop_threshold",
+            "soft_loop_threshold",
+            "max_recursive_depth",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ConfigurationError(
+                    f"LoopEvalConfig.{name} must be an integer >= 1, got {value!r}"
+                )
+
+
+LOOP_EVAL_DEFAULTS: dict[str, Any] = asdict(LoopEvalConfig())
+
+
+@dataclass(frozen=True)
+class _IndexedCall:
+    """A single invocation in evaluation order."""
+
+    index: int
+    name: str
+    arguments: Any
+    span_id: Optional[str] = None
+    parent_id: Optional[str] = None
+    turn_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _Finding:
+    """One detected loop or depth violation."""
+
+    length: int
+    threshold: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class _Run:
+    """A consecutive run of equal keys."""
+
+    start_index: int
+    length: int
+
+
+def config_from_metadata(metadata: Optional[dict[str, Any]]) -> LoopEvalConfig:
+    """Build :class:`LoopEvalConfig` from metric metadata.
+
+    Args:
+        metadata: Merged system/turn metadata for ``custom:loop_eval``.
+
+    Returns:
+        Config with defaults applied for missing or invalid keys.
+    """
+    data = metadata or {}
+    return LoopEvalConfig(
+        exact_loop_threshold=_positive_int(
+            data.get("exact_loop_threshold"), DEFAULT_EXACT_LOOP_THRESHOLD
+        ),
+        soft_loop_threshold=_positive_int(
+            data.get("soft_loop_threshold"), DEFAULT_SOFT_LOOP_THRESHOLD
+        ),
+        max_recursive_depth=_positive_int(
+            data.get("max_recursive_depth"), DEFAULT_MAX_RECURSIVE_DEPTH
+        ),
+    )
+
+
+def evaluate_loops(
+    conv_data: Any,
+    _turn_idx: Optional[int],
+    turn_data: Optional[TurnData],
+    is_conversation: bool,
+    config: Optional[LoopEvalConfig] = None,
+) -> tuple[Optional[float], str]:
+    """Evaluate loop detection for a turn or conversation.
+
+    Args:
+        conv_data: Conversation data (used when ``is_conversation`` is True).
+        _turn_idx: Turn index (unused; required by CustomMetrics).
+        turn_data: Turn data containing ``tool_calls``.
+        is_conversation: Whether to score each turn independently and
+            aggregate findings. Consecutive calls are not joined across turns.
+        config: Detection thresholds. Defaults are used when omitted.
+
+    Returns:
+        ``(score, reason)`` where 1.0 means no loops and 0.0 means severe
+        looping. ``score`` is ``None`` when required data is missing.
+    """
+    resolved = config or LoopEvalConfig()
+    if is_conversation:
+        return _evaluate_conversation(conv_data, resolved)
+    if turn_data is None:
+        return None, "TurnData is required for loop evaluation"
+    return evaluate_loop_calls(
+        turn_data.tool_calls, config=resolved, turn_id=turn_data.turn_id
+    )
+
+
+def evaluate_loop_calls(
+    tool_calls: Optional[list[list[dict[str, Any]]]],
+    config: Optional[LoopEvalConfig] = None,
+    turn_id: Optional[str] = None,
+) -> tuple[Optional[float], str]:
+    """Score a nested ``tool_calls`` sequence for loops.
+
+    Args:
+        tool_calls: Actual tool calls in ``list[list[dict]]`` form. An empty
+            list scores 1.0 (no loops). ``None`` is a missing-data error.
+        config: Detection thresholds.
+        turn_id: Optional turn identifier included in findings.
+
+    Returns:
+        ``(score, reason)``.
+    """
+    if tool_calls is None:
+        return None, "No tool_calls provided for loop evaluation"
+    return _score_calls(
+        _flatten_tool_calls(tool_calls, turn_id=turn_id),
+        config or LoopEvalConfig(),
+    )
+
+
+def evaluate_loops_from_trace(
+    trace: Trace,
+    config: Optional[LoopEvalConfig] = None,
+) -> tuple[float, str]:
+    """Score loop/depth patterns from a normalized internal :class:`Trace`.
+
+    Not used by ``lightspeed-eval`` or ``custom:loop_eval``. Call this from
+    Python after converting a platform payload with the trace adapters.
+    Consecutive exact/soft loops use TOOL spans in start-time order. Recursive
+    depth walks the full span parent chain and reports TOOL leaves.
+
+    Args:
+        trace: Internal trace model.
+        config: Detection thresholds.
+
+    Returns:
+        ``(score, reason)``. Missing tool spans scores 1.0.
+    """
+    resolved = config or LoopEvalConfig()
+    tool_spans = _ordered_tool_spans(trace)
+    tool_calls = [
+        _indexed_from_span(span, index) for index, span in enumerate(tool_spans)
+    ]
+    tool_indexes = {call.span_id: call.index for call in tool_calls if call.span_id}
+    all_nodes = [
+        _indexed_from_span(span, tool_indexes.get(span.span_id, index))
+        for index, span in enumerate(trace.spans)
+    ]
+    return _score_calls(
+        tool_calls,
+        resolved,
+        depth_nodes=all_nodes,
+        reportable_ids={span.span_id for span in tool_spans},
+    )
+
+
+def _evaluate_conversation(
+    conv_data: Optional[EvaluationData],
+    config: LoopEvalConfig,
+) -> tuple[Optional[float], str]:
+    """Evaluate loop detection per turn, then aggregate findings.
+
+    Exact/soft loops and recursive depth are scored within each turn (one
+    user query). Consecutive calls are not joined across turns: repeating a
+    tool for a new query is not thrashing. Missing ``tool_calls`` (``None``)
+    on any turn is a data error. An empty list is valid.
+    """
+    if conv_data is None:
+        return None, "Conversation data is required for conversation-level loop eval"
+
+    all_findings: list[_Finding] = []
+    call_count = 0
+    for turn in conv_data.turns:
+        if turn.tool_calls is None:
+            return (
+                None,
+                (
+                    f"No tool_calls provided on turn {turn.turn_id} "
+                    "for loop evaluation"
+                ),
+            )
+        calls = _flatten_tool_calls(turn.tool_calls, turn_id=turn.turn_id)
+        call_count += len(calls)
+        all_findings.extend(_findings_for_calls(calls, config))
+    return _score_findings(all_findings, call_count)
+
+
+def _flatten_tool_calls(
+    tool_calls: list[list[dict[str, Any]]],
+    turn_id: Optional[str] = None,
+    start_index: int = 0,
+) -> list[_IndexedCall]:
+    """Flatten nested tool-call sequences into evaluation order."""
+    calls: list[_IndexedCall] = []
+    index = start_index
+    for sequence in tool_calls:
+        if not isinstance(sequence, list):
+            continue
+        for raw in sequence:
+            if not isinstance(raw, dict):
+                continue
+            calls.append(_indexed_from_dict(raw, index, turn_id))
+            index += 1
+    return calls
+
+
+def _score_calls(
+    calls: list[_IndexedCall],
+    config: LoopEvalConfig,
+    *,
+    depth_nodes: Optional[list[_IndexedCall]] = None,
+    reportable_ids: Optional[set[str]] = None,
+) -> tuple[float, str]:
+    """Score consecutive loops plus recursive depth."""
+    return _score_findings(
+        _findings_for_calls(
+            calls,
+            config,
+            depth_nodes=depth_nodes,
+            reportable_ids=reportable_ids,
+        ),
+        len(calls),
+    )
+
+
+def _findings_for_calls(
+    calls: list[_IndexedCall],
+    config: LoopEvalConfig,
+    *,
+    depth_nodes: Optional[list[_IndexedCall]] = None,
+    reportable_ids: Optional[set[str]] = None,
+) -> list[_Finding]:
+    """Collect exact/soft loop and recursive-depth findings for one sequence."""
+    findings = _consecutive_findings(calls, config)
+    depth_finding = _depth_finding(depth_nodes or calls, config, reportable_ids)
+    if depth_finding is not None:
+        findings.append(depth_finding)
+    return findings
+
+
+def _indexed_from_dict(
+    raw: dict[str, Any], index: int, turn_id: Optional[str]
+) -> _IndexedCall:
+    """Build an indexed call from a tool_calls dict."""
+    name = raw.get("tool_name") or raw.get("name") or "unknown"
+    arguments = raw.get("arguments", raw.get("args", {}))
+    if isinstance(arguments, str):
+        arguments = _parse_json_arguments(arguments)
+    return _IndexedCall(
+        index=index,
+        name=str(name).strip() or "unknown",
+        arguments=arguments,
+        span_id=_first_str(raw, _SPAN_ID_KEYS),
+        parent_id=_first_str(raw, _PARENT_KEYS),
+        turn_id=turn_id,
+    )
+
+
+def _indexed_from_span(span: Span, index: int) -> _IndexedCall:
+    """Build an indexed call from a trace span."""
+    return _IndexedCall(
+        index=index,
+        name=span.name.strip() or "unknown",
+        arguments=span.inputs if span.inputs is not None else {},
+        span_id=span.span_id,
+        parent_id=span.parent_span_id,
+    )
+
+
+def _consecutive_findings(
+    calls: list[_IndexedCall],
+    config: LoopEvalConfig,
+) -> list[_Finding]:
+    """Detect exact and soft consecutive runs that meet thresholds."""
+    exact_run = _longest_run(calls, key=lambda call: (call.name, _canonical_args(call)))
+    exact = _finding_from_run(
+        calls,
+        exact_run,
+        config.exact_loop_threshold,
+        "Exact loop",
+        "with identical arguments ",
+    )
+
+    soft_run = _longest_run(calls, key=lambda call: call.name)
+    same_window = (
+        exact_run is not None
+        and soft_run is not None
+        and exact_run.start_index == soft_run.start_index
+        and exact_run.length == soft_run.length
+    )
+    findings: list[_Finding] = []
+    if exact is not None:
+        findings.append(exact)
+    if not same_window:
+        soft = _finding_from_run(
+            calls,
+            soft_run,
+            config.soft_loop_threshold,
+            "Soft loop",
+            "consecutively ",
+        )
+        if soft is not None:
+            findings.append(soft)
+    return findings
+
+
+def _finding_from_run(
+    calls: list[_IndexedCall],
+    run: Optional[_Run],
+    threshold: int,
+    label: str,
+    extra: str,
+) -> Optional[_Finding]:
+    """Build a finding from a consecutive run, if it meets ``threshold``."""
+    if run is None or run.length < threshold:
+        return None
+    start = calls[run.start_index]
+    return _Finding(
+        length=run.length,
+        threshold=threshold,
+        detail=(
+            f"{label}: '{start.name}' called {run.length} times "
+            f"{extra}starting at {_location(start)} "
+            f"(threshold {threshold})"
+        ),
+    )
+
+
+def _longest_run(
+    calls: list[_IndexedCall],
+    key: Callable[[_IndexedCall], Any],
+) -> Optional[_Run]:
+    """Return the longest consecutive run under ``key``.
+
+    Ties keep the earliest start index. Returns ``None`` when ``calls`` is empty.
+    """
+    if not calls:
+        return None
+
+    best_start = 0
+    best_length = 1
+    run_start = 0
+    run_length = 1
+    previous = key(calls[0])
+
+    for offset, call in enumerate(calls[1:], start=1):
+        current = key(call)
+        if current == previous:
+            run_length += 1
+            if run_length > best_length:
+                best_length = run_length
+                best_start = run_start
+        else:
+            run_start = offset
+            run_length = 1
+            previous = current
+
+    return _Run(start_index=best_start, length=best_length)
+
+
+def _depth_finding(
+    nodes: list[_IndexedCall],
+    config: LoopEvalConfig,
+    reportable_ids: Optional[set[str]] = None,
+) -> Optional[_Finding]:
+    """Find the deepest parent chain among reportable nodes."""
+    by_id = {node.span_id: node for node in nodes if node.span_id}
+    if not by_id:
+        return None
+
+    deepest: Optional[_IndexedCall] = None
+    max_depth = 0
+    deepest_chain: list[str] = []
+    for node in nodes:
+        if reportable_ids is not None and (
+            not node.span_id or node.span_id not in reportable_ids
+        ):
+            continue
+        chain = _ancestor_chain(node, by_id)
+        if len(chain) > max_depth:
+            max_depth = len(chain)
+            deepest = node
+            deepest_chain = chain
+
+    if deepest is None or max_depth <= config.max_recursive_depth:
+        return None
+    return _Finding(
+        length=max_depth,
+        threshold=config.max_recursive_depth,
+        detail=(
+            f"Excessive recursive depth: {max_depth} "
+            f"(threshold {config.max_recursive_depth}) along "
+            f"{' -> '.join(deepest_chain)} ending at {_location(deepest)}"
+        ),
+    )
+
+
+def _ancestor_chain(
+    node: _IndexedCall,
+    by_id: dict[str, _IndexedCall],
+) -> list[str]:
+    """Return the name chain from root to ``node``."""
+    names: list[str] = []
+    seen: set[str] = set()
+    current: Optional[_IndexedCall] = node
+    while current is not None:
+        if current.span_id and current.span_id in seen:
+            names.append(f"{current.name}(cycle)")
+            break
+        if current.span_id:
+            seen.add(current.span_id)
+        names.append(current.name)
+        parent_id = current.parent_id
+        current = by_id.get(parent_id) if parent_id else None
+    names.reverse()
+    return names
+
+
+def _ordered_tool_spans(trace: Trace) -> list[Span]:
+    """Return TOOL spans ordered by start time, then original order."""
+    indexed = [
+        (index, span)
+        for index, span in enumerate(trace.spans)
+        if span.span_type == SpanType.TOOL
+    ]
+    indexed.sort(
+        key=lambda item: (
+            item[1].start_time is None,
+            item[1].start_time.timestamp() if item[1].start_time else 0.0,
+            item[0],
+        )
+    )
+    return [span for _index, span in indexed]
+
+
+def _score_findings(
+    findings: list[_Finding],
+    call_count: int,
+) -> tuple[float, str]:
+    """Convert findings into a 0–1 score and a human-readable reason.
+
+    Penalty for a finding of length L against threshold T is
+    ``min(1, (L - T + 1) / T)``. The worst finding determines the score:
+    ``1.0 - max(penalties)``.
+    """
+    if not findings:
+        return 1.0, f"No loops detected across {call_count} tool call(s)"
+
+    penalties = [
+        min(1.0, (finding.length - finding.threshold + 1) / finding.threshold)
+        for finding in findings
+    ]
+    score = max(0.0, 1.0 - max(penalties))
+    return round(score, 4), "; ".join(finding.detail for finding in findings)
+
+
+def _canonical_args(call: _IndexedCall) -> str:
+    """Stable JSON form of arguments for exact-loop comparison."""
+    try:
+        return json.dumps(call.arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return str(call.arguments)
+
+
+def _parse_json_arguments(raw: str) -> Any:
+    """Parse JSON argument strings; return the original string on failure."""
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def _first_str(raw: dict[str, Any], keys: tuple[str, ...]) -> Optional[str]:
+    """Return the first non-empty string value among ``keys``."""
+    for key in keys:
+        value = raw.get(key)
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def _location(call: _IndexedCall) -> str:
+    """Human-readable start location for a finding."""
+    if call.turn_id:
+        return f"turn {call.turn_id}, tool call index {call.index}"
+    return f"tool call index {call.index}"
+
+
+def _positive_int(value: Any, default: int) -> int:
+    """Coerce a metadata value to an int >= 1, else ``default``."""
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default

--- a/src/lightspeed_evaluation/core/system/validator.py
+++ b/src/lightspeed_evaluation/core/system/validator.py
@@ -69,6 +69,11 @@ METRIC_REQUIREMENTS = {
             "with 'tool_name', 'arguments', and optional 'result'"
         ),
     },
+    "custom:loop_eval": {
+        "required_fields": ["tool_calls"],
+        "allow_empty_fields": ["tool_calls"],
+        "description": ("requires 'tool_calls' field (empty list is valid: no loops)"),
+    },
     "custom:openshift_agentic_run_status": {
         "required_fields": ["expected_openshift_agentic_run_status"],
         "description": "requires 'expected_openshift_agentic_run_status' field",
@@ -146,9 +151,18 @@ def check_metric_required_data(
     requirements = METRIC_REQUIREMENTS[metric_identifier]
     required_fields = requirements["required_fields"]
     description = requirements["description"]
+    allow_empty_fields = set(requirements.get("allow_empty_fields", []))
 
     for field_name in required_fields:
         field_value = getattr(turn_data, field_name, None)
+        if field_name in allow_empty_fields:
+            if field_value is None:
+                return (
+                    False,
+                    f"Metric '{metric_identifier}' {description}: "
+                    f"required field '{field_name}' is missing",
+                )
+            continue
         if _is_field_empty(field_value):
             return (
                 False,
@@ -512,55 +526,63 @@ class DataValidator:  # pylint: disable=too-few-public-methods
     def _check_metric_requirements(
         self, data: EvaluationData, api_enabled: bool = True
     ) -> list[str]:
-        """Check that required fields exist for specified metrics and API configuration."""
-        errors = []
+        """Check required fields for turn- and conversation-level metrics."""
+        errors: list[str] = []
+        conversation_metrics = data.conversation_metrics or []
 
-        # Check each turn against metric requirements
         for turn_data in data.turns:
-            # Skip validation if no turn metrics specified
-            if not turn_data.turn_metrics:
-                continue
-
-            for metric in turn_data.turn_metrics:
-                if metric not in METRIC_REQUIREMENTS:
-                    continue  # Unknown metrics are handled separately
-
-                # Skip script metric validation if API is disabled
-                if metric.startswith("script:") and not self.api_enabled:
+            turn_metrics: list[str] = turn_data.turn_metrics or []
+            metrics: list[str] = list(
+                dict.fromkeys(turn_metrics + conversation_metrics)
+            )
+            for metric in metrics:
+                error = self._metric_field_error(turn_data, metric, api_enabled)
+                if error is None:
                     continue
-
-                requirements = METRIC_REQUIREMENTS[metric]
-                required_fields = requirements["required_fields"]
-                description = requirements["description"]
-
-                # Check each required field
-                for field_name in required_fields:
-                    field_value = getattr(turn_data, field_name, None)
-
-                    # For API-populated fields, allow None if API is enabled
-                    if (
-                        field_name in API_POPULATED_FIELDS
-                        and api_enabled
-                        and field_value is None
-                    ):
-                        continue  # will be populated by API
-
-                    # Check if field is missing or empty
-                    if _is_field_empty(field_value):
-                        turn_data.add_invalid_metric(metric)
-
-                        api_context = (
-                            " when API is disabled"
-                            if field_name in API_POPULATED_FIELDS and not api_enabled
-                            else ""
-                        )
-                        errors.append(
-                            f"TurnData {turn_data.turn_id}: Metric '{metric}' "
-                            f"{description}{api_context}"
-                        )
-                        break  # Only report once per metric per turn
+                if metric in turn_metrics:
+                    turn_data.add_invalid_metric(metric)
+                if metric in conversation_metrics:
+                    data.add_invalid_metric(metric)
+                errors.append(error)
 
         return errors
+
+    def _metric_field_error(
+        self,
+        turn_data: TurnData,
+        metric: str,
+        api_enabled: bool,
+    ) -> Optional[str]:
+        """Return a requirement error for ``metric`` on ``turn_data``, if any."""
+        if metric not in METRIC_REQUIREMENTS:
+            return None
+        if metric.startswith("script:") and not self.api_enabled:
+            return None
+
+        requirements = METRIC_REQUIREMENTS[metric]
+        allow_empty = set(requirements.get("allow_empty_fields", []))
+
+        for field_name in requirements["required_fields"]:
+            field_value = getattr(turn_data, field_name, None)
+            if (
+                field_name in API_POPULATED_FIELDS
+                and api_enabled
+                and field_value is None
+            ):
+                continue
+            if field_name in allow_empty and field_value is not None:
+                continue
+            if _is_field_empty(field_value):
+                api_context = (
+                    " when API is disabled"
+                    if field_name in API_POPULATED_FIELDS and not api_enabled
+                    else ""
+                )
+                return (
+                    f"TurnData {turn_data.turn_id}: Metric '{metric}' "
+                    f"{requirements['description']}{api_context}"
+                )
+        return None
 
     def _validate_scripts(self, evaluation_data: list[EvaluationData]) -> None:
         """Validate all script paths when API is enabled."""

--- a/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/evaluator.py
@@ -194,18 +194,22 @@ class MetricsEvaluator:
                 )
 
             # Check required data for metric (after API call); skip with ERROR if missing
-            if (
-                request.turn_data is not None
-                and request.metric_identifier in METRIC_REQUIREMENTS
-            ):
-                ok, msg = check_metric_required_data(
-                    request.turn_data, request.metric_identifier
-                )
-                if not ok:
-                    logger.warning(
-                        "Skipping metric due to missing required data: %s", msg
+            if request.metric_identifier in METRIC_REQUIREMENTS:
+                if request.is_conversation:
+                    turns_to_check = request.conv_data.turns
+                elif request.turn_data is not None:
+                    turns_to_check = [request.turn_data]
+                else:
+                    turns_to_check = []
+                for turn in turns_to_check:
+                    ok, msg = check_metric_required_data(
+                        turn, request.metric_identifier
                     )
-                    return self._create_error_result(request, msg, start_time)
+                    if not ok:
+                        logger.warning(
+                            "Skipping metric due to missing required data: %s", msg
+                        )
+                        return self._create_error_result(request, msg, start_time)
 
             # Create evaluation scope
             evaluation_scope = EvaluationScope(

--- a/tests/unit/core/metrics/custom/test_custom.py
+++ b/tests/unit/core/metrics/custom/test_custom.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 
 from lightspeed_evaluation.core.metrics.custom.custom import CustomMetrics
 from lightspeed_evaluation.core.metrics.manager import MetricLevel
-from lightspeed_evaluation.core.models import EvaluationScope, TurnData
+from lightspeed_evaluation.core.models import EvaluationData, EvaluationScope, TurnData
 from lightspeed_evaluation.core.system.exceptions import LLMError
 
 
@@ -507,3 +507,100 @@ class TestBuildWorkflowPhases:
         result = cm._build_workflow_phases(turn)
 
         assert "unknown" in result
+
+
+class TestCustomMetricsLoopEval:
+    """Test CustomMetrics loop_eval wiring and metadata."""
+
+    def test_evaluate_loop_eval_no_loops(self, mocker: MockerFixture) -> None:
+        """Registered loop_eval metric scores 1.0 when tools do not repeat."""
+        custom_metrics = _make_custom_metrics(mocker)
+        turn_data = TurnData(
+            turn_id="t1",
+            query="list pods",
+            tool_calls=[
+                [{"tool_name": "oc_get", "arguments": {"kind": "pod"}}],
+                [{"tool_name": "oc_describe", "arguments": {"kind": "pod"}}],
+            ],
+        )
+        scope = _make_scope(turn_data)
+
+        score, reason = custom_metrics.evaluate("loop_eval", None, scope)
+
+        assert score == 1.0
+        assert "No loops detected" in reason
+
+    def test_evaluate_loop_eval_detects_exact_loop(self, mocker: MockerFixture) -> None:
+        """Registered loop_eval metric flags identical consecutive calls."""
+        custom_metrics = _make_custom_metrics(mocker)
+        repeated = {"tool_name": "oc_get", "arguments": {"kind": "pod"}}
+        turn_data = TurnData(
+            turn_id="t1",
+            query="list pods",
+            tool_calls=[[repeated], [repeated], [repeated]],
+        )
+        scope = _make_scope(turn_data)
+
+        score, reason = custom_metrics.evaluate("loop_eval", None, scope)
+
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason
+
+    def test_loop_eval_threshold_from_metric_manager(
+        self, mocker: MockerFixture
+    ) -> None:
+        """System metadata overrides the consecutive-call threshold."""
+        mock_llm_manager = mocker.Mock()
+        mock_llm_manager.get_model_name.return_value = "test-model"
+        mock_llm_manager.get_llm_params.return_value = {"parameters": {}}
+        mock_metric_manager = mocker.Mock()
+        mock_metric_manager.get_metric_metadata.return_value = {
+            "exact_loop_threshold": 2,
+            "soft_loop_threshold": 10,
+            "max_recursive_depth": 10,
+        }
+        custom_metrics = CustomMetrics(mock_llm_manager, mock_metric_manager)
+
+        repeated = {"tool_name": "search", "arguments": {"q": "x"}}
+        turn_data = TurnData(
+            turn_id="t1",
+            query="search",
+            tool_calls=[[repeated], [repeated]],
+        )
+        scope = _make_scope(turn_data)
+
+        score, reason = custom_metrics.evaluate("loop_eval", None, scope)
+
+        mock_metric_manager.get_metric_metadata.assert_called_once_with(
+            metric_identifier="custom:loop_eval",
+            level=MetricLevel.TURN,
+            conv_data=None,
+            turn_data=turn_data,
+        )
+        assert score is not None
+        assert score < 1.0
+        assert "threshold 2" in reason
+
+    def test_loop_eval_conversation_level(self, mocker: MockerFixture) -> None:
+        """Conversation-level loop_eval scores each turn; in-turn loops still fail."""
+        custom_metrics = _make_custom_metrics(mocker)
+        repeated = {"tool_name": "search", "arguments": {"q": "x"}}
+        conv_data = EvaluationData(
+            conversation_group_id="c1",
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="one",
+                    tool_calls=[[repeated], [repeated], [repeated]],
+                ),
+                TurnData(turn_id="t2", query="two", tool_calls=[[repeated]]),
+            ],
+        )
+        scope = EvaluationScope(turn_idx=None, turn_data=None, is_conversation=True)
+
+        score, reason = custom_metrics.evaluate("loop_eval", conv_data, scope)
+
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason

--- a/tests/unit/core/metrics/custom/test_loop_eval.py
+++ b/tests/unit/core/metrics/custom/test_loop_eval.py
@@ -1,0 +1,462 @@
+"""Tests for custom:loop_eval loop detection."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from lightspeed_evaluation.core.metrics.custom.loop_eval import (
+    LoopEvalConfig,
+    config_from_metadata,
+    evaluate_loop_calls,
+    evaluate_loops,
+    evaluate_loops_from_trace,
+)
+from lightspeed_evaluation.core.models import EvaluationData, TurnData
+from lightspeed_evaluation.core.models.trace import Span, SpanType, Trace
+from lightspeed_evaluation.core.system.exceptions import ConfigurationError
+
+
+def _call(name: str, arguments: dict | None = None, **extra: object) -> dict:
+    """Build a tool_calls dict."""
+    payload: dict = {"tool_name": name, "arguments": arguments or {}}
+    payload.update(extra)
+    return payload
+
+
+def _sequence(*calls: dict) -> list[list[dict]]:
+    """Wrap each call as its own sequence, matching API flattening."""
+    return [[call] for call in calls]
+
+
+class TestEvaluateLoopCalls:
+    """Tests for evaluate_loop_calls on TurnData.tool_calls sequences."""
+
+    def test_none_tool_calls_is_error(self) -> None:
+        """Missing tool_calls returns no score."""
+        score, reason = evaluate_loop_calls(None)
+        assert score is None
+        assert "No tool_calls" in reason
+
+    def test_empty_tool_calls_scores_perfect(self) -> None:
+        """Empty list means no loops."""
+        score, reason = evaluate_loop_calls([])
+        assert score == 1.0
+        assert "No loops detected" in reason
+
+    def test_varied_tools_no_loop(self) -> None:
+        """Distinct consecutive tools do not loop."""
+        tool_calls = _sequence(
+            _call("oc_get", {"kind": "pod"}),
+            _call("oc_describe", {"kind": "pod"}),
+            _call("oc_get", {"kind": "namespace"}),
+        )
+        score, reason = evaluate_loop_calls(tool_calls)
+        assert score == 1.0
+        assert "No loops detected" in reason
+        assert "3 tool call" in reason
+
+    def test_exact_loop_identical_args(self) -> None:
+        """Three consecutive identical calls are an exact loop."""
+        repeated = _call("oc_get", {"kind": "pod", "namespace": "default"})
+        tool_calls = _sequence(repeated, repeated, repeated)
+        score, reason = evaluate_loop_calls(tool_calls)
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason
+        assert "oc_get" in reason
+        assert "tool call index 0" in reason
+
+    def test_two_identical_calls_below_default_threshold(self) -> None:
+        """Two identical calls do not meet the default threshold of 3."""
+        repeated = _call("search", {"q": "pods"})
+        score, reason = evaluate_loop_calls(_sequence(repeated, repeated))
+        assert score == 1.0
+        assert "No loops detected" in reason
+
+    def test_soft_loop_same_tool_different_args(self) -> None:
+        """Same tool with different args is a soft loop, not exact."""
+        tool_calls = _sequence(
+            _call("search", {"q": "a"}),
+            _call("search", {"q": "b"}),
+            _call("search", {"q": "c"}),
+        )
+        score, reason = evaluate_loop_calls(tool_calls)
+        assert score is not None
+        assert score < 1.0
+        assert "Soft loop" in reason
+        assert "Exact loop" not in reason
+        assert "search" in reason
+
+    def test_exact_loop_does_not_also_report_identical_soft(self) -> None:
+        """An exact run is not double-reported as a soft loop of the same window."""
+        repeated = _call("oc_get", {"kind": "pod"})
+        score, reason = evaluate_loop_calls(_sequence(repeated, repeated, repeated))
+        assert "Exact loop" in reason
+        assert "Soft loop" not in reason
+        assert score is not None
+
+    def test_soft_loop_extends_beyond_exact_run(self) -> None:
+        """Identical prefix plus extra same-tool calls reports both kinds."""
+        same = _call("search", {"q": "a"})
+        tool_calls = _sequence(
+            same,
+            same,
+            same,
+            _call("search", {"q": "b"}),
+        )
+        score, reason = evaluate_loop_calls(tool_calls)
+        assert "Exact loop" in reason
+        assert "Soft loop" in reason
+        assert score is not None
+        assert score < 1.0
+
+    def test_configurable_exact_threshold(self) -> None:
+        """A lower exact threshold flags shorter identical runs."""
+        repeated = _call("oc_get", {"kind": "pod"})
+        config = LoopEvalConfig(exact_loop_threshold=2, soft_loop_threshold=5)
+        score, reason = evaluate_loop_calls(
+            _sequence(repeated, repeated), config=config
+        )
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason
+        assert "threshold 2" in reason
+
+    def test_severity_increases_with_run_length(self) -> None:
+        """Longer exact runs score worse than the minimum threshold run."""
+        repeated = _call("oc_get", {"kind": "pod"})
+        mild, _ = evaluate_loop_calls(_sequence(repeated, repeated, repeated))
+        severe, _ = evaluate_loop_calls(
+            _sequence(repeated, repeated, repeated, repeated, repeated)
+        )
+        assert mild is not None
+        assert severe is not None
+        assert severe < mild
+        assert severe == 0.0
+
+    def test_recursive_depth_from_parent_ids(self) -> None:
+        """A parent chain deeper than max_recursive_depth is reported."""
+        tool_calls = _sequence(
+            _call("root", {}, span_id="s1"),
+            _call("child", {}, span_id="s2", parent_span_id="s1"),
+            _call("leaf", {}, span_id="s3", parent_span_id="s2"),
+        )
+        config = LoopEvalConfig(
+            exact_loop_threshold=10,
+            soft_loop_threshold=10,
+            max_recursive_depth=2,
+        )
+        score, reason = evaluate_loop_calls(tool_calls, config=config)
+        assert score is not None
+        assert score < 1.0
+        assert "Excessive recursive depth" in reason
+        assert "root -> child -> leaf" in reason
+
+    def test_flat_calls_without_parent_ids_have_no_depth_finding(self) -> None:
+        """No span ids means recursive depth is not assessed."""
+        tool_calls = _sequence(
+            _call("a", {"x": 1}),
+            _call("b", {"x": 2}),
+            _call("c", {"x": 3}),
+        )
+        config = LoopEvalConfig(max_recursive_depth=1)
+        score, reason = evaluate_loop_calls(tool_calls, config=config)
+        assert score == 1.0
+        assert "Excessive recursive depth" not in reason
+
+    def test_json_string_arguments_canonicalize(self) -> None:
+        """JSON argument strings with different key order still exact-match."""
+        tool_calls = _sequence(
+            _call("search", None) | {"arguments": '{"b": 2, "a": 1}'},
+            {"tool_name": "search", "arguments": '{"a": 1, "b": 2}'},
+            {"tool_name": "search", "arguments": {"a": 1, "b": 2}},
+        )
+        score, reason = evaluate_loop_calls(tool_calls)
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason
+
+    def test_reports_turn_id_in_location(self) -> None:
+        """Start location includes turn_id when provided."""
+        repeated = _call("oc_get", {"kind": "pod"})
+        _score, reason = evaluate_loop_calls(
+            _sequence(repeated, repeated, repeated), turn_id="t9"
+        )
+        assert "turn t9, tool call index 0" in reason
+
+
+class TestEvaluateLoopsTurnAndConversation:
+    """Tests for the CustomMetrics-compatible evaluate_loops wrapper."""
+
+    def test_turn_level_requires_turn_data(self) -> None:
+        """Turn-level evaluation without TurnData is an error."""
+        score, reason = evaluate_loops(None, 0, None, False)
+        assert score is None
+        assert "TurnData is required" in reason
+
+    def test_turn_level_uses_turn_tool_calls(self) -> None:
+        """Turn-level evaluation reads tool_calls from TurnData."""
+        turn = TurnData(
+            turn_id="t1",
+            query="list pods",
+            tool_calls=_sequence(
+                _call("oc_get", {"kind": "pod"}),
+                _call("oc_describe", {"kind": "pod"}),
+            ),
+        )
+        score, reason = evaluate_loops(None, 0, turn, False)
+        assert score == 1.0
+        assert "No loops detected" in reason
+
+    def test_conversation_level_does_not_join_turns(self) -> None:
+        """Repeating a tool on a later query is not a cross-turn loop."""
+        repeated = _call("search", {"q": "same"})
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="first",
+                    tool_calls=_sequence(repeated, repeated),
+                ),
+                TurnData(
+                    turn_id="t2",
+                    query="second",
+                    tool_calls=_sequence(repeated),
+                ),
+            ],
+        )
+        score, reason = evaluate_loops(conv, None, None, True)
+        assert score == 1.0
+        assert "No loops detected" in reason
+        assert "Exact loop" not in reason
+
+    def test_conversation_level_detects_in_turn_loop(self) -> None:
+        """A loop fully inside one turn still fails conversation-level eval."""
+        repeated = _call("search", {"q": "same"})
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="first",
+                    tool_calls=_sequence(repeated, repeated, repeated),
+                ),
+                TurnData(
+                    turn_id="t2",
+                    query="second",
+                    tool_calls=_sequence(_call("oc_get", {"kind": "pod"})),
+                ),
+            ],
+        )
+        score, reason = evaluate_loops(conv, None, None, True)
+        assert score is not None
+        assert score < 1.0
+        assert "Exact loop" in reason
+        assert "turn t1" in reason
+
+    def test_conversation_level_does_not_join_parent_chains(self) -> None:
+        """Parent ids that point at another turn's spans are not a conversation-wide tree."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="first",
+                    tool_calls=_sequence(_call("root", {}, span_id="s1")),
+                ),
+                TurnData(
+                    turn_id="t2",
+                    query="second",
+                    tool_calls=_sequence(
+                        _call("child", {}, span_id="s2", parent_span_id="s1"),
+                        _call("leaf", {}, span_id="s3", parent_span_id="s2"),
+                    ),
+                ),
+            ],
+        )
+        config = LoopEvalConfig(
+            exact_loop_threshold=10,
+            soft_loop_threshold=10,
+            max_recursive_depth=2,
+        )
+        score, reason = evaluate_loops(conv, None, None, True, config=config)
+        assert score == 1.0
+        assert "Excessive recursive depth" not in reason
+
+    def test_conversation_level_missing_all_tool_calls(self) -> None:
+        """Conversation with no tool_calls on any turn is an error."""
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[TurnData(turn_id="t1", query="q", response="r")],
+        )
+        score, reason = evaluate_loops(conv, None, None, True)
+        assert score is None
+        assert "No tool_calls provided on turn t1" in reason
+
+    def test_conversation_level_mixed_none_is_error(self) -> None:
+        """Missing tool_calls on any turn is an error, not skipped."""
+        repeated = _call("search", {"q": "same"})
+        conv = EvaluationData(
+            conversation_group_id="c1",
+            turns=[
+                TurnData(
+                    turn_id="t1",
+                    query="first",
+                    tool_calls=_sequence(repeated, repeated),
+                ),
+                TurnData(turn_id="t2", query="second", tool_calls=None),
+                TurnData(
+                    turn_id="t3",
+                    query="third",
+                    tool_calls=_sequence(repeated),
+                ),
+            ],
+        )
+        score, reason = evaluate_loops(conv, None, None, True)
+        assert score is None
+        assert "No tool_calls provided on turn t2" in reason
+
+    def test_conversation_requires_conv_data(self) -> None:
+        """Conversation-level evaluation without conv_data is an error."""
+        score, reason = evaluate_loops(None, None, None, True)
+        assert score is None
+        assert "Conversation data is required" in reason
+
+
+class TestEvaluateLoopsFromTrace:
+    """Tests for trace-based loop and depth detection."""
+
+    def test_no_tool_spans_scores_perfect(self) -> None:
+        """A trace with only an agent span has no tool loops."""
+        trace = Trace(
+            trace_id="t1",
+            spans=[
+                Span(
+                    span_id="root",
+                    trace_id="t1",
+                    name="agent",
+                    span_type=SpanType.AGENT,
+                )
+            ],
+        )
+        score, reason = evaluate_loops_from_trace(trace)
+        assert score == 1.0
+        assert "No loops detected" in reason
+
+    def test_exact_loop_on_tool_spans(self) -> None:
+        """Consecutive TOOL spans with the same inputs are an exact loop."""
+        spans = [
+            Span(
+                span_id=f"s{i}",
+                trace_id="t1",
+                name="search",
+                span_type=SpanType.TOOL,
+                start_time=datetime(2024, 1, 1, 12, 0, i, tzinfo=UTC),
+                inputs={"q": "pods"},
+            )
+            for i in range(3)
+        ]
+        trace = Trace(trace_id="t1", spans=spans)
+        score, reason = evaluate_loops_from_trace(trace)
+        assert score < 1.0
+        assert "Exact loop" in reason
+        assert "search" in reason
+
+    def test_recursive_depth_walks_all_span_types(self) -> None:
+        """Depth counts AGENT and TOOL ancestors, not only consecutive tools."""
+        trace = Trace(
+            trace_id="t1",
+            spans=[
+                Span(
+                    span_id="agent",
+                    trace_id="t1",
+                    name="agent",
+                    span_type=SpanType.AGENT,
+                ),
+                Span(
+                    span_id="chain",
+                    trace_id="t1",
+                    name="chain",
+                    span_type=SpanType.CHAIN,
+                    parent_span_id="agent",
+                ),
+                Span(
+                    span_id="tool",
+                    trace_id="t1",
+                    name="oc_get",
+                    span_type=SpanType.TOOL,
+                    parent_span_id="chain",
+                    inputs={"kind": "pod"},
+                ),
+            ],
+        )
+        config = LoopEvalConfig(
+            exact_loop_threshold=10,
+            soft_loop_threshold=10,
+            max_recursive_depth=2,
+        )
+        score, reason = evaluate_loops_from_trace(trace, config=config)
+        assert score < 1.0
+        assert "Excessive recursive depth: 3" in reason
+        assert "agent -> chain -> oc_get" in reason
+        assert "tool call index 0" in reason
+
+
+class TestLoopEvalConfig:
+    """Direct-construction validation for LoopEvalConfig."""
+
+    def test_defaults_are_valid(self) -> None:
+        """Default thresholds construct without error."""
+        config = LoopEvalConfig()
+        assert config.exact_loop_threshold == 3
+        assert config.soft_loop_threshold == 3
+        assert config.max_recursive_depth == 10
+
+    @pytest.mark.parametrize(
+        "field",
+        ["exact_loop_threshold", "soft_loop_threshold", "max_recursive_depth"],
+    )
+    @pytest.mark.parametrize("value", [0, -1, True, 1.5, "3", None])
+    def test_invalid_threshold_raises(self, field: str, value: Any) -> None:
+        """Zero, negative, or non-int thresholds raise ConfigurationError."""
+        with pytest.raises(ConfigurationError, match=field):
+            LoopEvalConfig(**{field: value})
+
+
+class TestConfigFromMetadata:
+    """Tests for metadata coercion."""
+
+    def test_defaults_when_empty(self) -> None:
+        """Missing metadata uses defaults."""
+        config = config_from_metadata(None)
+        assert config.exact_loop_threshold == 3
+        assert config.soft_loop_threshold == 3
+        assert config.max_recursive_depth == 10
+
+    def test_invalid_values_fall_back(self) -> None:
+        """Boolean, non-positive, or non-int values keep defaults."""
+        config = config_from_metadata(
+            {
+                "exact_loop_threshold": True,
+                "soft_loop_threshold": "nope",
+                "max_recursive_depth": 8,
+            }
+        )
+        assert config.exact_loop_threshold == 3
+        assert config.soft_loop_threshold == 3
+        assert config.max_recursive_depth == 8
+
+    def test_non_positive_metadata_falls_back(self) -> None:
+        """Zero or negative metadata values keep defaults instead of raising."""
+        config = config_from_metadata(
+            {
+                "exact_loop_threshold": 0,
+                "soft_loop_threshold": -1,
+                "max_recursive_depth": 0,
+            }
+        )
+        assert config.exact_loop_threshold == 3
+        assert config.soft_loop_threshold == 3
+        assert config.max_recursive_depth == 10

--- a/tests/unit/core/system/test_validator_loop_eval.py
+++ b/tests/unit/core/system/test_validator_loop_eval.py
@@ -1,0 +1,125 @@
+# pylint: disable=protected-access
+
+"""Unit tests for custom:loop_eval validator requirements."""
+
+from lightspeed_evaluation.core.models import EvaluationData, TurnData
+from lightspeed_evaluation.core.system.validator import (
+    DataValidator,
+    check_metric_required_data,
+)
+
+
+class TestLoopEvalRequiredData:
+    """Runtime required-data checks for custom:loop_eval."""
+
+    def test_empty_tool_calls_is_ok(self) -> None:
+        """Empty tool_calls is valid for loop_eval (no loops)."""
+        turn = TurnData(turn_id="1", query="Q", tool_calls=[])
+        ok, msg = check_metric_required_data(turn, "custom:loop_eval")
+        assert ok is True
+        assert msg == ""
+
+    def test_missing_tool_calls_is_error(self) -> None:
+        """None tool_calls is missing data for loop_eval."""
+        turn = TurnData(turn_id="1", query="Q", tool_calls=None)
+        ok, msg = check_metric_required_data(turn, "custom:loop_eval")
+        assert ok is False
+        assert "tool_calls" in msg
+        assert "missing" in msg
+
+
+class TestLoopEvalDataValidation:
+    """Load-time validation for custom:loop_eval required fields."""
+
+    def test_empty_tool_calls_is_valid(self) -> None:
+        """Empty tool_calls is valid for loop_eval at load time."""
+        validator = DataValidator(api_enabled=False)
+
+        turn = TurnData(
+            turn_id="1",
+            query="Query",
+            tool_calls=[],
+            turn_metrics=["custom:loop_eval"],
+        )
+        conv_data = EvaluationData(conversation_group_id="test_conv", turns=[turn])
+
+        result = validator._validate_evaluation_data([conv_data])
+
+        assert result is True
+        assert not validator.validation_errors
+
+    def test_missing_tool_calls_fails_when_api_disabled(self) -> None:
+        """Missing tool_calls fails loop_eval validation when API is disabled."""
+        validator = DataValidator(api_enabled=False)
+
+        turn = TurnData(
+            turn_id="1",
+            query="Query",
+            tool_calls=None,
+            turn_metrics=["custom:loop_eval"],
+        )
+        conv_data = EvaluationData(conversation_group_id="test_conv", turns=[turn])
+
+        result = validator._validate_evaluation_data([conv_data])
+
+        assert result is False
+        assert any(
+            "tool_calls" in error.lower() for error in validator.validation_errors
+        )
+
+    def test_conversation_level_empty_tool_calls_is_valid(self) -> None:
+        """Empty tool_calls is valid for conversation-level loop_eval."""
+        validator = DataValidator(api_enabled=False)
+
+        turn = TurnData(turn_id="1", query="Query", tool_calls=[])
+        conv_data = EvaluationData(
+            conversation_group_id="test_conv",
+            turns=[turn],
+            conversation_metrics=["custom:loop_eval"],
+        )
+
+        result = validator._validate_evaluation_data([conv_data])
+
+        assert result is True
+        assert not validator.validation_errors
+        assert not conv_data.is_metric_invalid("custom:loop_eval")
+
+    def test_conversation_level_missing_tool_calls_fails_when_api_disabled(
+        self,
+    ) -> None:
+        """Conversation-level loop_eval requires tool_calls on every turn."""
+        validator = DataValidator(api_enabled=False)
+
+        turn = TurnData(turn_id="1", query="Query", tool_calls=None)
+        conv_data = EvaluationData(
+            conversation_group_id="test_conv",
+            turns=[turn],
+            conversation_metrics=["custom:loop_eval"],
+        )
+
+        result = validator._validate_evaluation_data([conv_data])
+
+        assert result is False
+        assert any(
+            "tool_calls" in error.lower() for error in validator.validation_errors
+        )
+        assert conv_data.is_metric_invalid("custom:loop_eval")
+
+    def test_conversation_level_mixed_none_fails_when_api_disabled(self) -> None:
+        """A single missing tool_calls turn fails conversation-level loop_eval."""
+        validator = DataValidator(api_enabled=False)
+
+        conv_data = EvaluationData(
+            conversation_group_id="test_conv",
+            turns=[
+                TurnData(turn_id="1", query="Query", tool_calls=[]),
+                TurnData(turn_id="2", query="Query", tool_calls=None),
+            ],
+            conversation_metrics=["custom:loop_eval"],
+        )
+
+        result = validator._validate_evaluation_data([conv_data])
+
+        assert result is False
+        assert any("TurnData 2" in error for error in validator.validation_errors)
+        assert conv_data.is_metric_invalid("custom:loop_eval")

--- a/tests/unit/pipeline/evaluation/test_evaluator.py
+++ b/tests/unit/pipeline/evaluation/test_evaluator.py
@@ -132,6 +132,32 @@ class TestMetricsEvaluator:
         assert "missing or empty" in result.reason
         mock_ragas.evaluate.assert_not_called()
 
+    def test_evaluate_conversation_loop_eval_missing_tool_calls_returns_error(
+        self, evaluator: MetricsEvaluator
+    ) -> None:
+        """Conversation-level loop_eval errors when any turn lacks tool_calls."""
+        mock_custom = evaluator.handlers["custom"]
+
+        turns = [
+            TurnData(
+                turn_id="1",
+                query="Query",
+                tool_calls=[[{"tool_name": "oc_get", "arguments": {}}]],
+            ),
+            TurnData(turn_id="2", query="Query", tool_calls=None),
+        ]
+        conv_data = EvaluationData(conversation_group_id="test_conv", turns=turns)
+        request = EvaluationRequest.for_conversation(conv_data, "custom:loop_eval")
+
+        result = evaluator.evaluate_metric(request)
+
+        assert result is not None
+        assert result.result == "ERROR"
+        assert result.score is None
+        assert "tool_calls" in result.reason
+        assert "missing" in result.reason
+        mock_custom.evaluate.assert_not_called()
+
     def test_evaluate_metric_conversation_level(
         self, evaluator: MetricsEvaluator
     ) -> None:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor Grok 4.6 high
- Generated by: Claude

## Related Tickets & Documents

- Related Issue #. https://redhat.atlassian.net/browse/LEADS-510
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the deterministic `custom:loop_eval` metric to detect repeated tool calls, tool thrashing, and excessive recursive depth.
  * Supports turn-level, conversation-level, and trace-based evaluation with configurable thresholds and explanatory scoring.
  * Added clear validation for required tool-call data, while allowing empty tool-call lists.
  * Updated proposal evaluation terminology and metrics to use AgenticRun naming.

* **Documentation**
  * Added configuration guidance, usage examples, evaluation recipes, and troubleshooting information.

* **Tests**
  * Added comprehensive coverage for loop detection, thresholds, validation, scoring, and conversation-level behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->