### PR TITLE
feat: add optional description field for llm pool and agents

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -31,6 +31,7 @@ llm_pool:
       max_completion_tokens: 1024
   models:
     judge_gpt_4o_mini:
+      description: "GPT-4o Mini judge for cost-efficient evaluation"
       # Uses default parameters
       provider: openai
       model: gpt-4o-mini
@@ -38,6 +39,7 @@ llm_pool:
       # ssl_verify: true
       # ssl_cert_file: null
     judge_gpt_4_1_mini:
+      description: "GPT-4.1 Mini judge with extended output tokens"
       provider: openai
       model: gpt-4.1-mini
       parameters:
@@ -81,6 +83,7 @@ agents:
   # Lightspeed-stack compatible HTTP API agent
   ls_api:
     type: http_api
+    description: "Local Lightspeed API for development testing"
     api_base: http://localhost:8080    # Base API URL (without version)
     version: v1                        # API version (e.g., v1, v2)
     endpoint_type: streaming           # Supported endpoint types: "query", "streaming", "infer" and "responses"

--- a/src/lightspeed_evaluation/core/models/__init__.py
+++ b/src/lightspeed_evaluation/core/models/__init__.py
@@ -1,6 +1,7 @@
 """Data models for the evaluation framework."""
 
 from lightspeed_evaluation.core.models.agents import (
+    AgentBaseConfig,
     AgentDefaultConfig,
     AgentsConfig,
     HttpApiAgentConfig,
@@ -68,6 +69,7 @@ from lightspeed_evaluation.core.models.trace import (
 
 __all__ = [
     # Agent config models
+    "AgentBaseConfig",
     "AgentDefaultConfig",
     "OpenshiftAgenticRunAgentConfig",
     "AgentsConfig",

--- a/src/lightspeed_evaluation/core/models/agents.py
+++ b/src/lightspeed_evaluation/core/models/agents.py
@@ -156,7 +156,18 @@ class HttpApiBaseFields(BaseModel):
         return data
 
 
-class HttpApiAgentConfig(HttpApiBaseFields):
+class AgentBaseConfig(BaseModel):
+    """Common fields shared by all agent configurations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: Optional[str] = Field(
+        default=None,
+        description="Human-readable description of this agent",
+    )
+
+
+class HttpApiAgentConfig(HttpApiBaseFields, AgentBaseConfig):
     """Configuration for an HTTP API agent."""
 
     type: Literal["http_api"] = Field(
@@ -168,10 +179,8 @@ class HttpApiAgentConfig(HttpApiBaseFields):
     )
 
 
-class OpenshiftAgenticRunAgentConfig(BaseModel):
+class OpenshiftAgenticRunAgentConfig(AgentBaseConfig):
     """Configuration for an AgenticRun CRD-based agent."""
-
-    model_config = ConfigDict(extra="forbid")
 
     type: Literal["openshift_agentic_run"] = "openshift_agentic_run"
     namespace: str = Field(

--- a/src/lightspeed_evaluation/core/models/llm.py
+++ b/src/lightspeed_evaluation/core/models/llm.py
@@ -296,6 +296,12 @@ class LLMProviderConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Optional human-readable description
+    description: Optional[str] = Field(
+        default=None,
+        description="Human-readable description of this LLM configuration",
+    )
+
     # Required: Provider type
     provider: str = Field(
         min_length=1,

--- a/src/lightspeed_evaluation/pipeline/evaluation/driver.py
+++ b/src/lightspeed_evaluation/pipeline/evaluation/driver.py
@@ -96,7 +96,10 @@ class HttpApiDriver(AgentDriver):
             self._api_client.close()
 
     def _create_api_client(self, config: HttpApiAgentConfig) -> Optional[APIClient]:
-        api_config = APIConfig.model_validate(config.model_dump(exclude={"type"}))
+        # Exclude fields present on HttpApiAgentConfig but absent on APIConfig
+        # so new metadata fields (e.g. description) never leak into API calls.
+        exclude = set(config.model_fields) - set(APIConfig.model_fields)
+        api_config = APIConfig.model_validate(config.model_dump(exclude=exclude))
         return APIClient(api_config)
 
 

--- a/tests/unit/core/models/test_agents.py
+++ b/tests/unit/core/models/test_agents.py
@@ -13,11 +13,13 @@ from lightspeed_evaluation.core.constants import (
     DEFAULT_ENDPOINT_TYPE,
 )
 from lightspeed_evaluation.core.models.agents import (
+    AgentBaseConfig,
     AgentDefaultConfig,
     AgentsConfig,
     HttpApiAgentConfig,
     MCPHeadersConfig,
     MCPServerConfig,
+    OpenshiftAgenticRunAgentConfig,
 )
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
 
@@ -29,6 +31,7 @@ class TestHttpApiAgentConfig:
         """Verify defaults match the existing APIConfig constants."""
         config = HttpApiAgentConfig()
         assert config.type == "http_api"
+        assert config.description is None
         assert config.api_base == DEFAULT_API_BASE
         assert config.version == DEFAULT_API_VERSION
         assert config.endpoint_type == DEFAULT_ENDPOINT_TYPE
@@ -41,6 +44,18 @@ class TestHttpApiAgentConfig:
         assert config.no_tools is None
         assert config.system_prompt is None
         assert config.extra_request_params is None
+
+    def test_description_field(self) -> None:
+        """Test description field is accepted and stored."""
+        config = HttpApiAgentConfig(
+            description="My test API agent for development",
+        )
+        assert config.description == "My test API agent for development"
+
+    def test_description_defaults_to_none(self) -> None:
+        """Test description defaults to None when not provided."""
+        config = HttpApiAgentConfig()
+        assert config.description is None
 
     def test_custom_values(self) -> None:
         """Test HttpApiAgentConfig with custom values."""
@@ -114,6 +129,33 @@ class TestHttpApiAgentConfig:
             HttpApiAgentConfig()
 
         assert not any("no_tools" in r.message for r in caplog.records)
+
+
+class TestAgentBaseConfig:
+    """Tests for AgentBaseConfig shared description field."""
+
+    def test_both_agent_types_inherit_from_base(self) -> None:
+        """Test both agent types inherit from AgentBaseConfig."""
+        assert issubclass(HttpApiAgentConfig, AgentBaseConfig)
+        assert issubclass(OpenshiftAgenticRunAgentConfig, AgentBaseConfig)
+
+    def test_description_defaults_to_none_http(self) -> None:
+        """Test description defaults to None on HttpApiAgentConfig."""
+        config = HttpApiAgentConfig()
+        assert config.description is None
+
+    def test_description_defaults_to_none_openshift(self) -> None:
+        """Test description defaults to None on OpenshiftAgenticRunAgentConfig."""
+        config = OpenshiftAgenticRunAgentConfig(namespace="test-ns")
+        assert config.description is None
+
+    def test_description_field_openshift(self) -> None:
+        """Test description field is accepted on OpenshiftAgenticRunAgentConfig."""
+        config = OpenshiftAgenticRunAgentConfig(
+            namespace="test-ns",
+            description="Production agentic run agent",
+        )
+        assert config.description == "Production agentic run agent"
 
 
 class TestAgentDefaultConfig:
@@ -398,3 +440,23 @@ class TestAgentsConfigResolve:
         _, resolved = config.resolve_agent_config()
         assert resolved["timeout"] == DEFAULT_API_TIMEOUT
         assert resolved["num_retries"] == DEFAULT_API_NUM_RETRIES
+
+    def test_description_flows_through_resolve(self) -> None:
+        """Test description is included in resolved agent config."""
+        config = AgentsConfig.model_validate(
+            {
+                "default": {"agent": ["my_agent"]},
+                "my_agent": {
+                    "type": "http_api",
+                    "description": "Test agent for CI",
+                },
+            }
+        )
+        _, resolved = config.resolve_agent_config()
+        assert resolved["description"] == "Test agent for CI"
+
+    def test_description_none_in_resolved_when_not_set(self) -> None:
+        """Test description is None in resolved config when not provided."""
+        config = self._make_config()
+        _, resolved = config.resolve_agent_config()
+        assert resolved["description"] is None

--- a/tests/unit/core/models/test_llm.py
+++ b/tests/unit/core/models/test_llm.py
@@ -1,0 +1,99 @@
+"""Tests for LLM configuration models."""
+
+import pytest
+from pydantic import ValidationError
+
+from lightspeed_evaluation.core.models.llm import (
+    LLMPoolConfig,
+    LLMProviderConfig,
+)
+
+
+class TestLLMProviderConfigDescription:
+    """Tests for the description field on LLMProviderConfig."""
+
+    def test_description_defaults_to_none(self) -> None:
+        """Test description defaults to None when not provided."""
+        config = LLMProviderConfig(provider="openai")
+        assert config.description is None
+
+    def test_description_field(self) -> None:
+        """Test description field is accepted and stored."""
+        config = LLMProviderConfig(
+            provider="openai",
+            model="gpt-4o-mini",
+            description="Cost-efficient judge for fast evaluations",
+        )
+        assert config.description == "Cost-efficient judge for fast evaluations"
+
+    def test_description_in_model_dump(self) -> None:
+        """Test description is present in model_dump output."""
+        config = LLMProviderConfig(
+            provider="openai",
+            description="My judge model",
+        )
+        dumped = config.model_dump()
+        assert dumped["description"] == "My judge model"
+
+    def test_description_none_in_model_dump(self) -> None:
+        """Test description None is present in model_dump output."""
+        config = LLMProviderConfig(provider="openai")
+        dumped = config.model_dump()
+        assert dumped["description"] is None
+
+
+class TestLLMPoolConfigDescription:
+    """Tests for description field in LLMPoolConfig context."""
+
+    def test_pool_model_with_description(self) -> None:
+        """Test description is preserved in pool model definitions."""
+        pool = LLMPoolConfig.model_validate(
+            {
+                "models": {
+                    "judge_1": {
+                        "provider": "openai",
+                        "model": "gpt-4o-mini",
+                        "description": "Primary judge for correctness",
+                    },
+                    "judge_2": {
+                        "provider": "openai",
+                        "model": "gpt-4.1-mini",
+                    },
+                }
+            }
+        )
+        assert pool.models["judge_1"].description == "Primary judge for correctness"
+        assert pool.models["judge_2"].description is None
+
+    def test_resolve_llm_config_ignores_description(self) -> None:
+        """Test that resolve_llm_config produces LLMConfig without description.
+
+        Description is a pool-level annotation, not an operational parameter.
+        LLMConfig does not have a description field.
+        """
+        pool = LLMPoolConfig.model_validate(
+            {
+                "models": {
+                    "judge_1": {
+                        "provider": "openai",
+                        "model": "gpt-4o-mini",
+                        "description": "My judge",
+                    },
+                }
+            }
+        )
+        llm_config = pool.resolve_llm_config("judge_1")
+        assert llm_config.provider == "openai"
+        assert llm_config.model == "gpt-4o-mini"
+        # LLMConfig doesn't have description - it's a pool-level annotation
+        assert "description" not in type(llm_config).model_fields
+
+    def test_description_rejected_as_extra_on_pool(self) -> None:
+        """Test that description on LLMPoolConfig itself is rejected (extra=forbid)."""
+        with pytest.raises(ValidationError):
+            LLMPoolConfig.model_validate(
+                {
+                    "description": "This should fail",
+                    "models": {},
+                }
+            )

--- a/tests/unit/pipeline/evaluation/test_driver.py
+++ b/tests/unit/pipeline/evaluation/test_driver.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
-from lightspeed_evaluation.core.models import TurnData
+from lightspeed_evaluation.core.models import APIConfig, TurnData
 from lightspeed_evaluation.core.system.exceptions import ConfigurationError
 from lightspeed_evaluation.pipeline.evaluation.driver import (
     AgentDriver,
@@ -175,6 +175,20 @@ class TestHttpApiDriver:
             HttpApiDriver(
                 {"type": "http_api", "invalid_field_only": True}, enabled=True
             )
+
+    def test_description_excluded_from_api_config(self, mocker: MockerFixture) -> None:
+        """Test description is not passed to APIConfig (extra=forbid)."""
+        mocker.patch("lightspeed_evaluation.pipeline.evaluation.driver.APIClient")
+        spy = mocker.spy(APIConfig, "model_validate")
+        # Should not raise — description must be excluded before APIConfig
+        HttpApiDriver(
+            {"type": "http_api", "description": "My test agent"}, enabled=True
+        )
+        # Verify agent-only fields were excluded while operational fields survive
+        call_args = spy.call_args[0][0]
+        assert "description" not in call_args
+        assert "type" not in call_args
+        assert "api_base" in call_args
 
 
 class TestOpenshiftAgenticRunDriverExecuteTurn:


### PR DESCRIPTION
## Description

Additional description field for both agents and llm pool. So that user can add human readable difference between multiple options.
This field is only supposed to be added to final config output in the report, not to be used for actual llm call or agent call as this is not a valid property for the Judge llm call or API call or CR.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Opus

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional descriptions for agent configurations and language model providers.
  * Descriptions are preserved as metadata for configured models and agents.
  * Configuration models now consistently reject unsupported fields.

* **Bug Fixes**
  * Agent-only metadata is excluded from API configuration validation, preventing description fields from being sent as request parameters.

* **Tests**
  * Added coverage for description defaults, storage, configuration resolution, strict field validation, and API validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->