### PR TITLE
feat: add statistical significance testing to pairwise agent comparison

### DIFF
--- a/src/lightspeed_evaluation/pipeline/behavioral/comparison.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/comparison.py
@@ -8,11 +8,17 @@ from lightspeed_evaluation.pipeline.behavioral.models import (
     ComparisonResult,
     PairwiseDelta,
     Rankings,
+    SignificanceResult,
+)
+from lightspeed_evaluation.pipeline.behavioral.statistics import (
+    metric_significance,
+    significance_tests,
 )
 
 
 def compare_agents(
     agents: dict[str, AgentConsolidated],
+    alpha: float = 0.05,
 ) -> Optional[ComparisonResult]:
     """Compare multiple agents: deltas, rankings, incomparable list.
 
@@ -21,6 +27,7 @@ def compare_agents(
 
     Args:
         agents: Agent name → AgentConsolidated mapping.
+        alpha: Significance level for statistical tests.
 
     Returns:
         ComparisonResult with deltas, rankings, incomparable. None if < 2 agents.
@@ -30,20 +37,24 @@ def compare_agents(
 
     agent_list = sorted(agents.values(), key=lambda a: a.agent_name)
     return ComparisonResult(
-        deltas=_compute_deltas(agent_list),
+        deltas=_compute_deltas(agent_list, alpha),
         rankings=_compute_rankings(agent_list),
         incomparable=_find_incomparable(agent_list),
     )
 
 
-def _compute_deltas(agents: list[AgentConsolidated]) -> list[PairwiseDelta]:
+def _compute_deltas(
+    agents: list[AgentConsolidated],
+    alpha: float,
+) -> list[PairwiseDelta]:
     """Compute pairwise deltas between all agent pairs."""
-    return [_pair_delta(a, b) for a, b in itertools.combinations(agents, 2)]
+    return [_pair_delta(a, b, alpha) for a, b in itertools.combinations(agents, 2)]
 
 
 def _pair_delta(
     agent_a: AgentConsolidated,
     agent_b: AgentConsolidated,
+    alpha: float,
 ) -> PairwiseDelta:
     """Compute delta between two agents (a - b)."""
     shared_metrics = set(agent_a.by_metric) & set(agent_b.by_metric)
@@ -54,6 +65,8 @@ def _pair_delta(
         if mean_a is not None and mean_b is not None:
             score_deltas[metric] = mean_a - mean_b
 
+    sig = _compute_significance(agent_a, agent_b, alpha)
+
     return PairwiseDelta(
         agent_a=agent_a.agent_name,
         agent_b=agent_b.agent_name,
@@ -61,7 +74,42 @@ def _pair_delta(
         agent_latency_mean_delta=_overall_delta(agent_a, agent_b, "agent_latency_mean"),
         agent_tokens_mean_delta=_overall_delta(agent_a, agent_b, "agent_tokens_mean"),
         score_deltas=score_deltas,
+        significance=sig or None,
     )
+
+
+def _compute_significance(
+    agent_a: AgentConsolidated,
+    agent_b: AgentConsolidated,
+    alpha: float,
+) -> list[SignificanceResult]:
+    """Run significance tests: overall pass/fail + per-metric scores."""
+    pass_counts_a = [r.passed for r in agent_a.per_run]
+    totals_a = [r.total for r in agent_a.per_run]
+    pass_counts_b = [r.passed for r in agent_b.per_run]
+    totals_b = [r.total for r in agent_b.per_run]
+    results = significance_tests(
+        pass_counts_a, totals_a, pass_counts_b, totals_b, alpha=alpha
+    )
+
+    shared_metrics = set(agent_a.by_metric) & set(agent_b.by_metric)
+    for metric in sorted(shared_metrics):
+        scores_a = _per_run_metric_scores(agent_a, metric)
+        scores_b = _per_run_metric_scores(agent_b, metric)
+        sig = metric_significance(scores_a, scores_b, metric, alpha)
+        if sig is not None:
+            results.append(sig)
+
+    return results
+
+
+def _per_run_metric_scores(agent: AgentConsolidated, metric: str) -> list[float]:
+    """Extract per-run scores for a specific metric."""
+    return [
+        r.by_metric[metric]
+        for r in agent.per_run
+        if r.by_metric and metric in r.by_metric
+    ]
 
 
 def _overall_delta(

--- a/src/lightspeed_evaluation/pipeline/behavioral/consolidation.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/consolidation.py
@@ -16,7 +16,10 @@ from lightspeed_evaluation.pipeline.behavioral.models import (
     AgentConsolidated,
     RunSummary,
 )
-from lightspeed_evaluation.pipeline.behavioral.statistics import pass_at_k
+from lightspeed_evaluation.pipeline.behavioral.statistics import (
+    confidence_interval,
+    pass_at_k,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +201,10 @@ def _build_overall(
         result["pass_rate_std"] = (
             statistics.stdev(pass_rates) if len(pass_rates) > 1 else 0.0
         )
+        ci = confidence_interval(pass_rates)
+        if ci is not None:
+            result["pass_rate_ci_low"] = max(0.0, ci[0])
+            result["pass_rate_ci_high"] = min(100.0, ci[1])
 
     if latencies:
         result["agent_latency_mean"] = statistics.mean(latencies)
@@ -221,6 +228,10 @@ def _build_by_metric(
             "max": max(scores),
         }
         entry["std"] = statistics.stdev(scores) if len(scores) > 1 else 0.0
+        ci = confidence_interval(scores)
+        if ci is not None:
+            entry["ci_low"] = ci[0]
+            entry["ci_high"] = ci[1]
         result[name] = entry
     return result
 

--- a/src/lightspeed_evaluation/pipeline/behavioral/models.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/models.py
@@ -86,6 +86,16 @@ class AgentConsolidated(BaseModel):
     per_run: list[RunSummary] = []
 
 
+class SignificanceResult(BaseModel):
+    """Statistical significance test result for a pairwise comparison."""
+
+    test: str
+    statistic: float
+    p_value: float
+    significant: bool
+    metric: Optional[str] = None
+
+
 class PairwiseDelta(BaseModel):
     """Delta between two agents."""
 
@@ -95,6 +105,7 @@ class PairwiseDelta(BaseModel):
     agent_latency_mean_delta: Optional[float] = None
     agent_tokens_mean_delta: Optional[float] = None
     score_deltas: dict[str, float] = {}
+    significance: Optional[list[SignificanceResult]] = None
 
 
 class Rankings(BaseModel):

--- a/src/lightspeed_evaluation/pipeline/behavioral/statistics.py
+++ b/src/lightspeed_evaluation/pipeline/behavioral/statistics.py
@@ -1,6 +1,139 @@
 """Statistical functions for NxM behavioral evaluation."""
 
 import math
+import statistics as stdlib_stats
+from typing import Optional
+
+from scipy.stats import fisher_exact, mannwhitneyu, sem
+from scipy.stats import t as t_dist
+
+from lightspeed_evaluation.pipeline.behavioral.models import SignificanceResult
+
+_MIN_SAMPLES = 2
+
+
+def significance_tests(
+    pass_counts_a: list[int],
+    totals_a: list[int],
+    pass_counts_b: list[int],
+    totals_b: list[int],
+    alpha: float = 0.05,
+) -> list[SignificanceResult]:
+    """Run Fisher's exact test on aggregated pass/fail counts.
+
+    Args:
+        pass_counts_a: Per-run pass counts for agent A.
+        totals_a: Per-run total counts for agent A.
+        pass_counts_b: Per-run pass counts for agent B.
+        totals_b: Per-run total counts for agent B.
+        alpha: Significance level.
+
+    Returns:
+        List of test results (may be empty if insufficient data).
+    """
+    results: list[SignificanceResult] = []
+
+    fisher = _fisher_exact(pass_counts_a, totals_a, pass_counts_b, totals_b, alpha)
+    if fisher is not None:
+        results.append(fisher)
+
+    return results
+
+
+def _fisher_exact(
+    pass_counts_a: list[int],
+    totals_a: list[int],
+    pass_counts_b: list[int],
+    totals_b: list[int],
+    alpha: float,
+) -> Optional[SignificanceResult]:
+    """Fisher's exact test on aggregated pass/fail contingency table."""
+    total_pass_a = sum(pass_counts_a)
+    total_n_a = sum(totals_a)
+    total_pass_b = sum(pass_counts_b)
+    total_n_b = sum(totals_b)
+
+    if total_n_a == 0 or total_n_b == 0:
+        return None
+    if total_pass_a > total_n_a or total_pass_b > total_n_b:
+        return None
+
+    table = [
+        [total_pass_a, total_n_a - total_pass_a],
+        [total_pass_b, total_n_b - total_pass_b],
+    ]
+    result = fisher_exact(table)
+    odds_ratio = float(result.statistic)
+    p_val = float(result.pvalue)
+    return SignificanceResult(
+        test="fisher_exact",
+        statistic=odds_ratio,
+        p_value=p_val,
+        significant=p_val < alpha,
+    )
+
+
+def metric_significance(
+    scores_a: list[float],
+    scores_b: list[float],
+    metric: str,
+    alpha: float = 0.05,
+) -> Optional[SignificanceResult]:
+    """Mann-Whitney U test on per-run metric scores between two agents.
+
+    Args:
+        scores_a: Per-run mean scores for agent A.
+        scores_b: Per-run mean scores for agent B.
+        metric: Metric identifier.
+        alpha: Significance level.
+
+    Returns:
+        SignificanceResult or None if insufficient data.
+    """
+    scores_a = [s for s in scores_a if math.isfinite(s)]
+    scores_b = [s for s in scores_b if math.isfinite(s)]
+    if len(scores_a) < _MIN_SAMPLES or len(scores_b) < _MIN_SAMPLES:
+        return None
+    if scores_a == scores_b:
+        return None
+    try:
+        result = mannwhitneyu(scores_a, scores_b, alternative="two-sided")
+    except ValueError:
+        return None
+
+    u_stat = float(result.statistic)
+    p_val = float(result.pvalue)
+    return SignificanceResult(
+        test="mann_whitney_u",
+        statistic=u_stat,
+        p_value=p_val,
+        significant=p_val < alpha,
+        metric=metric,
+    )
+
+
+def confidence_interval(
+    values: list[float],
+    confidence: float = 0.95,
+) -> Optional[tuple[float, float]]:
+    """Compute confidence interval for the mean using t-distribution.
+
+    Args:
+        values: Sample values.
+        confidence: Confidence level (default 0.95).
+
+    Returns:
+        (ci_low, ci_high) tuple, or None if fewer than 2 values.
+    """
+    values = [v for v in values if math.isfinite(v)]
+    if len(values) < 2:
+        return None
+    mean = stdlib_stats.mean(values)
+    se = float(sem(values))
+    if se == 0.0:
+        return (mean, mean)
+    ci = t_dist.interval(confidence, df=len(values) - 1, loc=mean, scale=se)
+    return (float(ci[0]), float(ci[1]))
 
 
 def pass_at_k(pass_counts: list[int], totals: list[int], k: int) -> float:

