### PR TITLE
chore: Add new llm pool, judge panel and agents as default config save

### DIFF
--- a/src/lightspeed_evaluation/core/constants.py
+++ b/src/lightspeed_evaluation/core/constants.py
@@ -88,7 +88,15 @@ DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 DEFAULT_OUTPUT_DIR = "./eval_output"
 DEFAULT_BASE_FILENAME = "evaluation"
 
-DEFAULT_STORED_CONFIGS = ["llm", "embedding", "api"]
+# llm and api are deprecated, keeping these for backward compatibility
+DEFAULT_STORED_CONFIGS = [
+    "llm",
+    "llm_pool",
+    "judge_panel",
+    "embedding",
+    "api",
+    "agents",
+]
 
 SUPPORTED_OUTPUT_TYPES = ["csv", "json", "txt"]
 SUPPORTED_CSV_COLUMNS = [

--- a/src/lightspeed_evaluation/core/output/generator.py
+++ b/src/lightspeed_evaluation/core/output/generator.py
@@ -657,6 +657,8 @@ class OutputHandler:
                 continue
 
             field_value = getattr(self.system_config, field_name)
+            if field_value is None:
+                continue
 
             # Format section name nicely
             section_name = field_name.replace("_", " ").title()
@@ -746,6 +748,8 @@ class OutputHandler:
                 continue
 
             field_value = getattr(self.system_config, field_name)
+            if field_value is None:
+                continue
 
             # Convert Pydantic model to dict, excluding cache_dir for security
             config_dict[field_name] = self._convert_config_to_dict(field_value)


### PR DESCRIPTION
## Description

Add new llm pool, judge panel and agents as default config save. Keep old llm and api as backward compatibility

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Unit tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing configuration sections for LLM pools, judge panels, and agents.
  * Existing LLM and API configuration entries remain available for backward compatibility.

* **Bug Fixes**
  * Configuration fields without values are now omitted from generated text and JSON output, producing cleaner results and avoiding unnecessary null entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->