--- a/tests/unit/pipeline/behavioral/test_comparison.py
+++ b/tests/unit/pipeline/behavioral/test_comparison.py
@@ -6,13 +6,14 @@ from lightspeed_evaluation.pipeline.behavioral.comparison import compare_agents
 from lightspeed_evaluation.pipeline.behavioral.models import (
     AgentConsolidated,
     ComparisonResult,
+    RunSummary,
 )
 
 
 def _make_agent(name: str, **kwargs: Any) -> AgentConsolidated:
     """Build an AgentConsolidated for testing.
 
-    Keyword args: pass_rate, latency, tokens, metrics, conversations.
+    Keyword args: pass_rate, latency, tokens, metrics, conversations, per_run.
     """
     overall: dict[str, float | None] = {
         "pass_rate_mean": kwargs.get("pass_rate", 80.0),
@@ -32,6 +33,7 @@ def _make_agent(name: str, **kwargs: Any) -> AgentConsolidated:
         conversations_count=kwargs.get("conversations", 5),
         overall=overall,
         by_metric=by_metric,
+        per_run=kwargs.get("per_run", []),
     )
 
 
@@ -116,3 +118,65 @@ class TestCompareAgents:
 
         assert result is not None
         assert len(result.deltas) == 3
+
+    def test_significance_with_per_run_data(self) -> None:
+        """Significance tests run when per_run data is available."""
+        runs_a = [RunSummary(total=10, passed=9, run_index=i) for i in range(5)]
+        runs_b = [RunSummary(total=10, passed=2, run_index=i) for i in range(5)]
+        agents = {
+            "a": _make_agent("a", pass_rate=90.0, per_run=runs_a),
+            "b": _make_agent("b", pass_rate=20.0, per_run=runs_b),
+        }
+        result = compare_agents(agents)
+
+        assert result is not None
+        delta = result.deltas[0]
+        assert delta.significance is not None
+        assert len(delta.significance) >= 1
+        fisher = next((s for s in delta.significance if s.test == "fisher_exact"), None)
+        assert fisher is not None
+        assert fisher.significant is True
+
+    def test_per_metric_significance(self) -> None:
+        """Per-metric Mann-Whitney detects difference with realistic variance."""
+        metric = "ragas:faithfulness"
+        scores_a = [0.90, 0.85, 0.95, 0.88, 0.92]
+        scores_b = [0.40, 0.35, 0.45, 0.38, 0.42]
+        runs_a = [
+            RunSummary(total=10, passed=9, run_index=i, by_metric={metric: s})
+            for i, s in enumerate(scores_a)
+        ]
+        runs_b = [
+            RunSummary(total=10, passed=4, run_index=i, by_metric={metric: s})
+            for i, s in enumerate(scores_b)
+        ]
+        agents = {
+            "a": _make_agent(
+                "a", pass_rate=90.0, metrics={metric: 0.9}, per_run=runs_a
+            ),
+            "b": _make_agent(
+                "b", pass_rate=40.0, metrics={metric: 0.4}, per_run=runs_b
+            ),
+        }
+        result = compare_agents(agents)
+
+        assert result is not None
+        sig = result.deltas[0].significance
+        assert sig is not None
+        metric_test = next(
+            (s for s in sig if s.test == "mann_whitney_u" and s.metric == metric),
+            None,
+        )
+        assert metric_test is not None
+        assert metric_test.significant is True
+
+    def test_no_significance_without_per_run(self) -> None:
+        """No significance tests when per_run is empty."""
+        agents = {
+            "a": _make_agent("a"),
+            "b": _make_agent("b"),
+        }
+        result = compare_agents(agents)
+
+        assert result is not None
+        assert result.deltas[0].significance is None

--- a/tests/unit/pipeline/behavioral/test_statistics.py
+++ b/tests/unit/pipeline/behavioral/test_statistics.py
@@ -1,6 +1,13 @@
 """Tests for NxM behavioral statistics."""
 
-from lightspeed_evaluation.pipeline.behavioral.statistics import pass_at_k
+from pytest import approx
+
+from lightspeed_evaluation.pipeline.behavioral.statistics import (
+    confidence_interval,
+    metric_significance,
+    pass_at_k,
+    significance_tests,
+)
 
 
 class TestPassAtK:
@@ -47,3 +54,98 @@ class TestPassAtK:
         """k > n with zero passes → 0.0."""
         result = pass_at_k([0], [2], k=3)
         assert result == 0.0
+
+
+class TestSignificanceTests:
+    """Tests for statistical significance functions."""
+
+    def test_clearly_different_agents(self) -> None:
+        """90% vs 12% pass rate across 5 runs: Fisher detects significance."""
+        results = significance_tests(
+            pass_counts_a=[9, 10, 9, 10, 9],
+            totals_a=[10, 10, 10, 10, 10],
+            pass_counts_b=[1, 2, 1, 0, 2],
+            totals_b=[10, 10, 10, 10, 10],
+            alpha=0.05,
+        )
+        fisher = next((r for r in results if r.test == "fisher_exact"), None)
+        assert fisher is not None
+        assert fisher.significant is True
+
+    def test_identical_agents_not_significant(self) -> None:
+        """Same pass counts: Fisher returns p=1.0, no false positive."""
+        results = significance_tests(
+            pass_counts_a=[8, 8, 8],
+            totals_a=[10, 10, 10],
+            pass_counts_b=[8, 8, 8],
+            totals_b=[10, 10, 10],
+            alpha=0.05,
+        )
+        fisher = next((r for r in results if r.test == "fisher_exact"), None)
+        assert fisher is not None
+        assert fisher.significant is False
+        assert fisher.p_value == 1.0
+
+    def test_alpha_controls_threshold(self) -> None:
+        """Same data: significant at alpha=0.10, not at alpha=0.001."""
+        kwargs = {
+            "pass_counts_a": [9, 8, 9],
+            "totals_a": [10, 10, 10],
+            "pass_counts_b": [5, 6, 5],
+            "totals_b": [10, 10, 10],
+        }
+        loose = significance_tests(**kwargs, alpha=0.10)
+        strict = significance_tests(**kwargs, alpha=0.001)
+
+        fisher_loose = next((r for r in loose if r.test == "fisher_exact"), None)
+        fisher_strict = next((r for r in strict if r.test == "fisher_exact"), None)
+        assert fisher_loose is not None and fisher_strict is not None
+        assert fisher_loose.significant is True
+        assert fisher_strict.significant is False
+
+    def test_single_run_fisher_only(self) -> None:
+        """Single run still produces Fisher result."""
+        results = significance_tests(
+            pass_counts_a=[8],
+            totals_a=[10],
+            pass_counts_b=[5],
+            totals_b=[10],
+            alpha=0.05,
+        )
+        assert len(results) == 1
+        assert results[0].test == "fisher_exact"
+
+    def test_empty_data_returns_empty(self) -> None:
+        """No data produces no results."""
+        assert not significance_tests([], [], [], [], alpha=0.05)
+
+    def test_identical_metric_scores_returns_none(self) -> None:
+        """Identical per-metric scores produce no MW result."""
+        assert metric_significance([0.9, 0.9, 0.9], [0.9, 0.9, 0.9], "m") is None
+
+    def test_nan_filtered_below_min_returns_none(self) -> None:
+        """NaN filtering can drop below minimum samples."""
+        assert metric_significance([0.9, float("nan")], [0.8, 0.7], "m") is None
+
+
+class TestConfidenceInterval:
+    """Tests for confidence interval computation."""
+
+    def test_known_values(self) -> None:
+        """CI on [80, 85, 90] produces correct bounds."""
+        ci = confidence_interval([80.0, 85.0, 90.0])
+        assert ci is not None
+        low, high = ci
+        assert low < 85.0 < high
+        assert (low + high) / 2 == approx(85.0)
+
+    def test_single_value_returns_none(self) -> None:
+        """CI requires at least 2 values."""
+        assert confidence_interval([80.0]) is None
+
+    def test_zero_variance(self) -> None:
+        """Identical values produce zero-width CI."""
+        ci = confidence_interval([50.0, 50.0, 50.0])
+        assert ci is not None
+        assert ci[0] == approx(50.0)
+        assert ci[1] == approx(50.0)


### PR DESCRIPTION
## Description

  - Fisher's exact on aggregate pass/fail, Mann-Whitney U on per-run pass rates and per-metric scores
  - SignificanceResult model with metric: Optional[str] to distinguish overall vs per-metric tests
  - alpha parameter on compare_agents() (default 0.05), raw p-values reported

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added statistical significance analysis for agent comparisons, covering overall pass/fail results and shared metric scores.
  * Comparison results now include test details, p-values, and significance status.
  * Added configurable significance thresholds through the `alpha` value.
  * Added confidence intervals to overall pass rates and per-metric results.

* **Bug Fixes**
  * Gracefully handles insufficient, identical, empty, or invalid data.

* **Tests**
  * Added coverage for significance results, metric comparisons, thresholds, confidence intervals, and missing per-run data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->